### PR TITLE
Introduce option for multi start Davidson

### DIFF
--- a/apps/caop_selected_basis_diagonalization/README.md
+++ b/apps/caop_selected_basis_diagonalization/README.md
@@ -41,6 +41,8 @@ Below is an explanation of each command-line option.
   Number of restart cycles in the Davidson algorithm.
 - `--block` (int):  
   Maximum dimension of the reduced space when constructing the projected Hamiltonian in the Davidson algorithm.
+- `--numivec` (int):  
+  Number of initial vectors (initial subspace dimension) for the Davidson method. This option controls how many basis vectors are used to form the initial Krylov subspace. When restarting, the lowest-energy eigenstates obtained from the previous reduced subspace diagonalization are reused as initial vectors, up to the number specified by this option.
 - `--tolerance` (float):  
   Convergence threshold for the Davidson algorithm. The iteration terminates once the norm of the residual vector falls below this value.
 - `--system_size` (int):  

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -251,6 +251,7 @@ namespace sbd {
 	throw std::runtime_error("Failed to read basis data from: " + filename);
       }
     }
+    sort_bitarray(config);
   }
 
   inline void mpi_bcast_string_vector(std::vector<std::string> & vec,

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -129,7 +129,6 @@ namespace sbd {
 	  HC[is] = - A[ij] * C[ib][is];
 	}
       }
-
       for(int i=0; i < n; i++) {
 	for(int j=0; j < n; j++) {
 	  U[i+lda*j] = A[i+lda*j];

--- a/include/sbd/caop/basic/mkham.h
+++ b/include/sbd/caop/basic/mkham.h
@@ -150,7 +150,11 @@ namespace sbd {
 	      }
 	    }
 	    if( check ) continue;
-	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk);
+	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk,
+					 [](const std::vector<size_t> & x,
+					    const std::vector<size_t> & y) {
+					   return x < y;
+					 });
 	    if( itik == tbs.end() ) continue;
 	    if( *itik == vk ) {
 	      auto ik = static_cast<size_t>(itik - tbs.begin());

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -106,7 +106,11 @@ namespace sbd {
 	    if( check ) continue;
 
 	    // we assume that tbs is aligned in ascending order
-	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk);
+	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk,
+					 [](const std::vector<size_t> & x,
+					    const std::vector<size_t> & y) {
+					   return x < y;
+					 });
 	    if( itik == tbs.end() ) continue;
 	    if( *itik == vk ) {
 	      auto ik = static_cast<size_t>(itik - tbs.begin());

--- a/include/sbd/caop/basic/restart.h
+++ b/include/sbd/caop/basic/restart.h
@@ -135,11 +135,14 @@ namespace sbd {
 	    send_w[k] = load_w[index_not_found[k]];
 	  }
 	}
+	ElemT normw;
+	Normalize(w,normw,b_comm);
       }
       MpiBcast(w,0,t_comm);
     }
     MpiBcast(w,0,h_comm);
   }
+  
   
 }
 

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -18,6 +18,7 @@ namespace sbd {
       int method = 0;
       int max_it = 1;
       int max_nb = 10;
+      int max_iv = 1;
       double eps = 1.0e-4;
       int init = 0;
 
@@ -46,6 +47,9 @@ namespace sbd {
 	}
 	if( std::string(argv[i]) == "--block" ) {
 	  sbd_data.max_nb = std::atoi(argv[++i]);
+	}
+	if( std::string(argv[i]) == "--numivec" ) {
+	  sbd_data.max_iv = std::atoi(argv[++i]);
 	}
 	if( std::string(argv[i]) == "--tolerance" ) {
 	  sbd_data.eps = std::atof(argv[++i]);
@@ -94,6 +98,7 @@ namespace sbd {
       }
       std::cout << "# max_it: " << sbd_data.max_it << std::endl;
       std::cout << "# block size: " << sbd_data.max_nb << std::endl;
+      std::cout << "# number of  initiial vectors: " << sbd_data.max_iv << std::endl;
       std::cout << "# tolerance: " << sbd_data.eps << std::endl;
       std::cout << "# init method: " << sbd_data.init << std::endl;
       std::cout << "# system size: " << sbd_data.system_size << std::endl;
@@ -123,6 +128,7 @@ namespace sbd {
       int method = sbd_data.method;
       int max_it = sbd_data.max_it;
       int max_nb = sbd_data.max_nb;
+      int max_iv = sbd_data.max_iv;
       int init   = sbd_data.init;
       double eps = sbd_data.eps;
       size_t system_size = sbd_data.system_size;
@@ -174,7 +180,7 @@ namespace sbd {
 	if( method == 0 ) {
 	  Davidson(hii,W,basis,bit_length,slide,H,sign,
 		   h_comm,b_comm,t_comm,
-		   max_it,max_nb,eps);
+		   max_it,max_nb,max_iv,eps);
 	} else if ( method == 2 ) {
 	  Lanczos(hii,W,basis,bit_length,slide,H,sign,
 		  h_comm,b_comm,t_comm,
@@ -238,7 +244,7 @@ namespace sbd {
 	if( method == 1 ) {
 	  Davidson(hii,ib,ik,hij,W,slide,
 		   h_comm,b_comm,t_comm,
-		   max_it,max_nb,eps);
+		   max_it,max_nb,max_iv,eps);
 	} else if ( method == 3 ) {
 	  Lanczos(hii,ib,ik,hij,W,slide,
 		  h_comm,b_comm,t_comm,
@@ -386,6 +392,7 @@ namespace sbd {
 	  load_basis_from_files(basisfiles,basis,
 				bit_length,system_size,
 				b_comm);
+	  sort_bitarray(basis);
 	  if( sbd_data.do_sort_basis ) {
 	    redistribution(basis,bit_length,system_size,b_comm);
 	    reordering(basis,bit_length,system_size,b_comm);


### PR DESCRIPTION
This PR introduces a new option --numivec that controls the number of initial vectors (initial subspace dimension) for the Davidson method.
The option allows multiple low-lying eigenstates from the previous reduced subspace to be used as initial vectors upon restart.
This is particularly useful for systems with large degeneracies, where using multiple initial vectors helps ensure stable and reliable convergence to the ground state.