### PR TITLE
change def of sx,sy,sz ops and add msg in caop

### DIFF
--- a/apps/caop_selected_basis_diagonalization/Configuration
+++ b/apps/caop_selected_basis_diagonalization/Configuration
@@ -5,8 +5,8 @@ SBD_PATH=../..
 CCCOM=mpicxx
 
 # flags for build: include path to openmp. The following is the case using homebrew's llvm on Mac
-CCFLAGS= -std=c++17 -stdlib=libc++ -fopenmp -I/opt/homebrew/opt/llvm/include -O3
-# CCFLAGS= -std=c++17 -stdlib=libc++ -fopenmp -I/opt/homebrew/opt/llvm/include -O3 -D_COMPLEX
+# CCFLAGS= -std=c++17 -stdlib=libc++ -fopenmp -I/opt/homebrew/opt/llvm/include -O3
+CCFLAGS= -std=c++17 -stdlib=libc++ -fopenmp -I/opt/homebrew/opt/llvm/include -O3 -D_COMPLEX
 
 # flags for linking: include link to lapack and blas. The following s the case using homebrew's openblas on Mac
 SYSLIB= -L/opt/homebrew/opt/openblas/lib -llapack -lblas

--- a/apps/caop_selected_basis_diagonalization/main.cc
+++ b/apps/caop_selected_basis_diagonalization/main.cc
@@ -85,7 +85,6 @@ int main(int argc, char * argv[]) {
       std::cout << "# save wavefunction file name: " << savename << std::endl;
     }
   }
-  
 
   double energy;
   std::vector<std::vector<size_t>> cobasis;

