### PR TITLE
Refine Lanzos in caop, fix bug in load wave function in caop, etc.

### DIFF
--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -152,6 +152,8 @@ namespace sbd {
 	  }
 	}
       }
+      RealT NormW;
+      Normalize(W,NormW,b_comm);
       if( stop_it ) {
 	break;
       }
@@ -301,6 +303,8 @@ namespace sbd {
 	  }
 	}
       }
+      RealT NormW;
+      Normalize(W,NormW,b_comm);
       if( stop_it ) {
 	break;
       }

--- a/include/sbd/caop/basic/restart.h
+++ b/include/sbd/caop/basic/restart.h
@@ -64,6 +64,8 @@ namespace sbd {
     int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
     int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
 
+    w.resize(basis.size(),ElemT(0.0));
+
     if( mpi_rank_h == 0 ) {
 
       if( mpi_rank_t == 0 ) {
@@ -78,7 +80,7 @@ namespace sbd {
 	  ifs.read(reinterpret_cast<char *>(&load_basis_length),sizeof(size_t));
 	  load_basis.resize(load_basis_size);
 	  for(size_t i=0; i < load_basis_size; i++) {
-	    load_basis.resize(load_basis_length);
+	    load_basis[i].resize(load_basis_length);
 	    ifs.read(reinterpret_cast<char *>(load_basis[i].data()),sizeof(size_t)*load_basis_length);
 	  }
 	  load_w.resize(load_basis_size);

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -275,7 +275,7 @@ namespace sbd {
 	InnerProduct(W,C,E,b_comm);
 	if( mpi_rank == 0 ) {
 	  std::cout << " " << make_timestamp()
-		    << " Energy = " << E << std::endl;
+		    << " Energy = " << GetReal(E) << std::endl;
 	}
 	energy = GetReal(E);
       }

--- a/samples/caop_selected_basis_diagonalization/README.md
+++ b/samples/caop_selected_basis_diagonalization/README.md
@@ -51,9 +51,9 @@ Below is an explanation of each command-line option.
   Set to `1` to include fermionic sign factors; set to `0` to ignore them.
 - `--init` (int):  
   Specifies how to initial state is generated. Currently, only `0` (a random initial vector) is supported.
-- `--sort_basis` (int):  
+- `--do_sort_basis` (int):  
   Set to `1` to sort the bitstrings loaded from `basisfiles` across all nodes. This is manly used when the input files contain overlapping bitstrings. Set to `0` if sorting is unnecessary.
-- `--redist_basis` (int):  
+- `--do_redist_basis` (int):  
   Set to `1` to redistribute the bitstrings from `basisfiles` uniformly across the nodes specified by `b_comm_size`. Set to `0` if redistribution is unnecessary. Note: If `--sort_basis` is set to `1`, uniform redistribution is performed automatically, and this option is ignored.
 
 ---

--- a/samples/caop_selected_basis_diagonalization/run.sh
+++ b/samples/caop_selected_basis_diagonalization/run.sh
@@ -1,5 +1,5 @@
 mpirun -np 16 -x OMP_NUM_THREADS=1  ./diag --hamfile hamiltonian.txt \
-       --basisfiles basis.txt --sort_basis 0 --redist_basis 1 \
+       --basisfiles basis.txt --do_sort_basis 0 --do_redist_basis 1 \
        --t_comm_size 4 --b_comm_size 4 \
        --method 1 --iteration 10 --block 10 --tolerance 1.0e-4 --fermionsign 0 \
        --system_size 8


### PR DESCRIPTION
In this pull request, I made the following fixes:
- Added normalization to improve the numerical stability of the Lanczos algorithm.
- Fixed a bug in LoadWavefunction in the caop code.
- Updated the wording in the caop README and in the sample scripts.