### PR TITLE
Refine/precision

### DIFF
--- a/include/sbd/framework/fcidump.h
+++ b/include/sbd/framework/fcidump.h
@@ -12,6 +12,8 @@
 #include <map>
 #include <string>
 #include <stdexcept>
+#include <limits>
+#include <iomanip>
 
 namespace sbd {
   
@@ -155,6 +157,8 @@ namespace sbd {
   // Serialize the FCIDump structure into a string for broadcasting
   std::string serializeFCIDump(const FCIDump& fciDump) {
     std::ostringstream oss;
+    oss << std::scientific
+	<< std::setprecision(std::numeric_limits<double>::max_digits10);
     // Serialize header
     for (const auto & [key, value] : fciDump.header) {
       oss << key << "=" << value << ",\n";


### PR DESCRIPTION
In this PR, I fixed an issue where the precision of the FCIDUMP data was being lost due to truncation.