--- a/include/sbd/caop/basic/arithmetic.h
+++ b/include/sbd/caop/basic/arithmetic.h
@@ -555,18 +555,19 @@ namespace sbd {
 
 
   CAOp Sp(int q) {
-    return CAOp(true,q);
+    return CAOp(false,q);
   }
 
   CAOp Sm(int q) {
-    return CAOp(false,q);
+    return CAOp(true,q);
   }
 
   template <typename ElemT>
   GeneralOp<ElemT> Sz(int q) {
     GeneralOp<ElemT> res;
-    res += Sp(q) * Sm(q);
-    res += ElemT(-0.5);
+    res += Sm(q) * Sp(q);
+    res *= ElemT(-1.0);
+    res += ElemT(0.5);
     return res;
   }
 

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -49,7 +49,8 @@ namespace sbd {
 		int num_block,
 		RealT eps) {
 
-    RealT eps_reg = 1.0e-12;
+    // RealT eps_reg = 1.0e-12;
+    RealT eps_reg = 1.0e-8;
 
     std::vector<std::vector<ElemT>> C(num_block,W);
     std::vector<std::vector<ElemT>> HC(num_block,W);
@@ -219,7 +220,8 @@ namespace sbd {
 		int num_block,
 		RealT eps) {
 
-    RealT eps_reg = 1.0e-12;
+    // RealT eps_reg = 1.0e-12;
+    RealT eps_reg = 1.0e-8;
 
     std::vector<std::vector<ElemT>> C(num_block,W);
     std::vector<std::vector<ElemT>> HC(num_block,W);

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -43,6 +43,7 @@ namespace sbd {
 
     std::vector<ElemT> HC(W);
     std::vector<std::vector<ElemT>> C(num_block,W);
+    std::vector<ElemT> edot;
 
     for(int it=0; it < max_iteration; it++) {
 
@@ -93,6 +94,9 @@ namespace sbd {
 	  HC[is] -= Aii * C[ib][is];
 	}
 
+	MGS(C,ib+1,HC,edot,b_comm);
+	MGS(C,ib+1,HC,edot,b_comm);
+
 #pragma omp parallel for
 	for(size_t is=0; is < HC.size(); is++) {
 	  C[ib+1][is] = HC[is];
@@ -120,16 +124,9 @@ namespace sbd {
 	  break;
 	}
 
-	ElemT volp(1.0/(mpi_size_h*mpi_size_t));
 #pragma omp parallel for
 	for(size_t is=0; is < HC.size(); is++) {
-	  HC[is] = - A[ij] * volp * C[ib][is];
-	}
-	MpiAllreduce(HC,MPI_SUM,t_comm);
-	MpiAllreduce(HC,MPI_SUM,h_comm);
-#pragma omp parallel for
-	for(size_t is=0; is < HC.size(); is++) {
-	  HC[is] *= volp;
+	  HC[is] = - A[ij] * C[ib][is];
 	}
       }
 
@@ -195,6 +192,7 @@ namespace sbd {
 
     std::vector<ElemT> HC(W);
     std::vector<std::vector<ElemT>> C(num_block,W);
+    std::vector<ElemT> edot;
 
     for(int it=0; it < max_iteration; it++) {
       
@@ -219,6 +217,7 @@ namespace sbd {
 	int ii = ib + lda * ib;
 	int ij = ib + lda * (ib+1);
 	int ji = ib+1 + lda * ib;
+
 	mult(hii,ih,jh,hij,C[ib],HC,
 	     slide,h_comm,b_comm,t_comm);
 	InnerProduct(C[ib],HC,Aii,b_comm);
@@ -243,6 +242,9 @@ namespace sbd {
 	for(size_t is=0; is < C[ib].size(); is++) {
 	  HC[is] -= Aii * C[ib][is];
 	}
+
+	MGS(C,ib+1,HC,edot,b_comm);
+	MGS(C,ib+1,HC,edot,b_comm);
 
 #pragma omp parallel for
 	for(size_t is=0; is < HC.size(); is++) {
@@ -271,16 +273,9 @@ namespace sbd {
 	  break;
 	}
 
-	ElemT volp(1.0/(mpi_size_h*mpi_size_t));
 #pragma omp parallel for
 	for(size_t is=0; is < HC.size(); is++) {
-	  HC[is] = - A[ij] * volp * C[ib][is];
-	}
-	MpiAllreduce(HC,MPI_SUM,t_comm);
-	MpiAllreduce(HC,MPI_SUM,h_comm);
-#pragma omp parallel for
-	for(size_t is=0; is < HC.size(); is++) {
-	  HC[is] *= volp;
+	  HC[is] = - A[ij] * C[ib][is];
 	}
       }
 

--- a/include/sbd/caop/basic/loadmodel.h
+++ b/include/sbd/caop/basic/loadmodel.h
@@ -57,11 +57,11 @@ namespace sbd {
   
   template <typename ElemT, typename TermT, typename ProductOp, typename GeneralOp>
   inline void apply_sy_impl(TermT& term, int index, std::true_type /*is_complex*/) {
-    ProductOp pCr(Cr(index));
-    ProductOp pAn(An(index));
-    GeneralOp gCr(ElemT(0.0, -0.5), pCr);
-    GeneralOp gAn(ElemT(0.0,  0.5), pAn);
-    term *= gCr + gAn;
+    ProductOp pSp(Sp(index));
+    ProductOp pSm(Sm(index));
+    GeneralOp gSp(ElemT(0.0, -0.5), pSp);
+    GeneralOp gSm(ElemT(0.0,  0.5), pSm);
+    term *= gSp + gSm;
   }
   
   template <typename ElemT, typename TermT, typename ProductOp, typename GeneralOp>
@@ -169,20 +169,20 @@ namespace sbd {
 		break;
 		
 	      case OpTokenKind::SPlus:
-		term *= Cr(index);
+		term *= Sp(index);
 		break;
 		
 	      case OpTokenKind::SMinus:
-		term *= An(index);
+		term *= Sm(index);
 		break;
 		
 	      case OpTokenKind::Sx:
 		{
-		  ProductOp pCr(Cr(index));
-		  ProductOp pAn(An(index));
-		  GeneralOp<ElemT> gCr(ElemT(0.5),pCr);
-		  GeneralOp<ElemT> gAn(ElemT(0.5),pAn);
-		  term *= gCr + gAn;
+		  ProductOp pSp(Sp(index));
+		  ProductOp pSm(Sm(index));
+		  GeneralOp<ElemT> gSp(ElemT(0.5),pSp);
+		  GeneralOp<ElemT> gSm(ElemT(0.5),pSm);
+		  term *= gSp + gSm;
 		  break;
 		}
 		
@@ -196,11 +196,11 @@ namespace sbd {
 #else
 		if constexpr (std::is_same_v<ElemT,std::complex<float>> ||
 			      std::is_same_v<ElemT,std::complex<double>>) {
-		  ProductOp pCr(Cr(index));
-		  ProductOp pAn(An(index));
-		  GeneralOp<ElemT> gCr(ElemT(0.0,-0.5),pCr);
-		  GeneralOp<ElemT> gAn(ElemT(0.0,0.5),pAn);
-		  term *= gCr + gAn;
+		  ProductOp pSp(Sp(index));
+		  ProductOp pSm(Sm(index));
+		  GeneralOp<ElemT> gSp(ElemT(0.0,-0.5),pSp);
+		  GeneralOp<ElemT> gSm(ElemT(0.0,0.5),pSm);
+		  term *= gSp + gSm;
 		} else {
 		  throw std::runtime_error(
 					   "Sy operator requires complex coefficient type");

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -42,6 +42,12 @@ namespace sbd {
       }
     }
 
+    ElemT volp(1.0/(mpi_size_h*mpi_size_t));
+#pragma omp parallel for
+    for(size_t i=0; i < wb.size(); i++) {
+      wb[i] *= volp;
+    }
+
     if( mpi_rank_t == 0 ) {
 #pragma omp parallel for
       for(size_t i=0; i < twk.size(); i++) {
@@ -152,6 +158,12 @@ namespace sbd {
       } else {
 	twk = w;
       }
+    }
+
+    ElemT volp(1.0/(mpi_size_h*mpi_size_t));
+#pragma omp parallel for
+    for(size_t i=0; i < hw.size(); i++) {
+      hw[i] *= volp;
     }
 
     if( mpi_rank_t == 0 ) {

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -359,6 +359,20 @@ namespace sbd {
 	std::cout << " " << make_timestamp()
 		  << " sbd: end load Hamiltonian" << std::endl;
       }
+#ifdef SBD_DEBUG
+      if( mpi_rank_b == 0 && mpi_rank_t == 0 ) {
+	for(int rank_h=0; rank_h < mpi_size_h; rank_h++) {
+	  if( mpi_rank_h == rank_h ) {
+	    std::cout << " Hamiltonian at mpi_rank ("
+		      << mpi_rank_h << ","
+		      << mpi_rank_b << ","
+		      << mpi_rank_t << ") ---------" << std::endl;
+	    std::cout << hamiltonian;
+	  }
+	  MPI_Barrier(h_comm);
+	}
+      }
+#endif
       /**
 	 Load basis data
        */


### PR DESCRIPTION
This PR updates the spin-operator parser in caop to follow the standard bit representation:
|0>= (Sz +1/2), |1>=(Sz -1/2). 