### PR TITLE
Add GDB for Thrust

### DIFF
--- a/include/sbd/chemistry/basic/correlation_thrust.h
+++ b/include/sbd/chemistry/basic/correlation_thrust.h
@@ -1,0 +1,143 @@
+/**
+@file sbd/chemistry/basic/correlation_thrust.h
+@brief function to evaluate correlation functions ( < cdag cdag c c > and < cdag c > ) in general
+*/
+
+#ifndef SBD_CHEMISTRY_BASIC_CORRELATION_THRUST_H
+#define SBD_CHEMISTRY_BASIC_CORRELATION_THRUST_H
+
+namespace sbd
+{
+
+template <typename ElemT>
+class CorrelationKernels : public DeterminantKernels<ElemT> {
+protected:
+    ElemT* onebody;
+    ElemT* twobody;
+    size_t onebody_size;
+    size_t twobody_size;
+public:
+    CorrelationKernels() {}
+
+    CorrelationKernels(const size_t bit_length_in, const size_t norbs_in,
+                        const ElemT zero_in,
+                        const oneInt_Thrust<ElemT> one_in,
+                        const twoInt_Thrust<ElemT> two_in,
+                        thrust::device_vector<ElemT>& b1,
+                        thrust::device_vector<ElemT>& b2
+                    ) : DeterminantKernels<ElemT>(bit_length_in, norbs_in, zero_in, one_in, two_in)
+    {
+        onebody = (ElemT*)thrust::raw_pointer_cast(b1.data());
+        twobody = (ElemT*)thrust::raw_pointer_cast(b2.data());
+        onebody_size = this->norbs * this->norbs;
+        twobody_size = this->norbs * this->norbs * this->norbs * this->norbs;
+    }
+
+    /**
+         Function for adding diagonal contribution
+    */
+    __device__ __host__ void ZeroDiffCorrelation(const size_t* det, ElemT WeightI)
+    {
+        for (int i = 0; i < 2 * this->norbs; i++) {
+            if (this->getocc(det, i)) {
+                int oi = i / 2;
+                int si = i % 2;
+                atomicAdd(onebody + si * onebody_size + oi + this->norbs * oi, Conjugate(WeightI) * WeightI);
+                for (int j = i + 1; j < 2 * this->norbs; j++) {
+                    if (this->getocc(det, j)) {
+                        int oj = j / 2;
+                        int sj = j % 2;
+                        atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), Conjugate(WeightI) * WeightI);
+                        atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), Conjugate(WeightI) * WeightI);
+                        if (si == sj) {
+                            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), -Conjugate(WeightI) * WeightI);
+                            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), -Conjugate(WeightI) * WeightI);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+        Function for adding one-occupation different contribution
+    */
+    __device__ __host__ void OneDiffCorrelation(const size_t* det,
+                            const ElemT WeightI,
+                            const ElemT WeightJ,
+                            int i,
+                            int a)
+    {
+        double sgn = 1.0;
+        this->parity(det, std::min(i, a), std::max(i, a), sgn);
+        int oi = i / 2;
+        int si = i % 2;
+        int oa = a / 2;
+        int sa = a % 2;
+        atomicAdd(onebody + si * onebody_size + (oi + this->norbs * oa), Conjugate(WeightI) * WeightJ * ElemT(sgn));
+        size_t one = 1;
+        for (int x = 0; x < this->D_size; x++) {
+            size_t bits = det[x];
+            for (int pos = 0; pos < this->bit_length; pos++) {
+                if ((bits & 1ULL) == 1ULL) {
+                    int soj = x * this->bit_length + pos;
+                    int oj = soj / 2;
+                    int sj = soj % 2;
+
+                    atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
+                    atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
+
+                    if (si == sj) {
+                        atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
+                        atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
+                    }
+                }
+                bits >>= 1;
+            }
+        }
+    }
+
+    /**
+        Function for adding two-occupation different contribution
+    */
+    __device__ __host__ void TwoDiffCorrelation(const size_t* det,
+                            const ElemT WeightI,
+                            const ElemT WeightJ,
+                            int i,
+                            int j,
+                            int a,
+                            int b)
+    {
+        double sgn = 1.0;
+        int I = std::min(i, j);
+        int J = std::max(i, j);
+        int A = std::min(a, b);
+        int B = std::max(a, b);
+        this->parity(det, std::min(I, A), std::max(I, A), sgn);
+        this->parity(det, std::min(J, B), std::max(J, B), sgn);
+        if (A > J || B < I)
+            sgn *= -1.0;
+        int oi = I / 2;
+        int si = I % 2;
+        int oa = A / 2;
+        int sa = A % 2;
+        int oj = J / 2;
+        int sj = J % 2;
+        int ob = B / 2;
+        int sb = B % 2;
+
+        if (si == sa) {
+            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
+            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
+        }
+
+        if (si == sb) {
+            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
+            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
+        }
+    }
+};
+
+}
+
+#endif

--- a/include/sbd/chemistry/basic/davidson_thrust.h
+++ b/include/sbd/chemistry/basic/davidson_thrust.h
@@ -1,9 +1,9 @@
 /**
-@file sbd/chemistry/tpb/davidson.h
+@file sbd/chemistry/basic/davidson.h
 @brief davidson for parallel task management for distributed basis
 */
-#ifndef SBD_CHEMISTRY_TPB_DAVIDSON_THRUST_H
-#define SBD_CHEMISTRY_TPB_DAVIDSON_THRUST_H
+#ifndef SBD_CHEMISTRY_DAVIDSON_THRUST_H
+#define SBD_CHEMISTRY_DAVIDSON_THRUST_H
 
 #include "sbd/framework/jacobi.h"
 #ifdef __CUDACC__
@@ -73,12 +73,7 @@ void GetTotalD_Thrust(const std::vector<ElemT> & hii,
 template <typename ElemT, typename RealT>
 void Davidson(const std::vector<ElemT> &hii,
                 std::vector<ElemT> &W,
-                MultDataThrust<ElemT>& data,
-                const size_t adet_comm_size,
-                const size_t bdet_comm_size,
-                MPI_Comm h_comm,
-                MPI_Comm b_comm,
-                MPI_Comm t_comm,
+                MultBase<ElemT>& mult,
                 int max_iteration,
                 int num_block,
                 RealT eps,
@@ -95,17 +90,17 @@ void Davidson(const std::vector<ElemT> &hii,
     thrust::device_vector<ElemT> R(W.size());
     thrust::device_vector<ElemT> dii;
     int mpi_rank_h;
-    MPI_Comm_rank(h_comm, &mpi_rank_h);
+    MPI_Comm_rank(mult.h_comm(), &mpi_rank_h);
     int mpi_size_h;
-    MPI_Comm_size(h_comm, &mpi_size_h);
+    MPI_Comm_size(mult.h_comm(), &mpi_size_h);
     int mpi_rank_b;
-    MPI_Comm_rank(b_comm, &mpi_rank_b);
+    MPI_Comm_rank(mult.b_comm(), &mpi_rank_b);
     int mpi_size_b;
-    MPI_Comm_size(b_comm, &mpi_size_b);
+    MPI_Comm_size(mult.b_comm(), &mpi_size_b);
     int mpi_rank_t;
-    MPI_Comm_rank(t_comm, &mpi_rank_t);
+    MPI_Comm_rank(mult.t_comm(), &mpi_rank_t);
     int mpi_size_t;
-    MPI_Comm_size(t_comm, &mpi_size_t);
+    MPI_Comm_size(mult.t_comm(), &mpi_size_t);
 
     ElemT *H = (ElemT *)calloc(num_block * num_block, sizeof(ElemT));
     ElemT *U = (ElemT *)calloc(num_block * num_block, sizeof(ElemT));
@@ -116,8 +111,7 @@ void Davidson(const std::vector<ElemT> &hii,
     MPI_Datatype DataE = GetMpiType<RealT>::MpiT;
     MPI_Datatype DataH = GetMpiType<ElemT>::MpiT;
 
-    GetTotalD_Thrust(hii, dii, h_comm);
-
+    GetTotalD_Thrust(hii, dii, mult.h_comm());
 
 #ifdef SBD_DEBUG_DAVIDSON
     std::cout << " diagonal term at mpi process (h,b,t) = ("
@@ -152,12 +146,10 @@ void Davidson(const std::vector<ElemT> &hii,
             //Zero(HC[ib]);
             thrust::fill(HC[ib].begin(), HC[ib].end(), 0);
 
-            mult(hii_dev, C[ib], HC[ib], data,
-                    adet_comm_size, bdet_comm_size,
-                    h_comm, b_comm, t_comm);
+            mult.run(hii_dev, C[ib], HC[ib]);
 
             for (int jb = 0; jb <= ib; jb++) {
-                InnerProduct(C[jb], HC[ib], H[jb + nb * ib], b_comm);
+                InnerProduct(C[jb], HC[ib], H[jb + nb * ib], mult.b_comm());
                 H[ib + nb * jb] = Conjugate(H[jb + nb * ib]);
             }
             for (int jb = 0; jb <= ib; jb++) {
@@ -198,13 +190,13 @@ void Davidson(const std::vector<ElemT> &hii,
                 */
             // #ifdef SBD_FUAGKUPATCH
             if (mpi_size_t > 1)
-                MpiAllreduce(W_dev, MPI_SUM, t_comm);
+                MpiAllreduce(W_dev, MPI_SUM, mult.t_comm());
             if (mpi_size_h > 1)
-                MpiAllreduce(W_dev, MPI_SUM, h_comm);
+                MpiAllreduce(W_dev, MPI_SUM, mult.h_comm());
             if (mpi_size_t > 1)
-                MpiAllreduce(R, MPI_SUM, t_comm);
+                MpiAllreduce(R, MPI_SUM, mult.t_comm());
             if (mpi_size_h > 1)
-                MpiAllreduce(R, MPI_SUM, h_comm);
+                MpiAllreduce(R, MPI_SUM, mult.h_comm());
             if (mpi_size_h * mpi_size_t > 1) {
                 ElemT volp(1.0 / (mpi_size_h * mpi_size_t));
                 // W[is] *= volp;
@@ -217,10 +209,10 @@ void Davidson(const std::vector<ElemT> &hii,
             // #endif
 
             RealT norm_W;
-            Normalize(W_dev, norm_W, b_comm);
+            Normalize(W_dev, norm_W, mult.b_comm());
 
             RealT norm_R;
-            Normalize(R, norm_R, b_comm);
+            Normalize(R, norm_R, mult.b_comm());
 
         	// std::cout << "  norm_W = " << norm_W << " , norm_R = " << norm_R << std::endl;
 
@@ -263,13 +255,13 @@ void Davidson(const std::vector<ElemT> &hii,
                 // Gram-Schmidt orthogonalization
                 for (int kb = 0; kb < ib + 1; kb++) {
                     ElemT olap;
-                    InnerProduct(C[kb], C[ib+1], olap, b_comm);
+                    InnerProduct(C[kb], C[ib+1], olap, mult.b_comm());
                     olap *= ElemT(-1.0);
                     thrust::transform(thrust::device, C[kb].begin(), C[kb].end(), C[ib + 1].begin(), C[ib + 1].begin(), AXPY_kernel<ElemT>(olap));
                 }
 
                 RealT norm_C;
-                Normalize(C[ib + 1], norm_C, b_comm);
+                Normalize(C[ib + 1], norm_C, mult.b_comm());
             }
 
             auto step_end = std::chrono::high_resolution_clock::now();
@@ -285,11 +277,11 @@ void Davidson(const std::vector<ElemT> &hii,
             double predicted_next_end = total_elapsed + ave_time_per_step;
             if (mpi_rank_h == 0) {
                 if (mpi_rank_t == 0) {
-                    MPI_Bcast(&predicted_next_end, 1, MPI_DOUBLE, 0, b_comm);
+                    MPI_Bcast(&predicted_next_end, 1, MPI_DOUBLE, 0, mult.b_comm());
                 }
-                MPI_Bcast(&predicted_next_end, 1, MPI_DOUBLE, 0, t_comm);
+                MPI_Bcast(&predicted_next_end, 1, MPI_DOUBLE, 0, mult.t_comm());
             }
-            MPI_Bcast(&predicted_next_end, 1, MPI_DOUBLE, 0, h_comm);
+            MPI_Bcast(&predicted_next_end, 1, MPI_DOUBLE, 0, mult.h_comm());
 
             if (predicted_next_end > max_time) {
                 do_continue = false;

--- a/include/sbd/chemistry/basic/determinants_thrust.h
+++ b/include/sbd/chemistry/basic/determinants_thrust.h
@@ -1,0 +1,166 @@
+/**
+@file sbd/chemistry/basic/determinants_thrust.h
+@brief Functions to handle the bit-string basis for Thrust
+*/
+
+#ifndef SBD_CHEMISTRY_BASIC_DETERMINANTS_THRUST_H
+#define SBD_CHEMISTRY_BASIC_DETERMINANTS_THRUST_H
+
+namespace sbd
+{
+
+template <typename ElemT>
+class DeterminantKernels {
+protected:
+    ElemT I0;
+    oneInt_Thrust<ElemT> I1;
+    twoInt_Thrust<ElemT> I2;
+    size_t bit_length;
+    size_t norbs;
+    size_t D_size;
+public:
+    DeterminantKernels() {}
+
+    DeterminantKernels(const size_t bit_length_in, const size_t norbs_in,
+                        const ElemT zero_in,
+                        const oneInt_Thrust<ElemT> one_in,
+                        const twoInt_Thrust<ElemT> two_in
+                ) : I0(zero_in), I1(one_in), I2(two_in)
+    {
+        bit_length = bit_length_in;
+        norbs = norbs_in;
+        D_size = (2 * norbs + bit_length - 1) / bit_length;
+    }
+
+    __device__ __host__ void DetFromAlphaBeta(size_t *D, const size_t *A, const size_t *B)
+    {
+        size_t i;
+        for (i = 0; i < D_size; i++) {
+            D[i] = 0;
+        }
+        for (i = 0; i < norbs; i++) {
+            size_t block = i / bit_length;
+            size_t bit_pos = i % bit_length;
+            size_t new_block_A = (2 * i) / bit_length;
+            size_t new_bit_pos_A = (2 * i) % bit_length;
+            size_t new_block_B = (2 * i + 1) / bit_length;
+            size_t new_bit_pos_B = (2 * i + 1) % bit_length;
+
+            if (A[block] & (size_t(1) << bit_pos)) {
+                D[new_block_A] |= size_t(1) << new_bit_pos_A;
+            }
+            if (B[block] & (size_t(1) << bit_pos)) {
+                D[new_block_B] |= size_t(1) << new_bit_pos_B;
+            }
+        }
+    }
+
+    inline __device__ __host__ void parity(const size_t* dets, const int start, const int end, double& sgn)
+    {
+        size_t blockStart = start / bit_length;
+        size_t bitStart = start % bit_length;
+
+        size_t blockEnd = end / bit_length;
+        size_t bitEnd = end % bit_length;
+
+        size_t nonZeroBits = 0; // counter for nonzero bits
+
+        // 1. Count bits in the start block
+        if (blockStart == blockEnd) {
+            // the case where start and end is same block
+            size_t mask = ((size_t(1) << bitEnd) - 1) ^ ((size_t(1) << bitStart) - 1);
+            nonZeroBits += __popcll(dets[blockStart] & mask);
+        }
+        else {
+            // 2. Handle the partial bits in the start block
+            if (bitStart != 0) {
+                size_t mask = ~((size_t(1) << bitStart) - 1); // count after bitStart
+                nonZeroBits += __popcll(dets[blockStart] & mask);
+                blockStart++;
+            }
+
+            // 3. Handle full blocks in between
+            for (size_t i = blockStart; i < blockEnd; i++) {
+                nonZeroBits += __popcll(dets[i]);
+            }
+
+            // 4. Handle the partial bits in the end block
+            if (bitEnd != 0) {
+                size_t mask = (size_t(1) << bitEnd) - 1; // count before bitEnd
+                nonZeroBits += __popcll(dets[blockEnd] & mask);
+            }
+        }
+
+        // parity estimation
+        sgn *= (-2. * (nonZeroBits % 2) + 1);
+
+        // flip sign if start == 1
+        if ((dets[start / bit_length] >> (start % bit_length)) & 1) {
+            sgn *= -1.;
+        }
+    }
+
+  inline __device__ __host__ bool getocc(const size_t* det, int x)
+    {
+        size_t index = x / bit_length;
+        size_t bit_pos = x % bit_length;
+        return (det[index] >> bit_pos) & 1;
+    }
+
+    inline __device__ __host__ ElemT ZeroExcite(const size_t* det, const size_t L)
+    {
+        ElemT energy(0.0);
+
+        for (int i = 0; i < 2 * L; i++) {
+            if (getocc(det, i)) {
+                energy += I1.Value(i, i);
+                for (int j = i + 1; j < 2 * L; j++) {
+                    if (getocc(det, j)) {
+                        energy += I2.DirectValue(i / 2, j / 2);
+                        if ((i % 2) == (j % 2)) {
+                            energy -= I2.ExchangeValue(i / 2, j / 2);
+                        }
+                    }
+                }
+            }
+        }
+        return energy + I0;
+    }
+
+    inline __device__ __host__ ElemT OneExcite(const size_t* det, int i, int a)
+    {
+        double sgn = 1.0;
+        parity(det, std::min(i, a), std::max(i, a), sgn);
+        ElemT energy = I1.Value(a, i);
+        for (int x = 0; x < D_size; x++) {
+            size_t bits = det[x];
+            for (int pos = 0; pos < bit_length; pos++) {
+                if ((bits & 1ULL) == 1ULL) {
+                    int j = x * bit_length + pos;
+                    energy += (I2.Value(a, i, j, j) - I2.Value(a, j, j, i));
+                }
+                bits >>= 1;
+            }
+        }
+        energy *= ElemT(sgn);
+        return energy;
+    }
+
+    inline __device__ __host__ ElemT TwoExcite(const size_t* det, int i, int j, int a, int b)
+    {
+        double sgn = 1.0;
+        int I = std::min(i, j);
+        int J = std::max(i, j);
+        int A = std::min(a, b);
+        int B = std::max(a, b);
+        parity(det, std::min(I, A), std::max(I, A), sgn);
+        parity(det, std::min(J, B), std::max(J, B), sgn);
+        if (A > J || B < I)
+            sgn *= -1.0;
+        return ElemT(sgn) * (I2.Value(A, I, B, J) - I2.Value(A, J, B, I));
+    }
+};
+
+}
+
+#endif

--- a/include/sbd/chemistry/basic/inc_all.h
+++ b/include/sbd/chemistry/basic/inc_all.h
@@ -6,6 +6,7 @@
 #ifdef SBD_THRUST
 #include "sbd/chemistry/basic/integrals_thrust.h"
 #include "sbd/chemistry/basic/determinants_thrust.h"
+#include "sbd/chemistry/basic/correlation_thrust.h"
 #include "sbd/framework/mpi_utility_thrust.h"
 #include "sbd/chemistry/basic/mult.h"
 #include "sbd/chemistry/basic/davidson_thrust.h"

--- a/include/sbd/chemistry/basic/inc_all.h
+++ b/include/sbd/chemistry/basic/inc_all.h
@@ -1,20 +1,15 @@
 #ifndef SBD_CHEMISTRY_BASIC_INC_ALL_H
 #define SBD_CHEMISTRY_BASIC_INC_ALL_H
 
-#ifdef SBD_THRUST
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
-#include <thrust/for_each.h>
-#include <thrust/execution_policy.h>
-#include<thrust/tuple.h>
-#include<thrust/transform.h>
-#include<thrust/iterator/zip_iterator.h>
-#include <thrust/inner_product.h>
-#endif
 
 #include "sbd/chemistry/basic/integrals.h"
 #ifdef SBD_THRUST
 #include "sbd/chemistry/basic/integrals_thrust.h"
+#include "sbd/chemistry/basic/determinants_thrust.h"
+#include "sbd/framework/mpi_utility_thrust.h"
+#include "sbd/chemistry/basic/mult.h"
+#include "sbd/chemistry/basic/davidson_thrust.h"
+#include "sbd/chemistry/basic/lanczos_thrust.h"
 #endif
 #include "sbd/chemistry/basic/determinants.h"
 #include "sbd/chemistry/basic/helpers.h"

--- a/include/sbd/chemistry/basic/integrals_thrust.h
+++ b/include/sbd/chemistry/basic/integrals_thrust.h
@@ -5,6 +5,14 @@
 #ifndef SBD_CHEMISTRY_BASIC_INTEGRALS_THRUST_H
 #define SBD_CHEMISTRY_BASIC_INTEGRALS_THRUST_H
 
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/for_each.h>
+#include <thrust/execution_policy.h>
+#include <thrust/tuple.h>
+#include <thrust/transform.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/inner_product.h>
 
 namespace sbd {
 

--- a/include/sbd/chemistry/basic/lanczos_thrust.h
+++ b/include/sbd/chemistry/basic/lanczos_thrust.h
@@ -1,9 +1,9 @@
 /**
-@file sbd/chemistry/tpb/lanzcos_thrust.h
+@file sbd/chemistry/basic/lanzcos_thrust.h
 @brief lanczos for parallel task management for distributed basis
 */
-#ifndef SBD_CHEMISTRY_TPB_LANCZOS_THRUST_H
-#define SBD_CHEMISTRY_TPB_LANCZOS_THRUST_H
+#ifndef SBD_CHEMISTRY_LANCZOS_THRUST_H
+#define SBD_CHEMISTRY_LANCZOS_THRUST_H
 
 
 
@@ -21,12 +21,7 @@ namespace sbd
 template <typename ElemT, typename RealT>
 void Lanczos(const std::vector<ElemT> &hii,
 				std::vector<ElemT> &W,
-                MultDataThrust<ElemT>& data,
-				const size_t adet_comm_size,
-				const size_t bdet_comm_size,
-				MPI_Comm h_comm,
-				MPI_Comm b_comm,
-				MPI_Comm t_comm,
+				MultBase<ElemT>& mult,
 				int max_iteration,
 				int num_block,
 				RealT eps)
@@ -36,17 +31,17 @@ void Lanczos(const std::vector<ElemT> &hii,
 	int lda = num_block;
 	MPI_Datatype DataE = GetMpiType<RealT>::MpiT;
 	int mpi_rank_h;
-	MPI_Comm_rank(h_comm, &mpi_rank_h);
+	MPI_Comm_rank(mult.h_comm(), &mpi_rank_h);
 	int mpi_size_h;
-	MPI_Comm_size(h_comm, &mpi_size_h);
+	MPI_Comm_size(mult.h_comm(), &mpi_size_h);
 	int mpi_rank_b;
-	MPI_Comm_rank(b_comm, &mpi_rank_b);
+	MPI_Comm_rank(mult.b_comm(), &mpi_rank_b);
 	int mpi_size_b;
-	MPI_Comm_size(b_comm, &mpi_size_b);
+	MPI_Comm_size(mult.b_comm(), &mpi_size_b);
 	int mpi_rank_t;
-	MPI_Comm_rank(t_comm, &mpi_rank_t);
+	MPI_Comm_rank(mult.t_comm(), &mpi_rank_t);
 	int mpi_size_t;
-	MPI_Comm_size(t_comm, &mpi_size_t);
+	MPI_Comm_size(mult.t_comm(), &mpi_size_t);
 
 	RealT *A = (RealT *)calloc(num_block * num_block, sizeof(RealT));
 	RealT *U = (RealT *)calloc(num_block * num_block, sizeof(RealT));
@@ -86,11 +81,9 @@ void Lanczos(const std::vector<ElemT> &hii,
 			int ii = ib + lda * ib;
 			int ij = ib + lda * (ib + 1);
 			int ji = ib + 1 + lda * ib;
-			mult(hii_dev, C[ib], HC, data,
-					adet_comm_size, bdet_comm_size,
-					h_comm, b_comm, t_comm);
+			mult.run(hii_dev, C[ib], HC);
 
-			InnerProduct(C[ib], HC, Aii, b_comm);
+			InnerProduct(C[ib], HC, Aii, mult.b_comm());
 			A[ii] = GetReal(Aii);
 			for (int i = 0; i < n; i++) {
 				for (int j = 0; j < n; j++) {
@@ -114,7 +107,7 @@ void Lanczos(const std::vector<ElemT> &hii,
 			// C[ib + 1][is] = HC[is];
 			C[ib + 1] = HC;
 
-			Normalize(C[ib + 1], A[ij], b_comm);
+			Normalize(C[ib + 1], A[ij], mult.b_comm());
 			A[ji] = A[ij];
 
 			if ((mpi_rank_h == 0) &&
@@ -138,8 +131,8 @@ void Lanczos(const std::vector<ElemT> &hii,
 			// HC[is] = -A[ij] * volp * C[ib][is];
             thrust::transform(thrust::device, C[ib].begin(), C[ib].end(), HC.begin(), AX_kernel<ElemT>(-A[ij] * volp));
 
-			MpiAllreduce(HC, MPI_SUM, t_comm);
-			MpiAllreduce(HC, MPI_SUM, h_comm);
+			MpiAllreduce(HC, MPI_SUM, mult.t_comm());
+			MpiAllreduce(HC, MPI_SUM, mult.h_comm());
 
 			// HC[is] *= volp;
 			thrust::transform(thrust::device, HC.begin(), HC.end(), HC.begin(), AX_kernel<ElemT>(volp));

--- a/include/sbd/chemistry/basic/mult.h
+++ b/include/sbd/chemistry/basic/mult.h
@@ -1,0 +1,71 @@
+/**
+@file sbd/chemistry/base/mult.h
+@brief Function to perform Hamiltonian operation for twist-basis parallelization scheme
+*/
+#ifndef SBD_CHEMISTRY_MULT_BASE_H
+#define SBD_CHEMISTRY_MULT_BASE_H
+
+#include <chrono>
+#include <cstdio>
+
+namespace sbd
+{
+
+template <typename ElemT>
+class MultBase {
+protected:
+    size_t bit_length_;
+    size_t norbs_;
+    size_t D_size_;
+    MPI_Comm h_comm_;
+	MPI_Comm b_comm_;
+	MPI_Comm t_comm_;
+public:
+    MultBase() {}
+
+    MultBase(size_t bit_length, size_t norbs, MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm)
+        : bit_length(bit_length), norbs(norbs), h_comm(h_comm), b_comm(b_comm), t_comm(t_comm)
+    {
+        D_size_ = (2 * norbs_ + bit_length_ - 1) / bit_length_;
+    }
+
+    inline size_t bit_length(void) const
+    {
+        return bit_length_;
+    }
+    inline size_t norbs(void) const
+    {
+        return norbs_;
+    }
+    inline size_t D_size(void) const
+    {
+        return D_size_;
+    }
+    inline MPI_Comm h_comm(void) const
+    {
+        return h_comm_;
+    }
+    inline MPI_Comm b_comm(void) const
+    {
+        return b_comm_;
+    }
+    inline MPI_Comm t_comm(void) const
+    {
+        return t_comm_;
+    }
+
+#ifdef SBD_THRUST
+    virtual void run(const thrust::device_vector<ElemT> &hii,
+                    const thrust::device_vector<ElemT> &Wk,
+                    thrust::device_vector<ElemT> &Wb) = 0;
+#else
+    virtual void run(const std::vector<ElemT> & hii,
+            	    const std::vector<ElemT> & Wk,
+	                std::vector<ElemT> & Wb) = 0;
+#endif
+};
+
+
+}
+
+#endif

--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -1,0 +1,443 @@
+/**
+@file sbd/chemistry/tpb/correlation_thrust.h
+@brief function to evaluate correlation functions ( < cdag cdag c c > and < cdag c > ) in general
+*/
+#ifndef SBD_CHEMISTRY_GDB_CORRELATION_THRUST_H
+#define SBD_CHEMISTRY_GDB_CORRELATION_THRUST_H
+
+namespace sbd {
+namespace gdb {
+
+template <typename ElemT>
+class CorrelationKernelBase : public MultKernelBase<ElemT> {
+protected:
+    CorrelationKernels<ElemT> correlation;
+public:
+    CorrelationKernelBase() {}
+
+    CorrelationKernelBase(
+                        const thrust::device_vector<ElemT>& v_wb,
+                        const thrust::device_vector<ElemT>& v_t,
+						const MultGDBThrust<ElemT>& data,
+                        thrust::device_vector<ElemT>& b1,
+                        thrust::device_vector<ElemT>& b2)
+                         : MultKernelBase<ElemT>(v_wb, v_t, data),
+                           correlation(data.bit_length(), data.norbs(),  data.I0(), data.I1(), data.I2(), b1, b2)
+    {
+    }
+
+};
+
+template <typename ElemT>
+class CorrelationInit : public CorrelationKernelBase<ElemT>
+{
+protected:
+public:
+    CorrelationInit(
+                const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+                thrust::device_vector<ElemT>& b1,
+                thrust::device_vector<ElemT>& b2) : CorrelationKernelBase<ElemT>(v_wb, v_t, data, b1, b2)
+    {
+    }
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		if( (i % this->mpi_size_h) == this->mpi_rank_h ) {
+			this->correlation.ZeroDiffCorrelation(this->det + i * this->D_size, this->wb[i]);
+        }
+    }
+};
+
+template <typename ElemT>
+class CorrelationSingleAlphaKernel : public CorrelationKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	CorrelationSingleAlphaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+                thrust::device_vector<ElemT>& b1,
+                thrust::device_vector<ElemT>& b2,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: CorrelationKernelBase<ElemT>(v_wb, v_t, data, b1, b2), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t ibst = idxmap.AdetToBdetSM[i];
+		size_t idet = idxmap.AdetToDetSM[i];
+		size_t ia = idxmap.AdetIndex[i];
+		size_t iast = ia;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
+			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			// single alpha excitations
+			for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+				size_t jast = exidx.SinglesFromAdetSM[ja];
+				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
+				if (idxa >= 0) {
+					if (jast != tidxmap.BdetToAdetSM[idxa])
+						continue;
+					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
+											this->wb[idet], this->twk[jdet],
+											exidx.SinglesAdetCrAnSM[ja],
+											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet]);
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+template <typename ElemT>
+class CorrelationDoubleAlphaKernel : public CorrelationKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	CorrelationDoubleAlphaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+                thrust::device_vector<ElemT>& b1,
+                thrust::device_vector<ElemT>& b2,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: CorrelationKernelBase<ElemT>(v_wb, v_t, data, b1, b2), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t ibst = idxmap.AdetToBdetSM[i];
+		size_t idet = idxmap.AdetToDetSM[i];
+		size_t ia = idxmap.AdetIndex[i];
+		size_t iast = ia;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
+			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			// double alpha excitations
+			for (size_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
+				size_t jast = exidx.DoublesFromAdetSM[ja];
+				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
+				if (idxa >= 0) {
+					if (jast != tidxmap.BdetToAdetSM[idxa])
+						continue;
+					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
+											this->wb[idet], this->twk[jdet],
+											exidx.DoublesAdetCrAnSM[ja],
+											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet],
+											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 2],
+											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 3]);
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+
+template <typename ElemT>
+class CorrelationSingleBetaKernel : public CorrelationKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	CorrelationSingleBetaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+                thrust::device_vector<ElemT>& b1,
+                thrust::device_vector<ElemT>& b2,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: CorrelationKernelBase<ElemT>(v_wb, v_t, data, b1, b2), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t iast = idxmap.BdetToAdetSM[i];
+		size_t idet = idxmap.BdetToDetSM[i];
+		size_t ib = idxmap.BdetIndex[i];
+		size_t ibst = ib;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
+			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			// single alpha excitations
+			for (size_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
+				size_t jbst = exidx.SinglesFromBdetSM[jb];
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
+											this->wb[idet], this->twk[jdet],
+											exidx.SinglesBdetCrAnSM[jb],
+											exidx.SinglesBdetCrAnSM[jb + exidx.size_single_bdet]);
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+template <typename ElemT>
+class CorrelationDoubleBetaKernel : public CorrelationKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	CorrelationDoubleBetaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+                thrust::device_vector<ElemT>& b1,
+                thrust::device_vector<ElemT>& b2,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: CorrelationKernelBase<ElemT>(v_wb, v_t, data, b1, b2), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t iast = idxmap.BdetToAdetSM[i];
+		size_t idet = idxmap.BdetToDetSM[i];
+		size_t ib = idxmap.BdetIndex[i];
+		size_t ibst = ib;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
+			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			// double alpha excitations
+			for (size_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
+				size_t jbst = exidx.DoublesFromBdetSM[jb];
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
+											this->wb[idet], this->twk[jdet],
+											exidx.DoublesBdetCrAnSM[jb],
+											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet],
+											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 2],
+											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 3]);
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+
+template <typename ElemT>
+class CorrelationAlphaBetaKernel : public CorrelationKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	CorrelationAlphaBetaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+                thrust::device_vector<ElemT>& b1,
+                thrust::device_vector<ElemT>& b2,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: CorrelationKernelBase<ElemT>(v_wb, v_t, data, b1, b2), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t ibst = idxmap.AdetToBdetSM[i];
+		size_t idet = idxmap.AdetToDetSM[i];
+		size_t ia = idxmap.AdetIndex[i];
+		size_t iast = ia;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		// alpha-beta two-particle excitations
+		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+			size_t jast = exidx.SinglesFromAdetSM[ja];
+			size_t start_idx = 0;
+			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
+			for (size_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
+				size_t jbst = exidx.SinglesFromBdetSM[k];
+				if (start_idx >= end_idx)
+					break;
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					start_idx = idxb - tidxmap.AdetToDetOffset[jast];
+					if (start_idx < end_idx) {
+						size_t jdet = tidxmap.AdetToDetSM[idxb];
+						this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
+											this->wb[idet], this->twk[jdet],
+												exidx.SinglesAdetCrAnSM[ja],
+												exidx.SinglesBdetCrAnSM[k],
+												exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
+												exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
+					}
+				}
+			}
+		}
+	}
+};
+
+
+template <typename ElemT>
+void MultGDBThrust<ElemT>::correlation(const std::vector<ElemT> & w_in,
+				std::vector<std::vector<ElemT>> & onebody_out,
+				std::vector<std::vector<ElemT>> & twobody_out)
+{
+    thrust::device_vector<ElemT> onebody(this->norbs() * this->norbs() * 2, ElemT(0.0));
+    thrust::device_vector<ElemT> twobody(this->norbs() * this->norbs() * this->norbs() * this->norbs() * 4, ElemT(0.0));
+
+    int mpi_rank_h = 0;
+    int mpi_size_h = 1;
+    MPI_Comm_rank(this->h_comm(), &mpi_rank_h);
+    MPI_Comm_size(this->h_comm(), &mpi_size_h);
+
+    int mpi_size_b;
+    MPI_Comm_size(this->b_comm(), &mpi_size_b);
+    int mpi_rank_b;
+    MPI_Comm_rank(this->b_comm(), &mpi_rank_b);
+    int mpi_size_t;
+    MPI_Comm_size(this->t_comm(), &mpi_size_t);
+    int mpi_rank_t;
+    MPI_Comm_rank(this->t_comm(), &mpi_rank_t);
+
+	thrust::device_vector<ElemT> w(w_in.size());
+	thrust::device_vector<ElemT> tw(w_in.size());
+	thrust::device_vector<ElemT> rw;
+	thrust::device_vector<size_t> tidxmap_storage;
+	DetIndexMapThrust tidxmap;
+
+    thrust::copy_n(w_in.begin(), w_in.size(), w.begin());
+
+	if (exidx[0].slide != 0) {
+		sbd::gdb::MpiSlide(idxmap, idxmap_storage, tidxmap, tidxmap_storage, -exidx[0].slide, this->b_comm());
+		sbd::MpiSlide(w, tw, -exidx[0].slide, this->b_comm());
+	} else {
+		tidxmap.copy(tidxmap_storage, idxmap, idxmap_storage);
+		thrust::copy_n(w.begin(), w.size(), tw.begin());
+	}
+
+    if (mpi_rank_t == 0) {
+		CorrelationInit kernel(w, tw, *this, onebody, twobody);
+		kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci, tw.size(), kernel);
+	}
+
+	for (size_t task = 0; task < exidx.size(); task++) {
+		// single alpha excitations
+		CorrelationSingleAlphaKernel kernel_single_alpha(w, tw, *this, onebody, twobody, idxmap, tidxmap, exidx[task]);
+		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_sa = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_sa, idxmap.size_adet, kernel_single_alpha);
+
+		// double alpha excitations
+		CorrelationDoubleAlphaKernel kernel_double_alpha(w, tw, *this, onebody, twobody, idxmap, tidxmap, exidx[task]);
+		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_da = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_da, idxmap.size_adet, kernel_double_alpha);
+
+		// single beta excitations
+		CorrelationSingleBetaKernel kernel_single_beta(w, tw, *this, onebody, twobody, idxmap, tidxmap, exidx[task]);
+		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_sb = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_sb, idxmap.size_bdet, kernel_single_beta);
+
+		// double beta excitations
+		CorrelationDoubleBetaKernel kernel_double_beta(w, tw, *this, onebody, twobody, idxmap, tidxmap, exidx[task]);
+		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_db = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_db, idxmap.size_bdet, kernel_double_beta);
+
+		// alpha-beta excitations
+		CorrelationAlphaBetaKernel kernel_alpha_beta(w, tw, *this, onebody, twobody, idxmap, tidxmap, exidx[task]);
+		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_ab = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_ab, idxmap.size_adet, kernel_alpha_beta);
+
+		if (task != exidx.size() - 1) {
+			int slide = exidx[task].slide - exidx[task + 1].slide;
+
+			rw = tw;
+			sbd::MpiSlide(rw, tw, slide, this->b_comm());
+			sbd::gdb::MpiSlide(idxmap, idxmap_storage, tidxmap, tidxmap_storage, -exidx[0].slide, this->b_comm());
+
+			thrust::device_vector<size_t> ridxmap_storage;
+			DetIndexMapThrust ridxmap;
+			ridxmap.copy(ridxmap_storage, tidxmap, tidxmap_storage);
+			sbd::gdb::MpiSlide(ridxmap, ridxmap_storage, tidxmap, tidxmap_storage, slide, this->b_comm());
+		}
+	} // end for(size_t task=0; task < exidx.size(); task++)
+
+    if (mpi_size_b > 1)
+        MpiAllreduce(onebody, MPI_SUM, this->b_comm());
+    if (mpi_size_t > 1)
+        MpiAllreduce(onebody, MPI_SUM, this->t_comm());
+    if (mpi_size_h > 1)
+        MpiAllreduce(onebody, MPI_SUM, this->h_comm());
+
+    if (mpi_size_b > 1)
+        MpiAllreduce(twobody, MPI_SUM, this->b_comm());
+    if (mpi_size_t > 1)
+        MpiAllreduce(twobody, MPI_SUM, this->t_comm());
+    if (mpi_size_h > 1)
+        MpiAllreduce(twobody, MPI_SUM, this->h_comm());
+
+    // copy out onebody, twobody
+    onebody_out.resize(2);
+    size_t size = this->norbs() * this->norbs();
+    size_t offset = 0;
+    for(int s=0; s < 2; s++) {
+        onebody_out[s].resize(size, ElemT(0.0));
+        thrust::copy_n(onebody.begin() + offset, size, onebody_out[s].begin());
+        offset += size;
+    }
+
+    twobody_out.resize(4);
+    size = this->norbs() * this->norbs() * this->norbs() * this->norbs();
+    offset = 0;
+    for(int s=0; s < 4; s++) {
+        twobody_out[s].resize(size, ElemT(0.0));
+        thrust::copy_n(twobody.begin() + offset, size, twobody_out[s].begin());
+        offset += size;
+    }
+} // end function Correlation
+
+} // end namespace gdb
+} // end namespace sbd
+
+#endif

--- a/include/sbd/chemistry/gdb/davidson_thrust.h
+++ b/include/sbd/chemistry/gdb/davidson_thrust.h
@@ -1,0 +1,366 @@
+/**
+@file sbd/chemistry/gdb/davidson_thrust.h
+@brief davidson for general determinant basis
+*/
+#ifndef SBD_CHEMISTRY_GDB_DAVIDSON_THRUST_H
+#define SBD_CHEMISTRY_GDB_DAVIDSON_THRUST_H
+
+namespace sbd {
+  namespace gdb {
+
+    template <typename ElemT>
+    void BasisInitVector(std::vector<ElemT> & w,
+			 const std::vector<std::vector<size_t>> & det,
+			 MPI_Comm h_comm,
+			 MPI_Comm b_comm,
+			 MPI_Comm t_comm,
+			 int init) {
+      int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
+      int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
+      int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
+      int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
+      int mpi_size_t; MPI_Comm_size(t_comm,&mpi_size_t);
+      int mpi_rank_t; MPI_Comm_rank(t_comm,&mpi_rank_t);
+
+      w.resize(det.size());
+      if( init == 0 ) {
+	if( mpi_rank_b == 0 ) {
+	  w[0] = ElemT(1.0);
+	}
+	MpiBcast(w,0,t_comm);
+      } else if ( init == 1 ) {
+	if( mpi_rank_t == 0 ) {
+	  Randomize(w,b_comm,h_comm);
+	}
+	MpiBcast(w,0,t_comm);
+      }
+    }
+
+    template <typename ElemT, typename RealT>
+    void Davidson(const std::vector<ElemT> & hii,
+		  std::vector<ElemT> & w,
+		  const std::vector<std::vector<size_t>> & det,
+		  const size_t bit_length,
+		  const size_t norb,
+		  const DetIndexMap & idxmap,
+		  const std::vector<ExcitationLookup> & exidx,
+		  const ElemT & I0,
+		  const oneInt<ElemT> & I1,
+		  const twoInt<ElemT> & I2,
+		  MPI_Comm h_comm,
+		  MPI_Comm b_comm,
+		  MPI_Comm t_comm,
+		  int max_iteration,
+		  int num_block,
+		  RealT eps) {
+
+      RealT eps_reg = 1.0e-12;
+
+      std::vector<std::vector<ElemT>> v(num_block,w);
+      std::vector<std::vector<ElemT>> Hv(num_block,w);
+      std::vector<ElemT> r(w);
+      std::vector<ElemT> dii(hii);
+      int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
+      int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
+      int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
+      int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
+      int mpi_rank_t; MPI_Comm_rank(t_comm,&mpi_rank_t);
+      int mpi_size_t; MPI_Comm_size(t_comm,&mpi_size_t);
+
+      ElemT * H = (ElemT *) calloc(num_block*num_block,sizeof(ElemT));
+      ElemT * U = (ElemT *) calloc(num_block*num_block,sizeof(ElemT));
+      RealT * E = (RealT *) malloc(num_block*sizeof(RealT));
+      char jobz = 'V';
+      char uplo = 'U';
+      int nb = num_block;
+      MPI_Datatype DataE = GetMpiType<RealT>::MpiT;
+      MPI_Datatype DataH = GetMpiType<ElemT>::MpiT;
+
+      GetTotalD(hii,dii,h_comm);
+
+      bool do_continue = true;
+
+      for(int it=0; it < max_iteration; it++) {
+
+#pragma omp parallel for
+	for(size_t is=0; is < w.size(); is++) {
+	  v[0][is] = w[is];
+	}
+
+	for(int ib=0; ib < nb; ib++) {
+
+#ifdef SBD_DEBUG_MULT
+	  for(int rank_h=0; rank_h < mpi_size_h; rank_h++) {
+	    for(int rank_b=0; rank_b < mpi_size_b; rank_b++) {
+	      for(int rank_t=0; rank_t < mpi_size_t; rank_t++) {
+		if( mpi_rank_h == rank_h &&
+		    mpi_rank_b == rank_b &&
+		    mpi_rank_t == rank_t ) {
+		  std::cout << " " << make_timestamp()
+			    << " sbd: davidson step "
+			    << it << "," << ib
+			    << ", wave function weight before applying H at rank ("
+			    << mpi_rank_h << ","
+			    << mpi_rank_b << ","
+			    << mpi_rank_t << "):";
+		  for(size_t is=0; is < static_cast<size_t>(2); is++) {
+		    std::cout << (( is == 0 ) ? " " : ",")
+			      << v[ib][is];
+		  }
+		  if( mpi_size_b == 1 ) {
+		    std::cout << ", ...";
+		    for(size_t is=v[ib].size()/2-2; is < v[ib].size()/2+2; is++) {
+		      std::cout << "," << v[ib][is];
+		    }
+		  }
+		  std::cout << ", ...";
+		  for(size_t is=v[ib].size()-2; is < v[ib].size(); is++) {
+		    std::cout << "," << v[ib][is];
+		  }
+		  std::cout << std::endl;
+		}
+		MPI_Barrier(t_comm);
+	      }
+	      MPI_Barrier(b_comm);
+	    }
+	    MPI_Barrier(h_comm);
+	  }
+#endif
+
+	  Zero(Hv[ib]);
+	  mult(hii,v[ib],Hv[ib],bit_length,norb,
+	       det,idxmap,exidx,I0,I1,I2,
+	       h_comm,b_comm,t_comm);
+
+#ifdef SBD_DEBUG_MULT
+	  for(int rank_h=0; rank_h < mpi_size_h; rank_h++) {
+	    for(int rank_b=0; rank_b < mpi_size_b; rank_b++) {
+	      for(int rank_t=0; rank_t < mpi_size_t; rank_t++) {
+		if( mpi_rank_h == rank_h &&
+		    mpi_rank_b == rank_b &&
+		    mpi_rank_t == rank_t ) {
+		  std::cout << " " << make_timestamp()
+			    << " sbd: davidson step "
+			    << it << "," << ib
+			    << " wave function weight after applying H at rank ("
+			    << mpi_rank_h << ","
+			    << mpi_rank_b << ","
+			    << mpi_rank_t << "):";
+		  for(size_t is=0; is < static_cast<size_t>(2); is++) {
+		    std::cout << (( is == 0 ) ? " " : ",")
+			      << Hv[ib][is];
+		  }
+		  if( mpi_size_b == 1 ) {
+		    std::cout << ", ...";
+		    for(size_t is=Hv[ib].size()/2-2; is < Hv[ib].size()/2+2; is++) {
+		      std::cout << "," << Hv[ib][is];
+		    }
+		  }
+		  std::cout << ", ...";
+		  for(size_t is=Hv[ib].size()-2; is < Hv[ib].size(); is++) {
+		    std::cout << "," << Hv[ib][is];
+		  }
+		  std::cout << std::endl;
+		}
+		MPI_Barrier(t_comm);
+	      }
+	      MPI_Barrier(b_comm);
+	    }
+	    MPI_Barrier(h_comm);
+	  }
+#endif
+
+
+	  for(int jb=0; jb <= ib; jb++) {
+	    InnerProduct(v[jb],Hv[ib],H[jb+nb*ib],b_comm);
+	    H[ib+nb*jb] = Conjugate(H[jb+nb*ib]);
+	  }
+	  for(int jb=0; jb <= ib; jb++) {
+	    for(int kb=0; kb <= ib; kb++) {
+	      U[jb+nb*kb] = H[jb+nb*kb];
+	    }
+	  }
+
+#ifdef SBD_DEBUG_MULT
+	  if( mpi_rank_h == 0 &&
+	      mpi_rank_b == 0 &&
+	      mpi_rank_t == 0 ) {
+	    std::cout << " " << make_timestamp()
+		      << " sbd: davidson step "
+		      << it << "," << ib
+		      << " effective matrix = [";
+	    for(int kb=0; kb <= ib; kb++) {
+	      for(int jb=0; jb <= ib; jb++) {
+		std::cout << ( (jb==0) ? "[" : "," ) << U[jb+nb*kb];
+	      }
+	      std::cout << "]";
+	    }
+	    std::cout << "]" << std::endl;
+	  }
+
+#endif
+
+	  hp_numeric::MatHeev(jobz,uplo,ib+1,U,nb,E);
+	  ElemT x = U[0];
+#pragma omp parallel for
+	  for(size_t is=0; is < w.size(); is++) {
+	    w[is] = v[0][is] * x;
+	  }
+	  x = ElemT(-1.0) * U[0];
+#pragma omp parallel for
+	  for(size_t is=0; is < w.size(); is++) {
+	    r[is] = Hv[0][is] * x;
+	  }
+	  for(int kb=1; kb <= ib; kb++) {
+	    x = U[kb];
+#pragma omp parallel for
+	    for(size_t is=0; is < w.size(); is++) {
+	      w[is] += v[kb][is] * x;
+	    }
+	    x = ElemT(-1.0) * U[kb];
+#pragma omp parallel for
+	    for(size_t is=0; is < w.size(); is++) {
+	      r[is] += Hv[kb][is] * x;
+	    }
+	  }
+#pragma omp parallel for
+	  for(size_t is=0; is < w.size(); is++) {
+	    r[is] += E[0]*w[is];
+	  }
+
+	  MpiAllreduce(w,MPI_SUM,t_comm);
+	  MpiAllreduce(w,MPI_SUM,h_comm);
+	  MpiAllreduce(r,MPI_SUM,t_comm);
+	  MpiAllreduce(r,MPI_SUM,h_comm);
+	  ElemT volp(1.0/(mpi_size_h*mpi_size_t));
+#pragma	omp parallel for
+	  for(size_t is=0; is < w.size(); is++) {
+	    w[is] *= volp;
+	  }
+#pragma omp parallel for
+	  for(size_t is=0; is < r.size(); is++) {
+	    r[is] *= volp;
+	  }
+
+#ifdef SBD_DEBUG_MULT
+	  for(int rank_h=0; rank_h < mpi_size_h; rank_h++) {
+	    for(int rank_b=0; rank_b < mpi_size_b; rank_b++) {
+	      for(int rank_t=0; rank_t < mpi_size_t; rank_t++) {
+		if( mpi_rank_h == rank_h &&
+		    mpi_rank_b == rank_b &&
+		    mpi_rank_t == rank_t ) {
+		  std::cout << " " << make_timestamp()
+			    << " sbd: davidson step "
+			    << it << "," << ib
+			    << " residual vector at rank ("
+			    << mpi_rank_h << ","
+			    << mpi_rank_b << ","
+			    << mpi_rank_t << "):";
+		  for(size_t is=0; is < static_cast<size_t>(2); is++) {
+		    std::cout << (( is == 0 ) ? " " : ",")
+			      << r[is];
+		  }
+		  if( mpi_size_b == 1 ) {
+		    std::cout << ", ...";
+		    for(size_t is=r.size()/2-2; is < r.size()/2+2; is++) {
+		      std::cout << "," << r[is];
+		    }
+		  }
+		  std::cout << ", ...";
+		  for(size_t is=r.size()-2; is < r.size(); is++) {
+		    std::cout << "," << r[is];
+		  }
+		  std::cout << std::endl;
+		}
+		MPI_Barrier(t_comm);
+	      }
+	      MPI_Barrier(b_comm);
+	    }
+	    MPI_Barrier(h_comm);
+	  }
+#endif
+
+	  RealT norm_w;
+	  Normalize(w,norm_w,b_comm);
+
+	  RealT norm_r;
+	  Normalize(r,norm_r,b_comm);
+
+	  if( mpi_rank_h == 0 ) {
+	    if( mpi_rank_t == 0 ) {
+	      if( mpi_rank_b == 0 ) {
+		std::cout << " Davidson iteration " << it << "." << ib
+			  << " (tol=" << norm_r << "):";
+		for(int p=0; p < std::min(ib+1,4); p++) {
+		  std::cout << " " << E[p];
+		}
+		std::cout << std::endl;
+	      }
+	    }
+	  }
+	  if( norm_r < eps ) {
+	    do_continue = false;
+	    break;
+	  }
+	  if( ib < nb-1 ) {
+	    // Determine
+#pragma omp parallel for
+	    for(size_t is=0; is < w.size(); is++) {
+	      if( std::abs(E[0]-dii[is]) > eps_reg ) {
+		v[ib+1][is] = r[is]/(E[0] - dii[is]);
+	      } else {
+		v[ib+1][is] = r[is]/(E[0] - dii[is] - eps_reg);
+	      }
+	    }
+	    // Gram-Schmidt orthogonalization
+	    for(int kb=0; kb < ib+1; kb++) {
+	      ElemT olap;
+	      InnerProduct(v[kb],v[ib+1],olap,b_comm);
+	      olap *= ElemT(-1.0);
+#pragma omp parallel for
+	      for(size_t is=0; is < w.size(); is++) {
+		v[ib+1][is] += v[kb][is]*olap;
+	      }
+	    }
+	    RealT norm_v;
+	    Normalize(v[ib+1],norm_v,b_comm);
+	  }
+	} // end for(int ib=0; ib < nb; ib++)
+	if( !do_continue ) {
+	  break;
+	}
+	// Restart with C[0] = W;
+#pragma omp parallel for
+	for(size_t is=0; is < w.size(); is++) {
+	  v[0][is] = w[is];
+	}
+      } // end for(int it=0; it < max_iteration; it++)
+      free(H);
+      free(U);
+      free(E);
+    }
+
+
+template <typename ElemT, typename RealT>
+void Davidson(const std::vector<ElemT> & hii,
+		const std::vector<std::vector<size_t*>> & ih,
+		const std::vector<std::vector<size_t*>> & jh,
+		const std::vector<std::vector<ElemT*>> & hij,
+		const std::vector<std::vector<size_t>> & len,
+		const std::vector<int> & slide,
+		std::vector<ElemT> & w,
+		MPI_Comm h_comm,
+		MPI_Comm b_comm,
+		MPI_Comm t_comm,
+		int max_iteration,
+		int num_block,
+		RealT eps)
+{
+	// not used for Thrust
+}
+
+
+} // end namespace gdb
+} // end namespace sbd
+
+#endif

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -1,0 +1,594 @@
+/**
+@file sbd/chemistry/gdb/helpers.h
+@brief Helper array to construct Hamiltonian for general determinant basis for Thrust
+ */
+#ifndef SBD_CHEMISTRY_GDB_HELPER_THRUST_H
+#define SBD_CHEMISTRY_GDB_HELPER_THRUST_H
+
+#include "sbd/framework/type_def.h"
+#include "sbd/framework/mpi_utility.h"
+
+namespace sbd
+{
+namespace gdb
+{
+
+/**
+       DetBasisMapper is an array to find relation between dets.
+*/
+class DetIndexMapThrust
+{
+public:
+    size_t* AdetToDetOffset;
+    size_t* BdetToDetOffset;
+    size_t* AdetIndex;
+    size_t* BdetIndex;
+    size_t* AdetToBdetSM;
+    size_t* AdetToDetSM;
+    size_t* BdetToAdetSM;
+    size_t* BdetToDetSM;
+    size_t size_adet = 0;
+    size_t size_bdet = 0;
+
+    DetIndexMapThrust() {}
+
+    DetIndexMapThrust(const DetIndexMapThrust& other)
+    {
+        AdetToDetOffset = other.AdetToDetOffset;
+        BdetToDetOffset = other.BdetToDetOffset;
+        AdetIndex = other.AdetIndex;
+        BdetIndex = other.BdetIndex;
+        AdetToBdetSM = other.AdetToBdetSM;
+        AdetToDetSM = other.AdetToDetSM;
+        BdetToAdetSM = other.BdetToAdetSM;
+        BdetToDetSM = other.BdetToDetSM;
+        size_adet = other.size_adet;
+        size_bdet = other.size_bdet;
+    }
+
+    DetIndexMapThrust(thrust::device_vector<size_t>& storage, const DetIndexMap& idxmap)
+    {
+        size_t size = 0;
+
+        std::vector<size_t> offset_adet(idxmap.AdetToDetLen.size() + 1);
+        std::vector<size_t> offset_bdet(idxmap.BdetToDetLen.size() + 1);
+        for(size_t i=0; i < idxmap.AdetToDetLen.size(); i++) {
+            offset_adet[i] = size_adet;
+            size_adet += idxmap.AdetToDetLen[i];
+        }
+        offset_adet[idxmap.AdetToDetLen.size()] = size_adet;
+
+        for(size_t i=0; i < idxmap.BdetToDetLen.size(); i++) {
+            offset_bdet[i] = size_bdet;
+            size_bdet += idxmap.BdetToDetLen[i];
+        }
+        offset_bdet[idxmap.BdetToDetLen.size()] = size_bdet;
+
+        size = idxmap.AdetToDetLen.size() + 1 + idxmap.BdetToDetLen.size() + 1 + size_adet * 3 + size_bdet * 3;
+        storage.resize(size);
+        size_t* base_memory = (size_t*)thrust::raw_pointer_cast(storage.data());
+
+        size_t count = 0;
+        // store offset
+        AdetToDetOffset = base_memory + count;
+        thrust::copy_n(offset_adet.begin(), offset_adet.size(), storage.begin() + count);
+        count += offset_adet.size();
+
+        BdetToDetOffset = base_memory + count;
+        thrust::copy_n(offset_bdet.begin(), offset_bdet.size(), storage.begin() + count);
+        count += offset_bdet.size();
+
+        // set Adet, Bdet indices
+        AdetIndex = base_memory + count;
+        for(size_t i=0; i < idxmap.AdetToDetLen.size(); i++) {
+            thrust::fill_n(storage.begin() + count + offset_adet[i], idxmap.AdetToDetLen[i], i);
+        }
+        count += size_adet;
+
+        BdetIndex = base_memory + count;
+        for(size_t i=0; i < idxmap.BdetToDetLen.size(); i++) {
+            thrust::fill_n(storage.begin() + count + offset_bdet[i], idxmap.BdetToDetLen[i], i);
+        }
+        count += size_bdet;
+
+        // copy SMs
+        thrust::copy_n(idxmap.storage.begin(), size_adet * 2 + size_bdet * 2, storage.begin() + count);
+        AdetToDetSM = base_memory + count;
+        count += size_adet;
+        AdetToBdetSM = base_memory + count;
+        count += size_adet;
+        BdetToDetSM = base_memory + count;
+        count += size_bdet;
+        BdetToAdetSM = base_memory + count;
+    }
+
+    void copy(thrust::device_vector<size_t>& storage, const DetIndexMapThrust& idxmap, const thrust::device_vector<size_t>& src_storage)
+    {
+        storage = src_storage;
+
+        size_t* base = (size_t*)thrust::raw_pointer_cast(storage.data());
+        size_t* src_base = (size_t*)thrust::raw_pointer_cast(src_storage.data());
+
+        AdetToDetOffset = base + (idxmap.AdetToDetOffset - src_base);
+        BdetToDetOffset = base + (idxmap.BdetToDetOffset - src_base);
+        AdetIndex = base + (idxmap.AdetIndex - src_base);
+        BdetIndex = base + (idxmap.BdetIndex - src_base);
+        AdetToBdetSM = base + (idxmap.AdetToBdetSM - src_base);
+        AdetToDetSM = base + (idxmap.AdetToDetSM - src_base);
+        BdetToAdetSM = base + (idxmap.BdetToAdetSM - src_base);
+        BdetToDetSM = base + (idxmap.BdetToDetSM - src_base);
+        size_adet = idxmap.size_adet;
+        size_bdet = idxmap.size_bdet;
+    }
+
+    inline __device__ __host__ int64_t adet_lower_bound(size_t jast, size_t jbst, size_t start = 0)
+    {
+        size_t is = AdetToDetOffset[jast] + start;
+        size_t ie = AdetToDetOffset[jast + 1];
+        size_t i = (is + ie) / 2;
+        while(is != ie) {
+            if( AdetToBdetSM[i] < jbst) {
+                is = i + 1;
+                i = (is + ie) / 2;
+            } else {
+                ie = i;
+                i = (is + ie) / 2;
+            }
+        }
+        if (ie == AdetToDetOffset[jast + 1]) {
+            // not found
+            return -1;
+        }
+        return i;
+    }
+
+    inline __device__ __host__ int64_t bdet_lower_bound(size_t jbst, size_t jast)
+    {
+        size_t is = BdetToDetOffset[jbst];
+        size_t ie = BdetToDetOffset[jbst + 1];
+        size_t i = (is + ie) / 2;
+        while(is != ie) {
+            if( BdetToAdetSM[i] < jast) {
+                is = i + 1;
+                i = (is + ie) / 2;
+            } else {
+                ie = i;
+                i = (is + ie) / 2;
+            }
+        }
+        if (ie == BdetToDetOffset[jbst + 1]) {
+            // not found
+            return -1;
+        }
+        return i;
+
+        /*
+        for(size_t i = BdetToDetOffset[jbst]; i < BdetToDetOffset[jbst + 1]; i++) {
+            if( BdetToAdetSM[i] >= jast) {
+                return (int64_t)i;
+            }
+        }
+        return -1;*/
+    }
+
+
+};
+
+/**
+       Labels connected
+*/
+class ExcitationLookupThrust
+{
+public:
+    int slide;
+    size_t* SelfFromAdetOffset;
+    size_t* SelfFromBdetOffset;
+    size_t* SinglesFromAdetOffset;
+    size_t* SinglesFromBdetOffset;
+    size_t* DoublesFromAdetOffset;
+    size_t* DoublesFromBdetOffset;
+    size_t* SelfFromAdetSM;
+    size_t* SelfFromBdetSM;
+    size_t* SinglesFromAdetSM;
+    int* SinglesAdetCrAnSM;
+    size_t* SinglesFromBdetSM;
+    int* SinglesBdetCrAnSM;
+    size_t* DoublesFromAdetSM;
+    int* DoublesAdetCrAnSM;
+    size_t* DoublesFromBdetSM;
+    int* DoublesBdetCrAnSM;
+    size_t size_self_adet = 0;
+    size_t size_self_bdet = 0;
+    size_t size_single_adet = 0;
+    size_t size_single_bdet = 0;
+    size_t size_double_adet = 0;
+    size_t size_double_bdet = 0;
+
+    ExcitationLookupThrust() {}
+
+    ExcitationLookupThrust(const ExcitationLookupThrust& other)
+    {
+        slide = other.slide;
+        SelfFromAdetOffset = other.SelfFromAdetOffset;
+        SelfFromBdetOffset = other.SelfFromBdetOffset;
+        SinglesFromAdetOffset = other.SinglesFromAdetOffset;
+        SinglesFromBdetOffset = other.SinglesFromBdetOffset;
+        DoublesFromAdetOffset = other.DoublesFromAdetOffset;
+        DoublesFromBdetOffset = other.DoublesFromBdetOffset;
+        SelfFromAdetSM = other.SelfFromAdetSM;
+        SelfFromBdetSM = other.SelfFromBdetSM;
+        SinglesFromAdetSM = other.SinglesFromAdetSM;
+        SinglesAdetCrAnSM = other.SinglesAdetCrAnSM;
+        SinglesFromBdetSM = other.SinglesFromBdetSM;
+        SinglesBdetCrAnSM = other.SinglesBdetCrAnSM;
+        DoublesFromAdetSM = other.DoublesFromAdetSM;
+        DoublesAdetCrAnSM = other.DoublesAdetCrAnSM;
+        DoublesFromBdetSM = other.DoublesFromBdetSM;
+        DoublesBdetCrAnSM = other.DoublesBdetCrAnSM;
+
+        size_self_adet = other.size_self_adet;
+        size_self_bdet = other.size_self_bdet;
+        size_single_adet = other.size_single_adet;
+        size_single_bdet = other.size_single_bdet;
+        size_double_adet = other.size_double_adet;
+        size_double_bdet = other.size_double_bdet;
+    }
+
+    ExcitationLookupThrust(thrust::device_vector<size_t>& storage, thrust::device_vector<int>& cran_storage, const ExcitationLookup& exidx)
+    {
+        size_t size = 0;
+
+        slide = exidx.slide;
+
+        std::vector<size_t> offset_self_adet(exidx.SelfFromAdetLen.size() + 1);
+        for(size_t i=0; i < exidx.SelfFromAdetLen.size(); i++) {
+            offset_self_adet[i] = size_self_adet;
+            size_self_adet += exidx.SelfFromAdetLen[i];
+            size++;
+        }
+        offset_self_adet[exidx.SelfFromAdetLen.size()] = size_self_adet;
+        size += size_self_adet + 1;
+
+        std::vector<size_t> offset_self_bdet(exidx.SelfFromBdetLen.size() + 1);
+        for(size_t i=0; i < exidx.SelfFromBdetLen.size(); i++) {
+            offset_self_bdet[i] = size_self_bdet;
+            size_self_bdet += exidx.SelfFromBdetLen[i];
+            size++;
+        }
+        offset_self_bdet[exidx.SelfFromBdetLen.size()] = size_self_bdet;
+        size += size_self_bdet + 1;
+
+        std::vector<size_t> offset_single_adet(exidx.SinglesFromAdetLen.size() + 1);
+        for(size_t i=0; i < exidx.SinglesFromAdetLen.size(); i++) {
+            offset_single_adet[i] = size_single_adet;
+            size_single_adet += exidx.SinglesFromAdetLen[i];
+            size++;
+        }
+        offset_single_adet[exidx.SinglesFromAdetLen.size()] = size_single_adet;
+        size += size_single_adet + 1;
+
+        std::vector<size_t> offset_double_adet(exidx.DoublesFromAdetLen.size() + 1);
+        for(size_t i=0; i < exidx.DoublesFromAdetLen.size(); i++) {
+            offset_double_adet[i] = size_double_adet;
+            size_double_adet += exidx.DoublesFromAdetLen[i];
+            size++;
+        }
+        offset_double_adet[exidx.DoublesFromAdetLen.size()] = size_double_adet;
+        size += size_double_adet + 1;
+
+        std::vector<size_t> offset_single_bdet(exidx.SinglesFromBdetLen.size() + 1);
+        for(size_t i=0; i < exidx.SinglesFromBdetLen.size(); i++) {
+            offset_single_bdet[i] = size_single_bdet;
+            size_single_bdet += exidx.SinglesFromBdetLen[i];
+            size++;
+        }
+        offset_single_bdet[exidx.SinglesFromBdetLen.size()] = size_single_bdet;
+        size += size_single_bdet + 1;
+
+        std::vector<size_t> offset_double_bdet(exidx.DoublesFromBdetLen.size() + 1);
+        for(size_t i=0; i < exidx.DoublesFromBdetLen.size(); i++) {
+            offset_double_bdet[i] = size_double_bdet;
+            size_double_bdet += exidx.DoublesFromBdetLen[i];
+            size++;
+        }
+        offset_double_bdet[exidx.DoublesFromBdetLen.size()] = size_double_bdet;
+        size += size_double_bdet + 1;
+
+        storage.resize(size);
+        size_t* base_memory = (size_t*)thrust::raw_pointer_cast(storage.data());
+
+        size_t count = 0;
+        // store offset
+        SelfFromAdetOffset = base_memory + count;
+        thrust::copy_n(offset_self_adet.begin(), offset_self_adet.size(), storage.begin() + count);
+        count += offset_self_adet.size();
+
+        SelfFromBdetOffset = base_memory + count;
+        thrust::copy_n(offset_self_bdet.begin(), offset_self_bdet.size(), storage.begin() + count);
+        count += offset_self_bdet.size();
+
+        SinglesFromAdetOffset = base_memory + count;
+        thrust::copy_n(offset_single_adet.begin(), offset_single_adet.size(), storage.begin() + count);
+        count += offset_single_adet.size();
+
+        DoublesFromAdetOffset = base_memory + count;
+        thrust::copy_n(offset_double_adet.begin(), offset_double_adet.size(), storage.begin() + count);
+        count += offset_double_adet.size();
+
+        SinglesFromBdetOffset = base_memory + count;
+        thrust::copy_n(offset_single_bdet.begin(), offset_single_bdet.size(), storage.begin() + count);
+        count += offset_single_bdet.size();
+
+        DoublesFromBdetOffset = base_memory + count;
+        thrust::copy_n(offset_double_bdet.begin(), offset_double_bdet.size(), storage.begin() + count);
+        count += offset_double_bdet.size();
+
+        // copy SMs
+        thrust::copy_n(exidx.storage.begin(), size - count, storage.begin() + count);
+        SelfFromAdetSM = base_memory + count;
+        count += size_self_adet;
+        SinglesFromAdetSM = base_memory + count;
+        count += size_single_adet;
+        DoublesFromAdetSM = base_memory + count;
+        count += size_double_adet;
+        SelfFromBdetSM = base_memory + count;
+        count += size_self_bdet;
+        SinglesFromBdetSM = base_memory + count;
+        count += size_single_bdet;
+        DoublesFromBdetSM = base_memory + count;
+
+        // convert CrAn from AoS to SoA
+        size_t size_cran = size_single_adet * 2 + size_double_adet * 4 + size_single_bdet * 2 + size_double_bdet * 4;
+        std::vector<int> buf;
+        count = 0;
+
+        cran_storage.resize(size_cran);
+        int* base_cran = (int*)thrust::raw_pointer_cast(cran_storage.data());
+
+        SinglesAdetCrAnSM = base_cran + count;
+        buf.resize(size_single_adet * 2);
+#pragma omp parallel for
+        for(size_t i=0; i < exidx.SinglesFromAdetLen.size(); i++) {
+            for (int j=0; j <  exidx.SinglesFromAdetLen[i]; j++) {
+                size_t offset = offset_single_adet[i] + j;
+                buf[offset] = exidx.SinglesAdetCrAnSM[i][j * 2];
+                buf[size_single_adet + offset] = exidx.SinglesAdetCrAnSM[i][j * 2 + 1];
+            }
+        }
+        thrust::copy_n(buf.begin(), size_single_adet * 2, cran_storage.begin() + count);
+        count += size_single_adet * 2;
+
+
+        DoublesAdetCrAnSM = base_cran + count;
+        buf.resize(size_double_adet * 4);
+#pragma omp parallel for
+        for(size_t i=0; i < exidx.DoublesFromAdetLen.size(); i++) {
+            for (int j=0; j <  exidx.DoublesFromAdetLen[i]; j++) {
+                size_t offset = offset_double_adet[i] + j;
+                buf[offset] = exidx.DoublesAdetCrAnSM[i][j * 4];
+                buf[size_double_adet + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 1];
+                buf[size_double_adet * 2 + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 2];
+                buf[size_double_adet * 3 + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 3];
+            }
+        }
+        thrust::copy_n(buf.begin(), size_double_adet * 4, cran_storage.begin() + count);
+        count += size_double_adet * 4;
+
+        SinglesBdetCrAnSM = base_cran + count;
+        buf.resize(size_single_bdet * 2);
+#pragma omp parallel for
+        for(size_t i=0; i < exidx.SinglesFromBdetLen.size(); i++) {
+            for (int j=0; j <  exidx.SinglesFromBdetLen[i]; j++) {
+                size_t offset = offset_single_bdet[i] + j;
+                buf[offset] = exidx.SinglesBdetCrAnSM[i][j * 2];
+                buf[size_single_bdet + offset] = exidx.SinglesBdetCrAnSM[i][j * 2 + 1];
+            }
+        }
+        thrust::copy_n(buf.begin(), size_single_bdet * 2, cran_storage.begin() + count);
+        count += size_single_bdet * 2;
+
+        DoublesBdetCrAnSM = base_cran + count;
+        buf.resize(size_double_bdet * 4);
+#pragma omp parallel for
+        for(size_t i=0; i < exidx.DoublesFromBdetLen.size(); i++) {
+            for (int j=0; j <  exidx.DoublesFromBdetLen[i]; j++) {
+                size_t offset = offset_double_bdet[i] + j;
+                buf[offset] = exidx.DoublesBdetCrAnSM[i][j * 4];
+                buf[size_double_bdet + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 1];
+                buf[size_double_bdet * 2 + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 2];
+                buf[size_double_bdet * 3 + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 3];
+            }
+        }
+        thrust::copy_n(buf.begin(), size_double_bdet * 4, cran_storage.begin() + count);
+        count += size_double_bdet * 4;
+    }
+
+
+};
+
+
+void MpiSlide(const DetIndexMapThrust& send_map,
+        const thrust::device_vector<size_t>& send_storage,
+        DetIndexMapThrust& recv_map,
+        thrust::device_vector<size_t>& recv_storage,
+        int slide,
+        MPI_Comm comm)
+{
+    std::vector<size_t> send_offset;
+    std::vector<size_t> recv_offset;
+
+    size_t* base = (size_t*)thrust::raw_pointer_cast(send_storage.data());
+    send_offset.push_back((size_t)(send_map.AdetToDetOffset - base));
+    send_offset.push_back((size_t)(send_map.BdetToDetOffset - base));
+    send_offset.push_back((size_t)(send_map.AdetIndex - base));
+    send_offset.push_back((size_t)(send_map.BdetIndex - base));
+    send_offset.push_back((size_t)(send_map.AdetToBdetSM - base));
+    send_offset.push_back((size_t)(send_map.AdetToDetSM - base));
+    send_offset.push_back((size_t)(send_map.BdetToAdetSM - base));
+    send_offset.push_back((size_t)(send_map.BdetToDetSM - base));
+    send_offset.push_back(send_map.size_adet);
+    send_offset.push_back(send_map.size_bdet);
+
+    sbd::MpiSlide(send_storage, recv_storage, slide, comm);
+    sbd::MpiSlide(send_offset, recv_offset, slide, comm);
+
+    base = (size_t*)thrust::raw_pointer_cast(recv_storage.data());
+    recv_map.AdetToDetOffset = base + recv_offset[0];
+    recv_map.BdetToDetOffset = base + recv_offset[1];
+    recv_map.AdetIndex = base + recv_offset[2];
+    recv_map.BdetIndex = base + recv_offset[3];
+    recv_map.AdetToBdetSM = base + recv_offset[4];
+    recv_map.AdetToDetSM = base + recv_offset[5];
+    recv_map.BdetToAdetSM = base + recv_offset[6];
+    recv_map.BdetToDetSM = base + recv_offset[7];
+    recv_map.size_adet = recv_offset[8];
+    recv_map.size_bdet = recv_offset[9];
+}
+
+
+
+template <typename ElemT>
+class MpiSlider {
+protected:
+    MPI_Request req_send;
+    MPI_Request req_recv;
+    MPI_Request req_send_map;
+    MPI_Request req_recv_map;
+    size_t send_size;
+    size_t recv_size;
+    size_t send_size_map;
+    size_t recv_size_map;
+public:
+    MpiSlider()
+    {
+        send_size = 0;
+        recv_size = 0;
+        send_size_map = 0;
+        recv_size_map = 0;
+    }
+
+    void ExchangeAsync(const thrust::device_vector<ElemT> &send,
+                thrust::device_vector<ElemT> &recv,
+                const DetIndexMapThrust& send_map,
+                const thrust::device_vector<size_t> &send_map_storage,
+                DetIndexMapThrust& recv_map,
+                thrust::device_vector<size_t> &recv_map_storage,
+                int slide,
+                MPI_Comm comm,
+                int id)
+    {
+        int mpi_rank;
+        MPI_Comm_rank(comm,&mpi_rank);
+        int mpi_size;
+        MPI_Comm_size(comm,&mpi_size);
+        int mpi_dest   = (mpi_size+mpi_rank+slide) % mpi_size;
+        int mpi_source = (mpi_size+mpi_rank-slide) % mpi_size;
+
+        // exchange data size to be sent
+        std::vector<MPI_Request> req_size(2);
+        std::vector<MPI_Status> sta_size(2);
+        std::vector<size_t> send_offset(12);
+        std::vector<size_t> recv_offset(12);
+        send_offset[0] = send.size();
+        send_offset[1] = send_map_storage.size();
+
+        // exchange idxmap offset
+        size_t* base = (size_t*)thrust::raw_pointer_cast(send_map_storage.data());
+        send_offset[2] = (size_t)(send_map.AdetToDetOffset - base);
+        send_offset[3] = (size_t)(send_map.BdetToDetOffset - base);
+        send_offset[4] = (size_t)(send_map.AdetIndex - base);
+        send_offset[5] = (size_t)(send_map.BdetIndex - base);
+        send_offset[6] = (size_t)(send_map.AdetToBdetSM - base);
+        send_offset[7] = (size_t)(send_map.AdetToDetSM - base);
+        send_offset[8] = (size_t)(send_map.BdetToAdetSM - base);
+        send_offset[9] = (size_t)(send_map.BdetToDetSM - base);
+        send_offset[10] = send_map.size_adet;
+        send_offset[11] = send_map.size_bdet;
+
+        MPI_Isend(send_offset.data(),12,SBD_MPI_SIZE_T,mpi_dest,id*4,comm,&req_size[0]);
+        MPI_Irecv(recv_offset.data(),12,SBD_MPI_SIZE_T,mpi_source,id*4,comm,&req_size[1]);
+        MPI_Waitall(2,req_size.data(),sta_size.data());
+
+        send_size = send_offset[0];
+        recv_size = recv_offset[0];
+        send_size_map = send_offset[1];
+        recv_size_map = recv_offset[1];
+
+        // exchange async
+        MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+        if( send_size != 0 ) {
+            MPI_Isend((ElemT*)thrust::raw_pointer_cast(send.data()),send_size,DataT,mpi_dest,id*4+2,comm,&req_send);
+        }
+        if( recv_size != 0 ) {
+            recv.resize(recv_size);
+            MPI_Irecv((ElemT*)thrust::raw_pointer_cast(recv.data()),recv_size,DataT,mpi_source,id*4+2,comm,&req_recv);
+        } else {
+            recv = send;
+        }
+
+        if( send_size_map != 0 ) {
+            MPI_Isend((size_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,SBD_MPI_SIZE_T,mpi_dest,id*4+3,comm,&req_send_map);
+        }
+        if( recv_size_map != 0 ) {
+            recv_map_storage.resize(recv_size_map);
+            MPI_Irecv((size_t*)thrust::raw_pointer_cast(recv_map_storage.data()),recv_size_map,SBD_MPI_SIZE_T,mpi_source,id*4+3,comm,&req_recv_map);
+
+        } else {
+            recv_map_storage = send_map_storage;
+            recv_offset = send_offset;
+        }
+        base = (size_t*)thrust::raw_pointer_cast(recv_map_storage.data());
+        recv_map.AdetToDetOffset = base + recv_offset[2];
+        recv_map.BdetToDetOffset = base + recv_offset[3];
+        recv_map.AdetIndex = base + recv_offset[4];
+        recv_map.BdetIndex = base + recv_offset[5];
+        recv_map.AdetToBdetSM = base + recv_offset[6];
+        recv_map.AdetToDetSM = base + recv_offset[7];
+        recv_map.BdetToAdetSM = base + recv_offset[8];
+        recv_map.BdetToDetSM = base + recv_offset[9];
+        recv_map.size_adet = recv_offset[10];
+        recv_map.size_bdet = recv_offset[11];
+    }
+
+    bool Sync(void)
+    {
+        bool recv = false;
+        if (send_size > 0) {
+            MPI_Status st;
+
+            MPI_Wait(&req_send, &st);
+        }
+        if (recv_size > 0) {
+            MPI_Status st;
+
+            MPI_Wait(&req_recv, &st);
+            recv = true;
+        }
+        if (send_size_map > 0) {
+            MPI_Status st;
+
+            MPI_Wait(&req_send_map, &st);
+        }
+        if (recv_size_map > 0) {
+            MPI_Status st;
+
+            MPI_Wait(&req_recv_map, &st);
+            recv = true;
+        }
+
+        send_size = 0;
+        recv_size = 0;
+        send_size_map = 0;
+        recv_size_map = 0;
+        return recv;
+    }
+};
+
+
+
+
+} // end namespace gdb
+
+} // end namespace sbd
+
+#endif

--- a/include/sbd/chemistry/gdb/inc_all.h
+++ b/include/sbd/chemistry/gdb/inc_all.h
@@ -5,6 +5,7 @@
 #ifdef SBD_THRUST
 #include "sbd/chemistry/gdb/helper_thrust.h"
 #include "sbd/chemistry/gdb/mult_thrust.h"
+#include "sbd/chemistry/gdb/correlation_thrust.h"
 #else
 #include "sbd/chemistry/gdb/mult.h"
 #endif

--- a/include/sbd/chemistry/gdb/inc_all.h
+++ b/include/sbd/chemistry/gdb/inc_all.h
@@ -2,9 +2,18 @@
 #define SBD_CHEMISTRY_GDB_INC_ALL_H
 
 #include "sbd/chemistry/gdb/helper.h"
+#ifdef SBD_THRUST
+#include "sbd/chemistry/gdb/helper_thrust.h"
+#include "sbd/chemistry/gdb/mult_thrust.h"
+#else
 #include "sbd/chemistry/gdb/mult.h"
+#endif
 #include "sbd/chemistry/gdb/qcham.h"
+#ifdef SBD_THRUST
+#include "sbd/chemistry/gdb/davidson_thrust.h"
+#else
 #include "sbd/chemistry/gdb/davidson.h"
+#endif
 #include "sbd/chemistry/gdb/occupation.h"
 #include "sbd/chemistry/gdb/correlation.h"
 #include "sbd/chemistry/gdb/restart.h"

--- a/include/sbd/chemistry/gdb/mult.h
+++ b/include/sbd/chemistry/gdb/mult.h
@@ -24,7 +24,7 @@ namespace sbd {
 	      MPI_Comm h_comm,
 	      MPI_Comm b_comm,
 	      MPI_Comm t_comm) {
-      
+
       int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
       int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
       int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
@@ -164,7 +164,7 @@ namespace sbd {
 
 	      if( exidx[task].SelfFromAdetLen[iast] != 0 ) {
 		size_t jast = exidx[task].SelfFromAdetSM[iast][0];
-		
+
 		// single beta excitations
 		for(size_t jb=0; jb < exidx[task].SinglesFromBdetLen[ibst]; jb++) {
 		  size_t jbst = exidx[task].SinglesFromBdetSM[ibst][jb];
@@ -219,7 +219,7 @@ namespace sbd {
 		    wb[idet] += eij * twk[jdet];
 		  }
 		}
-		
+
 	      } // if there are same alpha
 
 	    } // corresponding beta string loop for bra-side basis
@@ -238,12 +238,12 @@ namespace sbd {
 	  // std::swap(rdet,tdet);
 	  // sbd::MpiSlide(rdet,tdet,slide,b_comm);
 	}
-	
+
       } // end task for loop
 
       MpiAllreduce(wb,MPI_SUM,t_comm);
       MpiAllreduce(wb,MPI_SUM,h_comm);
-      
+
     } // end function for mult
 
     template <typename ElemT>
@@ -302,9 +302,9 @@ namespace sbd {
       sbd::MpiAllreduce(wb,MPI_SUM,t_comm);
       sbd::MpiAllreduce(wb,MPI_SUM,h_comm);
     }
-    
+
   } // end namespace gdb
-  
+
 } // end namespace sbd
 
 #endif

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -1,0 +1,595 @@
+/**
+@file sbd/chemistry/tpb/mult.h
+@brief Function to perform Hamiltonian operation for general determinant basis
+*/
+#ifndef SBD_CHEMISTRY_GDB_MULT_THRUST_H
+#define SBD_CHEMISTRY_GDB_MULT_THRUST_H
+
+
+#include "sbd/framework/mpi_utility_thrust.h"
+
+namespace sbd
+{
+namespace gdb
+{
+
+template <typename ElemT>
+class MultGDBThrust : public sbd::MultBase<ElemT> {
+protected:
+	thrust::device_vector<size_t> idxmap_storage;
+	DetIndexMapThrust idxmap;
+    thrust::device_vector<size_t> dets_;
+    ElemT I0_;
+    oneInt_Thrust<ElemT> I1_;
+    thrust::device_vector<ElemT> I1_store;
+    twoInt_Thrust<ElemT> I2_;
+    thrust::device_vector<ElemT> I2_store;
+    thrust::device_vector<ElemT> I2_dm;
+    thrust::device_vector<ElemT> I2_em;
+
+	std::vector<thrust::device_vector<size_t>> exidx_storage;
+    std::vector<thrust::device_vector<int>> CrAn_storage;
+	std::vector<ExcitationLookupThrust> exidx;
+public:
+
+	MultGDBThrust() {}
+
+	const ElemT& I0(void) const
+	{
+		return I0_;
+	}
+	const oneInt_Thrust<ElemT>& I1(void) const
+	{
+		return I1_;
+	}
+	const twoInt_Thrust<ElemT>& I2(void) const
+	{
+		return I2_;
+	}
+	const thrust::device_vector<size_t>& dets(void) const
+	{
+		return dets_;
+	}
+
+	void Init(
+        const size_t bit_length_in,
+        const size_t norbs_in,
+		const std::vector<std::vector<size_t>> &dets_in,
+		const DetIndexMap &idxmap_in,
+		const std::vector<ExcitationLookup>& exidx_in,
+		const ElemT &I0_in,
+        const oneInt<ElemT> &I1_in,
+        const twoInt<ElemT> &I2_in,
+		MPI_Comm h_comm,
+		MPI_Comm b_comm,
+		MPI_Comm t_comm);
+
+    void run(const thrust::device_vector<ElemT> &hii,
+                    const thrust::device_vector<ElemT> &Wk,
+                    thrust::device_vector<ElemT> &Wb) override;
+};
+
+// contructor for Mult data
+template <typename ElemT>
+void MultGDBThrust<ElemT>::Init(
+	    const size_t bit_length_in,
+        const size_t norbs_in,
+		const std::vector<std::vector<size_t>> &dets_in,
+		const DetIndexMap &idxmap_in,
+		const std::vector<ExcitationLookup>& exidx_in,
+		const ElemT &I0_in,
+        const oneInt<ElemT> &I1_in,
+        const twoInt<ElemT> &I2_in,
+		MPI_Comm h_comm_in,
+		MPI_Comm b_comm_in,
+		MPI_Comm t_comm_in)
+{
+    this->bit_length_ = bit_length_in;
+    this->norbs_ = norbs_in;
+    this->D_size_ = (2 * norbs_in + bit_length_in - 1) / bit_length_in;
+
+    this->h_comm_ = h_comm_in;
+    this->b_comm_ = b_comm_in;
+    this->t_comm_ = t_comm_in;
+
+    I0_ = I0_in;
+    // copyin I1
+    I1_store.resize(I1_in.store.size());
+    thrust::copy_n(I1_in.store.begin(), I1_in.store.size(), I1_store.begin());
+    I1_ = oneInt_Thrust<ElemT>(I1_store, I1_in.norbs);
+
+    // copyin I2
+    I2_store.resize(I2_in.store.size());
+    thrust::copy_n(I2_in.store.begin(), I2_in.store.size(), I2_store.begin());
+    I2_dm.resize(I2_in.DirectMat.size());
+    thrust::copy_n(I2_in.DirectMat.begin(), I2_in.DirectMat.size(), I2_dm.begin());
+    I2_em.resize(I2_in.ExchangeMat.size());
+    thrust::copy_n(I2_in.ExchangeMat.begin(), I2_in.ExchangeMat.size(), I2_em.begin());
+    I2_ = twoInt_Thrust<ElemT>(I2_store, I2_in.norbs, I2_dm, I2_em, I2_in.zero, I2_in.maxEntry);
+
+    // copyin exidx
+    exidx.clear();
+    exidx_storage.resize(exidx_in.size());
+    CrAn_storage.resize(exidx_in.size());
+    for (size_t task = 0; task < exidx_in.size(); task++) {
+        exidx.push_back(ExcitationLookupThrust(exidx_storage[task], CrAn_storage[task], exidx_in[task]));
+    }
+
+    // copyin dets
+    dets_.resize(this->D_size_ * dets_in.size());
+    for (int i = 0; i < dets_in.size(); i++) {
+        thrust::copy_n(dets_in[i].begin(), this->D_size_, dets_.begin() + i * this->D_size_);
+    }
+
+	// copy indexmap
+	idxmap = DetIndexMapThrust(idxmap_storage, idxmap_in);
+}
+
+template <typename ElemT>
+class MultKernelBase : public DeterminantKernels<ElemT> {
+protected:
+    ElemT *wb;
+    ElemT* twk;
+    size_t mpi_rank_h;
+    size_t mpi_size_h;
+    size_t* det;
+public:
+    MultKernelBase() {}
+
+    MultKernelBase( const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data
+                ) : DeterminantKernels<ElemT>(data.bit_length(), data.norbs(), data.I0(), data.I1(), data.I2())
+    {
+        wb = (ElemT*)thrust::raw_pointer_cast(v_wb.data());
+        twk = (ElemT*)thrust::raw_pointer_cast(v_t.data());
+        det = (size_t*)thrust::raw_pointer_cast(data.dets().data());
+    }
+
+    MultKernelBase(const MultGDBThrust<ElemT>& data)
+                 : DeterminantKernels<ElemT>(data.bit_length(), data.norbs(), data.I0(), data.I1(), data.I2())
+    {
+        det = (size_t*)thrust::raw_pointer_cast(data.dets().data());
+    }
+
+    void set_mpi_size(size_t h_rank, size_t h_size)
+    {
+        mpi_rank_h = h_rank;
+        mpi_size_h = h_size;
+    }
+};
+
+
+template <typename ElemT>
+class MultSingleAlphaKernel : public MultKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	MultSingleAlphaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t ibst = idxmap.AdetToBdetSM[i];
+		size_t idet = idxmap.AdetToDetSM[i];
+		size_t ia = idxmap.AdetIndex[i];
+		size_t iast = ia;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
+			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			// single alpha excitations
+			for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+				size_t jast = exidx.SinglesFromAdetSM[ja];
+				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
+				if (idxa >= 0) {
+					if (jast != tidxmap.BdetToAdetSM[idxa])
+						continue;
+					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
+											exidx.SinglesAdetCrAnSM[ja],
+											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet]);
+					this->wb[idet] += eij * this->twk[jdet];
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+template <typename ElemT>
+class MultDoubleAlphaKernel : public MultKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	MultDoubleAlphaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t ibst = idxmap.AdetToBdetSM[i];
+		size_t idet = idxmap.AdetToDetSM[i];
+		size_t ia = idxmap.AdetIndex[i];
+		size_t iast = ia;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
+			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			// double alpha excitations
+			for (size_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
+				size_t jast = exidx.DoublesFromAdetSM[ja];
+				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
+				if (idxa >= 0) {
+					if (jast != tidxmap.BdetToAdetSM[idxa])
+						continue;
+					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+											exidx.DoublesAdetCrAnSM[ja],
+											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet],
+											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 2],
+											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 3]);
+					// size_t od;
+					this->wb[idet] += eij * this->twk[jdet];
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+
+
+
+template <typename ElemT>
+class MultSingleBetaKernel : public MultKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	MultSingleBetaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t iast = idxmap.BdetToAdetSM[i];
+		size_t idet = idxmap.BdetToDetSM[i];
+		size_t ib = idxmap.BdetIndex[i];
+		size_t ibst = ib;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
+			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			// single alpha excitations
+			for (size_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
+				size_t jbst = exidx.SinglesFromBdetSM[jb];
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
+											exidx.SinglesBdetCrAnSM[jb],
+											exidx.SinglesBdetCrAnSM[jb + exidx.size_single_bdet]);
+					this->wb[idet] += eij * this->twk[jdet];
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+template <typename ElemT>
+class MultDoubleBetaKernel : public MultKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	MultDoubleBetaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t iast = idxmap.BdetToAdetSM[i];
+		size_t idet = idxmap.BdetToDetSM[i];
+		size_t ib = idxmap.BdetIndex[i];
+		size_t ibst = ib;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
+			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			// double alpha excitations
+			for (size_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
+				size_t jbst = exidx.DoublesFromBdetSM[jb];
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+											exidx.DoublesBdetCrAnSM[jb],
+											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet],
+											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 2],
+											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 3]);
+					// size_t od;
+					this->wb[idet] += eij * this->twk[jdet];
+				}
+			}
+		} // if there is same beta string
+	}
+};
+
+
+template <typename ElemT>
+class MultAlphaBetaKernel : public MultKernelBase<ElemT>
+{
+protected:
+	DetIndexMapThrust idxmap;
+	DetIndexMapThrust tidxmap;
+	ExcitationLookupThrust exidx;
+public:
+	MultAlphaBetaKernel (const thrust::device_vector<ElemT>& v_wb,
+                const thrust::device_vector<ElemT>& v_t,
+                const MultGDBThrust<ElemT>& data,
+				const DetIndexMapThrust& idxmap_in,
+				const DetIndexMapThrust& tidxmap_in,
+				const ExcitationLookupThrust& exidx_in)
+		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
+
+    // kernel entry point
+    __device__ __host__ void operator()(size_t i)
+    {
+		size_t ibst = idxmap.AdetToBdetSM[i];
+		size_t idet = idxmap.AdetToDetSM[i];
+		size_t ia = idxmap.AdetIndex[i];
+		size_t iast = ia;
+		if (idet % this->mpi_size_h != this->mpi_rank_h)
+			return;
+
+		// alpha-beta two-particle excitations
+		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+			size_t jast = exidx.SinglesFromAdetSM[ja];
+			size_t start_idx = 0;
+			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
+			for (size_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
+				size_t jbst = exidx.SinglesFromBdetSM[k];
+				if (start_idx >= end_idx)
+					break;
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					start_idx = idxb - tidxmap.AdetToDetOffset[jast];
+					if (start_idx < end_idx) {
+						size_t jdet = tidxmap.AdetToDetSM[idxb];
+						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+												exidx.SinglesAdetCrAnSM[ja],
+												exidx.SinglesBdetCrAnSM[k],
+												exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
+												exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
+						// size_t odiff;
+						// ElemT eij = Hij(det[idet],tdet[jdet],bit_length,norb,I0,I1,I2,odiff);
+						this->wb[idet] += eij * this->twk[jdet];
+					}
+				}
+			}
+		}
+	}
+};
+
+
+template <typename ElemT>
+class Wb_init_kernel {
+protected:
+    ElemT* Wb;
+    ElemT* hii;
+    ElemT* T;
+public:
+    Wb_init_kernel(thrust::device_vector<ElemT>& Wb_in, const thrust::device_vector<ElemT>& hii_in, const thrust::device_vector<ElemT>& T_in)
+    {
+        Wb = (ElemT*)thrust::raw_pointer_cast(Wb_in.data());
+        hii = (ElemT*)thrust::raw_pointer_cast(hii_in.data());
+        T = (ElemT*)thrust::raw_pointer_cast(T_in.data());
+    }
+    __host__ __device__ void operator()(size_t i)
+    {
+        Wb[i] += hii[i] * T[i];
+    }
+};
+
+template <typename ElemT>
+void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
+								const thrust::device_vector<ElemT> &wk,
+								thrust::device_vector<ElemT> &wb)
+{
+	int mpi_size_h;
+	MPI_Comm_size(this->h_comm(), &mpi_size_h);
+	int mpi_rank_h;
+	MPI_Comm_rank(this->h_comm(), &mpi_rank_h);
+	int mpi_size_b;
+	MPI_Comm_size(this->b_comm(), &mpi_size_b);
+	int mpi_rank_b;
+	MPI_Comm_rank(this->b_comm(), &mpi_rank_b);
+	int mpi_size_t;
+	MPI_Comm_size(this->t_comm(), &mpi_size_t);
+	int mpi_rank_t;
+	MPI_Comm_rank(this->t_comm(), &mpi_rank_t);
+
+	// double buffering for MPI slide
+	thrust::device_vector<ElemT> twk[2];
+	thrust::device_vector<size_t> tidxmap_storage[2];
+	DetIndexMapThrust tidxmap[2];
+	int active_buf = 0;
+    int recv_buf = 1;
+    size_t task_sent = 0;
+
+	if (exidx[0].slide != 0) {
+		sbd::gdb::MpiSlide(idxmap, idxmap_storage, tidxmap[active_buf], tidxmap_storage[active_buf], -exidx[0].slide, this->b_comm());
+		sbd::MpiSlide(wk, twk[active_buf], -exidx[0].slide, this->b_comm());
+	} else {
+		tidxmap[active_buf].copy(tidxmap_storage[active_buf], idxmap, idxmap_storage);
+		twk[active_buf] = wk;
+	}
+
+	if (mpi_rank_t == 0) {
+        auto ci = thrust::counting_iterator<size_t>(0);
+        thrust::for_each_n(thrust::device, ci, twk[active_buf].size(), Wb_init_kernel(wb, hii, twk[active_buf]));
+	}
+
+	MpiSlider<ElemT> slider;
+	for (size_t task = 0; task < exidx.size(); task++) {
+        if (task_sent == task) {
+            if (task_sent != 0) {
+                if (slider.Sync()) {
+					int t = active_buf;
+					active_buf = recv_buf;
+					recv_buf = t;
+                }
+            }
+
+            // exchange asynchronously for later tasks
+            for (size_t extask = task_sent; extask < exidx.size() - 1; extask++) {
+				int slide = exidx[extask].slide - exidx[extask + 1].slide;
+				slider.ExchangeAsync(twk[active_buf], twk[recv_buf], tidxmap[active_buf], tidxmap_storage[active_buf], tidxmap[recv_buf], tidxmap_storage[recv_buf], slide, this->b_comm(), (int)extask);
+				task_sent = extask + 1;
+				break;
+            }
+        }
+
+		// single alpha excitations
+		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_sa = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_sa, idxmap.size_adet, kernel_single_alpha);
+
+		// double alpha excitations
+		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_da = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_da, idxmap.size_adet, kernel_double_alpha);
+
+		// single beta excitations
+		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_sb = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_sb, idxmap.size_bdet, kernel_single_beta);
+
+		// double beta excitations
+		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_db = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_db, idxmap.size_bdet, kernel_double_beta);
+
+		// alpha-beta excitations
+		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+		auto ci_ab = thrust::counting_iterator<size_t>(0);
+		thrust::for_each_n(thrust::device, ci_ab, idxmap.size_adet, kernel_alpha_beta);
+	} // end task for loop
+
+	if (mpi_size_t > 1)
+		MpiAllreduce(wb, MPI_SUM, this->t_comm());
+	if (mpi_size_h > 1)
+		MpiAllreduce(wb, MPI_SUM, this->h_comm());
+}
+
+
+
+template <typename ElemT>
+void mult(const std::vector<ElemT> &hii,
+			const std::vector<ElemT> &wk,
+			std::vector<ElemT> &wb,
+			size_t bit_length,
+			size_t norb,
+			const std::vector<std::vector<size_t>> &det,
+			const DetIndexMap &idxmap,
+			const std::vector<ExcitationLookup> &exidx,
+			const ElemT &I0,
+			const oneInt<ElemT> &I1,
+			const twoInt<ElemT> &I2,
+			MPI_Comm h_comm,
+			MPI_Comm b_comm,
+			MPI_Comm t_comm)
+{
+	////  temporal implementation until Davidson for GPU is not ready
+	MultGDBThrust<ElemT> data;
+	data.Init(bit_length, norb, det, idxmap, exidx, I0, I1, I2, h_comm, b_comm, t_comm);
+
+	thrust::device_vector<ElemT> wb_dev(wb.size());
+	thrust::device_vector<ElemT> wk_dev(wk.size());
+	thrust::device_vector<ElemT> hii_dev(hii.size());
+
+	thrust::copy_n(wb.begin(), wb.size(), wb_dev.begin());
+	thrust::copy_n(wk.begin(), wk.size(), wk_dev.begin());
+	thrust::copy_n(hii.begin(), hii.size(), hii_dev.begin());
+
+	data.run(hii_dev, wk_dev, wb_dev);
+
+	thrust::copy_n(wb_dev.begin(), wb.size(), wb.begin());
+	////
+
+} // end function for mult
+
+
+
+template <typename ElemT>
+void mult(const std::vector<ElemT> & hii,
+		const std::vector<std::vector<size_t*>> & ih,
+		const std::vector<std::vector<size_t*>> & jh,
+		const std::vector<std::vector<ElemT*>> & hij,
+		const std::vector<std::vector<size_t>> & len,
+		const std::vector<int> & slide,
+		const std::vector<ElemT> & wk,
+		std::vector<ElemT> & wb,
+		MPI_Comm h_comm,
+		MPI_Comm b_comm,
+		MPI_Comm t_comm)
+{
+	//this is not used for Thrust
+}
+
+
+} // end namespace gdb
+
+} // end namespace sbd
+
+#endif

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -67,6 +67,11 @@ public:
     void run(const thrust::device_vector<ElemT> &hii,
                     const thrust::device_vector<ElemT> &Wk,
                     thrust::device_vector<ElemT> &Wb) override;
+
+
+	void correlation(const std::vector<ElemT> & w,
+				std::vector<std::vector<ElemT>> & onebody_out,
+				std::vector<std::vector<ElemT>> & twobody_out);
 };
 
 // contructor for Mult data

--- a/include/sbd/chemistry/gdb/sbdiag.h
+++ b/include/sbd/chemistry/gdb/sbdiag.h
@@ -452,9 +452,13 @@ namespace sbd {
 		    << " sbd: start rdm calculation" << std::endl;
 	}
 	auto time_start_rdm = std::chrono::high_resolution_clock::now();
+#ifdef SBD_THRUST
+	device_mult.correlation(w,one_p_rdm,two_p_rdm);
+#else
 	Correlation(w,det,bit_length,static_cast<size_t>(L),
 		    idxmap,exidx,h_comm,b_comm,t_comm,
 		    one_p_rdm,two_p_rdm);
+#endif
 	density.resize(2*L);
 	for(size_t io=0; io < L; io++) {
 	  density[2*io+0] = GetReal(one_p_rdm[0][io+L*io]);

--- a/include/sbd/chemistry/gdb/sbdiag.h
+++ b/include/sbd/chemistry/gdb/sbdiag.h
@@ -18,6 +18,7 @@ namespace sbd {
       int max_it = 1;
       int max_nb = 10;
       double eps = 1.0e-4;
+      double max_time = 86400.0;
       int init = 0;
       int do_shuffle = 0;
       int do_rdm = 0;
@@ -136,9 +137,13 @@ namespace sbd {
       int L;
       int N;
       int method = sbd_data.method;
-      int max_it = sbd_data.max_it;
+#ifdef SBD_THRUST
+	  method &= 1;
+#endif
+	  int max_it = sbd_data.max_it;
       int max_nb = sbd_data.max_nb;
       double eps = sbd_data.eps;
+      double max_time = sbd_data.max_time;
       int init = sbd_data.init;
       int do_shuffle = sbd_data.do_shuffle;
       int do_rdm = sbd_data.do_rdm;
@@ -148,7 +153,7 @@ namespace sbd {
       /**
 	 Setup system parameters from fcidump
       */
-      if( mpi_rank == 0 ) {
+	  if( mpi_rank == 0 ) {
 	std::cout << " " << make_timestamp()
 		  << " sbd: start integral construction" << std::endl;
       }
@@ -221,6 +226,10 @@ namespace sbd {
       /**
 	 Diagonalization
       */
+#ifdef SBD_THRUST
+	// multiplyer class for TPB on Thrust
+	MultGDBThrust<double> device_mult;
+#endif
       if( method == 0 ) {
 
 	if( mpi_rank == 0 ) {
@@ -250,11 +259,19 @@ namespace sbd {
 		    << " sbd: start davidson" << std::endl;
 	}
 	auto time_start_david = std::chrono::high_resolution_clock::now();
+#ifdef SBD_THRUST
+	device_mult.Init(bit_length,static_cast<size_t>(L),det,
+					idxmap,exidx,I0,I1,I2,
+		 			h_comm,b_comm,t_comm);
+	sbd::Davidson(hii, w, device_mult,
+			max_it,max_nb,eps,max_time);
+#else
 	Davidson(hii,w,det,bit_length,static_cast<size_t>(L),
 		 idxmap,exidx,I0,I1,I2,
 		 h_comm,b_comm,t_comm,
 		 max_it,max_nb,eps);
-	auto time_end_david = std::chrono::high_resolution_clock::now();
+#endif
+    auto time_end_david = std::chrono::high_resolution_clock::now();
 	auto elapsed_david_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_david-time_start_david).count();
 	auto elapsed_diag_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_david-time_start_mkham).count();
 	double elapsed_david = 1.0e-6 * elapsed_david_count;
@@ -275,6 +292,22 @@ namespace sbd {
 		    << " sbd: start Hamiltonian expectation value" << std::endl;
 	}
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
+#ifdef SBD_THRUST
+	// copyin hii
+    thrust::device_vector<double> hii_dev(hii.size());
+    thrust::copy_n(hii.begin(), hii.size(), hii_dev.begin());
+
+    // copyin W
+    thrust::device_vector<double> w_dev(w.size());
+    thrust::copy_n(w.begin(), w.size(), w_dev.begin());
+
+    thrust::device_vector<double> v(w.size(), 0.0);
+
+	device_mult.run(hii_dev, w_dev, v);
+
+	ElemT E;
+	InnerProduct(w_dev,v,E,b_comm);
+#else
 	std::vector<ElemT> v(w.size(),ElemT(0.0));
 	mult(hii,w,v,bit_length,static_cast<size_t>(L),det,
 	     idxmap,exidx,I0,I1,I2,
@@ -282,6 +315,7 @@ namespace sbd {
 	ElemT E;
 	InnerProduct(w,v,E,b_comm);
 	energy = GetReal(E);
+#endif
 	auto time_end_mult = std::chrono::high_resolution_clock::now();
 	auto elapsed_mult_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mult-time_start_mult).count();
 	double elapsed_mult = 1.0e-6 * elapsed_mult_count;
@@ -301,7 +335,7 @@ namespace sbd {
 		    << " sbd: start diagonalization" << std::endl;
 	  std::cout << " " << make_timestamp()
 		    << " sbd: start make Hamiltonian" << std::endl;
-	  
+
 	}
 	auto time_start_mkham = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> hii;
@@ -587,7 +621,7 @@ namespace sbd {
       diag(comm,sbd_data,fcidump,det,loadname,savename,
 	   energy,density,rdet,one_p_rdm,two_p_rdm);
     }
-    
+
   } // end namespace gdb
 } // end namespace sbd
 

--- a/include/sbd/chemistry/tpb/correlation_thrust.h
+++ b/include/sbd/chemistry/tpb/correlation_thrust.h
@@ -11,10 +11,7 @@ namespace sbd
 template <typename ElemT>
 class CorrelationKernelBase : public MultKernelBase<ElemT> {
 protected:
-    ElemT* onebody;
-    ElemT* twobody;
-    size_t onebody_size;
-    size_t twobody_size;
+    CorrelationKernels<ElemT> correlation;
 public:
     CorrelationKernelBase() {}
 
@@ -22,117 +19,12 @@ public:
                         const thrust::device_vector<ElemT>& v_wb,
                         const thrust::device_vector<ElemT>& v_t,
                         thrust::device_vector<ElemT>& b1,
-                        thrust::device_vector<ElemT>& b2) : MultKernelBase<ElemT>(v_wb, v_t, data)
+                        thrust::device_vector<ElemT>& b2)
+                         : MultKernelBase<ElemT>(v_wb, v_t, data),
+                           correlation(data.bit_length(), data.norbs(),  data.I0, data.I1, data.I2, b1, b2)
     {
-        onebody = (ElemT*)thrust::raw_pointer_cast(b1.data());
-        twobody = (ElemT*)thrust::raw_pointer_cast(b2.data());
-        onebody_size = this->norbs * this->norbs;
-        twobody_size = this->norbs * this->norbs * this->norbs * this->norbs;
     }
 
-    /**
-         Function for adding diagonal contribution
-    */
-    __device__ __host__ void ZeroDiffCorrelation(const size_t* det, ElemT WeightI)
-    {
-        for (int i = 0; i < 2 * this->norbs; i++) {
-            if (this->getocc(det, i)) {
-                int oi = i / 2;
-                int si = i % 2;
-                atomicAdd(onebody + si * onebody_size + oi + this->norbs * oi, Conjugate(WeightI) * WeightI);
-                for (int j = i + 1; j < 2 * this->norbs; j++) {
-                    if (this->getocc(det, j)) {
-                        int oj = j / 2;
-                        int sj = j % 2;
-                        atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), Conjugate(WeightI) * WeightI);
-                        atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), Conjugate(WeightI) * WeightI);
-                        if (si == sj) {
-                            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), -Conjugate(WeightI) * WeightI);
-                            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), -Conjugate(WeightI) * WeightI);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-        Function for adding one-occupation different contribution
-    */
-    __device__ __host__ void OneDiffCorrelation(const size_t* det,
-                            const ElemT WeightI,
-                            const ElemT WeightJ,
-                            int i,
-                            int a)
-    {
-        double sgn = 1.0;
-        this->parity(det, std::min(i, a), std::max(i, a), sgn);
-        int oi = i / 2;
-        int si = i % 2;
-        int oa = a / 2;
-        int sa = a % 2;
-        atomicAdd(onebody + si * onebody_size + (oi + this->norbs * oa), Conjugate(WeightI) * WeightJ * ElemT(sgn));
-        size_t one = 1;
-        for (int x = 0; x < this->D_size; x++) {
-            size_t bits = det[x];
-            for (int pos = 0; pos < this->bit_length; pos++) {
-                if ((bits & 1ULL) == 1ULL) {
-                    int soj = x * this->bit_length + pos;
-                    int oj = soj / 2;
-                    int sj = soj % 2;
-
-                    atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
-                    atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
-
-                    if (si == sj) {
-                        atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
-                        atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
-                    }
-                }
-                bits >>= 1;
-            }
-        }
-    }
-
-    /**
-        Function for adding two-occupation different contribution
-    */
-    __device__ __host__ void TwoDiffCorrelation(const size_t* det,
-                            const ElemT WeightI,
-                            const ElemT WeightJ,
-                            int i,
-                            int j,
-                            int a,
-                            int b)
-    {
-        double sgn = 1.0;
-        int I = std::min(i, j);
-        int J = std::max(i, j);
-        int A = std::min(a, b);
-        int B = std::max(a, b);
-        this->parity(det, std::min(I, A), std::max(I, A), sgn);
-        this->parity(det, std::min(J, B), std::max(J, B), sgn);
-        if (A > J || B < I)
-            sgn *= -1.0;
-        int oi = I / 2;
-        int si = I % 2;
-        int oa = A / 2;
-        int sa = A % 2;
-        int oj = J / 2;
-        int sj = J % 2;
-        int ob = B / 2;
-        int sb = B % 2;
-
-        if (si == sa) {
-            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
-            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
-        }
-
-        if (si == sb) {
-            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
-            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
-        }
-    }
 };
 
 template <typename ElemT>
@@ -163,7 +55,7 @@ public:
         if (i + offset < braAlphaSize * braBetaSize) {
             if( ((i + offset) % this->mpi_size_h) == this->mpi_rank_h ) {
                 size_t* DetI = this->det_I + (i + offset) * this->D_size;
-                this->ZeroDiffCorrelation(DetI, this->Wb[i + offset]);
+                this->correlation.ZeroDiffCorrelation(DetI, this->Wb[i + offset]);
             }
         }
     }
@@ -201,7 +93,7 @@ public:
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
             this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
-            this->ZeroDiffCorrelation(DetI, this->Wb[braIdx]);
+            this->correlation.ZeroDiffCorrelation(DetI, this->Wb[braIdx]);
         }
     }
 };
@@ -247,7 +139,7 @@ public:
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
 
-                this->TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
                                     helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
                                     helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
             }
@@ -294,7 +186,7 @@ public:
                 size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
-                this->OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
+                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
             }
         }
     }
@@ -339,7 +231,7 @@ public:
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
 
-                this->TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
                                     helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
                                     helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
             }
@@ -385,7 +277,7 @@ public:
                 size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
-                this->OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
+                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
             }
         }
     }
@@ -430,7 +322,7 @@ public:
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
 
-                this->TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
                                             helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
                                             helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
             }
@@ -480,7 +372,7 @@ public:
                     size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                     + jb - helper.ketBetaStart;
                     ElemT WeightJ = this->T[ketIdx];
-                    this->TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                    this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
                                         helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
                                         helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
                 }
@@ -529,7 +421,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
-                this->OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_alpha]);
+                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_alpha]);
             }
             for (size_t k = helper.DoublesFromBetaOffset[b]; k < helper.DoublesFromBetaOffset[b + 1]; k++) {
                 size_t ja = ia;
@@ -537,7 +429,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
-                this->TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
                                         helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_alpha],
                                         helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_alpha], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_alpha]);
            }
@@ -585,7 +477,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
-                this->OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_beta]);
+                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_beta]);
             }
             for (size_t j = helper.DoublesFromAlphaOffset[a]; j < helper.DoublesFromAlphaOffset[a + 1]; j++) {
                 size_t ja = helper.DoublesFromAlphaKetIndex[j];
@@ -593,7 +485,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
-                this->TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
                                     helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_beta],
                                     helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_beta], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_beta]);
             }

--- a/include/sbd/chemistry/tpb/correlation_thrust.h
+++ b/include/sbd/chemistry/tpb/correlation_thrust.h
@@ -18,7 +18,7 @@ protected:
 public:
     CorrelationKernelBase() {}
 
-    CorrelationKernelBase(const MultDataThrust<ElemT>& data,
+    CorrelationKernelBase(const MultTPBThrust<ElemT>& data,
                         const thrust::device_vector<ElemT>& v_wb,
                         const thrust::device_vector<ElemT>& v_t,
                         thrust::device_vector<ElemT>& b1,
@@ -73,7 +73,7 @@ public:
         int sa = a % 2;
         atomicAdd(onebody + si * onebody_size + (oi + this->norbs * oa), Conjugate(WeightI) * WeightJ * ElemT(sgn));
         size_t one = 1;
-        for (int x = 0; x < this->size_D; x++) {
+        for (int x = 0; x < this->D_size; x++) {
             size_t bits = det[x];
             for (int pos = 0; pos < this->bit_length; pos++) {
                 if ((bits & 1ULL) == 1ULL) {
@@ -143,7 +143,7 @@ protected:
     size_t offset;
 public:
     CorrelationInit(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -162,7 +162,7 @@ public:
 
         if (i + offset < braAlphaSize * braBetaSize) {
             if( ((i + offset) % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t* DetI = this->det_I + (i + offset) * this->size_D;
+                size_t* DetI = this->det_I + (i + offset) * this->D_size;
                 this->ZeroDiffCorrelation(DetI, this->Wb[i + offset]);
             }
         }
@@ -177,7 +177,7 @@ protected:
     size_t offset;
 public:
     CorrelationInitNoCache(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -195,12 +195,12 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
             this->ZeroDiffCorrelation(DetI, this->Wb[braIdx]);
         }
     }
@@ -215,7 +215,7 @@ protected:
     size_t offset;
 public:
     CorrelationAlphaBeta(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -243,7 +243,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
 
@@ -264,7 +264,7 @@ protected:
     size_t offset;
 public:
     CorrelationSingleAlpha(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -291,7 +291,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
                 this->OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
@@ -308,7 +308,7 @@ protected:
     size_t offset;
 public:
     CorrelationDoubleAlpha(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -335,7 +335,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
 
@@ -355,7 +355,7 @@ protected:
     size_t offset;
 public:
     CorrelationSingleBeta(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -382,7 +382,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
                 this->OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
@@ -399,7 +399,7 @@ protected:
     size_t offset;
 public:
     CorrelationDoubleBeta(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -426,7 +426,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
                 ElemT WeightI = this->Wb[braIdx];
                 ElemT WeightJ = this->T[ketIdx];
 
@@ -447,7 +447,7 @@ protected:
     size_t offset;
 public:
     CorrelationTask0(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -465,12 +465,12 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
             ElemT WeightI = this->Wb[braIdx];
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
@@ -497,7 +497,7 @@ protected:
     size_t offset;
 public:
     CorrelationTask1(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -515,12 +515,12 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
             ElemT WeightI = this->Wb[braIdx];
 
             for (size_t k = helper.SinglesFromBetaOffset[b]; k < helper.SinglesFromBetaOffset[b + 1]; k++) {
@@ -553,7 +553,7 @@ protected:
     size_t offset;
 public:
     CorrelationTask2(const TaskHelpersThrust<ElemT>& h,
-                const MultDataThrust<ElemT>& data,
+                const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
@@ -571,12 +571,12 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
             ElemT WeightI = this->Wb[braIdx];
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
@@ -606,31 +606,26 @@ public:
 */
 template <typename ElemT>
 void Correlation(const std::vector<ElemT> &W_in,
-                    const size_t adet_comm_size,
-                    const size_t bdet_comm_size,
-                    MultDataThrust<ElemT> &data,
-                    MPI_Comm h_comm,
-                    MPI_Comm b_comm,
-                    MPI_Comm t_comm,
+                    MultTPBThrust<ElemT>& data,
                     std::vector<std::vector<ElemT>> &onebody_out,
                     std::vector<std::vector<ElemT>> &twobody_out)
 {
-    thrust::device_vector<ElemT> onebody(data.norbs * data.norbs * 2, ElemT(0.0));
-    thrust::device_vector<ElemT> twobody(data.norbs * data.norbs * data.norbs * data.norbs * 4, ElemT(0.0));
+    thrust::device_vector<ElemT> onebody(data.norbs() * data.norbs() * 2, ElemT(0.0));
+    thrust::device_vector<ElemT> twobody(data.norbs() * data.norbs() * data.norbs() * data.norbs() * 4, ElemT(0.0));
 
     int mpi_rank_h = 0;
     int mpi_size_h = 1;
-    MPI_Comm_rank(h_comm, &mpi_rank_h);
-    MPI_Comm_size(h_comm, &mpi_size_h);
+    MPI_Comm_rank(data.h_comm(), &mpi_rank_h);
+    MPI_Comm_size(data.h_comm(), &mpi_size_h);
 
     int mpi_size_b;
-    MPI_Comm_size(b_comm, &mpi_size_b);
+    MPI_Comm_size(data.b_comm(), &mpi_size_b);
     int mpi_rank_b;
-    MPI_Comm_rank(b_comm, &mpi_rank_b);
+    MPI_Comm_rank(data.b_comm(), &mpi_rank_b);
     int mpi_size_t;
-    MPI_Comm_size(t_comm, &mpi_size_t);
+    MPI_Comm_size(data.t_comm(), &mpi_size_t);
     int mpi_rank_t;
-    MPI_Comm_rank(t_comm, &mpi_rank_t);
+    MPI_Comm_rank(data.t_comm(), &mpi_rank_t);
     size_t braAlphaSize = 0;
     size_t braBetaSize = 0;
     if (data.helper.size() != 0) {
@@ -642,8 +637,8 @@ void Correlation(const std::vector<ElemT> &W_in,
     size_t adet_max = data.adets.size();
     size_t bdet_min = 0;
     size_t bdet_max = data.bdets.size();
-    get_mpi_range(adet_comm_size,0,adet_min,adet_max);
-    get_mpi_range(bdet_comm_size,0,bdet_min,bdet_max);
+    get_mpi_range(data.adet_comm_size,0,adet_min,adet_max);
+    get_mpi_range(data.bdet_comm_size,0,bdet_min,bdet_max);
     size_t max_det_size = (adet_max-adet_min)*(bdet_max-bdet_min);
 
     thrust::device_vector<ElemT> T(max_det_size);
@@ -652,8 +647,8 @@ void Correlation(const std::vector<ElemT> &W_in,
     thrust::copy_n(W_in.begin(), W_in.size(), W.begin());
 
     if (data.helper.size() != 0) {
-        Mpi2dSlide(W, T, adet_comm_size, bdet_comm_size,
-                    -data.helper[0].adetShift, -data.helper[0].bdetShift, b_comm);
+        Mpi2dSlide(W, T, data.adet_comm_size, data.bdet_comm_size,
+                    -data.helper[0].adetShift, -data.helper[0].bdetShift, data.b_comm());
     }
 
     size_t offset = 0;
@@ -843,28 +838,28 @@ void Correlation(const std::vector<ElemT> &W_in,
             int bdetslide = data.helper[task].bdetShift - data.helper[task + 1].bdetShift;
             R.resize(T.size());
             R = T;
-            Mpi2dSlide(R, T, adet_comm_size, bdet_comm_size, adetslide, bdetslide, b_comm);
+            Mpi2dSlide(R, T, data.adet_comm_size, data.bdet_comm_size, adetslide, bdetslide, data.b_comm());
         }
     } // end for(size_t task=0; task < helper.size(); task++)
 
     if (mpi_size_b > 1)
-        MpiAllreduce(onebody, MPI_SUM, b_comm);
+        MpiAllreduce(onebody, MPI_SUM, data.b_comm());
     if (mpi_size_t > 1)
-        MpiAllreduce(onebody, MPI_SUM, t_comm);
+        MpiAllreduce(onebody, MPI_SUM, data.t_comm());
     if (mpi_size_h > 1)
-        MpiAllreduce(onebody, MPI_SUM, h_comm);
+        MpiAllreduce(onebody, MPI_SUM, data.h_comm());
 
     if (mpi_size_b > 1)
-        MpiAllreduce(twobody, MPI_SUM, b_comm);
+        MpiAllreduce(twobody, MPI_SUM, data.b_comm());
     if (mpi_size_t > 1)
-        MpiAllreduce(twobody, MPI_SUM, t_comm);
+        MpiAllreduce(twobody, MPI_SUM, data.t_comm());
     if (mpi_size_h > 1)
-        MpiAllreduce(twobody, MPI_SUM, h_comm);
+        MpiAllreduce(twobody, MPI_SUM, data.h_comm());
 
 
     // copy out onebody, twobody
     onebody_out.resize(2);
-    size = data.norbs * data.norbs;
+    size = data.norbs() * data.norbs();
     offset = 0;
     for(int s=0; s < 2; s++) {
         onebody_out[s].resize(size, ElemT(0.0));
@@ -873,7 +868,7 @@ void Correlation(const std::vector<ElemT> &W_in,
     }
 
     twobody_out.resize(4);
-    size = data.norbs * data.norbs * data.norbs * data.norbs;
+    size = data.norbs() * data.norbs() * data.norbs() * data.norbs();
     offset = 0;
     for(int s=0; s < 4; s++) {
         twobody_out[s].resize(size, ElemT(0.0));

--- a/include/sbd/chemistry/tpb/helper_thrust.h
+++ b/include/sbd/chemistry/tpb/helper_thrust.h
@@ -7,11 +7,6 @@
 
 namespace sbd {
 
-#include "sbd/chemistry/tpb/helper.h"
-
-//#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
-
 
 template <typename ElemT>
 class TaskHelpersThrust {

--- a/include/sbd/chemistry/tpb/inc_all.h
+++ b/include/sbd/chemistry/tpb/inc_all.h
@@ -8,10 +8,7 @@
 #include "sbd/chemistry/tpb/qcham.h"
 #include "sbd/chemistry/tpb/mult.h"
 #ifdef SBD_THRUST
-#include "sbd/framework/mpi_utility_thrust.h"
 #include "sbd/chemistry/tpb/mult_thrust.h"
-#include "sbd/chemistry/tpb/davidson_thrust.h"
-#include "sbd/chemistry/tpb/lanczos_thrust.h"
 #endif
 #include "sbd/chemistry/tpb/davidson.h"
 #include "sbd/chemistry/tpb/lanczos.h"

--- a/include/sbd/chemistry/tpb/mult_thrust.h
+++ b/include/sbd/chemistry/tpb/mult_thrust.h
@@ -8,8 +8,6 @@
 #include <chrono>
 #include <cstdio>
 
-#include "sbd/chemistry/tpb/helper_thrust.h"
-
 
 // per thread DetI, DetJ storage size (1GB max)
 #define MAX_DET_SIZE 134217728
@@ -18,7 +16,7 @@ namespace sbd
 {
 
 template <typename ElemT>
-class MultDataThrust {
+class MultTPBThrust : public MultBase<ElemT> {
 public:
     thrust::device_vector<size_t> adets;
     thrust::device_vector<size_t> bdets;
@@ -43,45 +41,161 @@ public:
     thrust::device_vector<ElemT> I2_em;
     std::vector<thrust::device_vector<size_t>> helper_storage;
     std::vector<thrust::device_vector<int>> CrAn_storage;
-    size_t bit_length;
-    size_t norbs;
-    size_t size_D;
     size_t num_max_threads;
     std::vector<TaskHelpersThrust<ElemT>> helper;
     bool use_precalculated_dets;
     int max_memory_gb_for_determinants;
+    size_t adet_comm_size;
+    size_t bdet_comm_size;
 
-    MultDataThrust() {}
+    MultTPBThrust() {}
 
-    void Init( const std::vector<std::vector<size_t>> &adets_in,
+    void Init(
+        const std::vector<std::vector<size_t>> &adets_in,
         const std::vector<std::vector<size_t>> &bdets_in,
         const size_t bit_length_in,
         const size_t norbs_in,
+        const size_t adet_comm_size_in,
+        const size_t bdet_comm_size_in,
         const std::vector<TaskHelpers> &helper_in,
         const ElemT &I0_in,
         const oneInt<ElemT> &I1_in,
         const twoInt<ElemT> &I2_in,
+        MPI_Comm h_comm_in,
+        MPI_Comm b_comm_in,
+        MPI_Comm t_comm_in,
         bool use_pre_dets,
         int max_gb_dets);
 
     void UpdateDet(size_t task);
 
+    void run(const thrust::device_vector<ElemT> &hii,
+                    const thrust::device_vector<ElemT> &Wk,
+                    thrust::device_vector<ElemT> &Wb) override;
 };
+
+// contructor for Mult data
+template <typename ElemT>
+void MultTPBThrust<ElemT>::Init(
+    const std::vector<std::vector<size_t>> &adets_in,
+    const std::vector<std::vector<size_t>> &bdets_in,
+    const size_t bit_length_in,
+    const size_t norbs_in,
+    const size_t adet_comm_size_in,
+    const size_t bdet_comm_size_in,
+    const std::vector<TaskHelpers> &helper_in,
+    const ElemT &I0_in,
+    const oneInt<ElemT> &I1_in,
+    const twoInt<ElemT> &I2_in,
+    MPI_Comm h_comm_in,
+	MPI_Comm b_comm_in,
+	MPI_Comm t_comm_in,
+    bool use_pre_dets,
+    int max_gb_dets)
+{
+    this->bit_length_ = bit_length_in;
+    this->norbs_ = norbs_in;
+    this->D_size_ = (2 * norbs_in + bit_length_in - 1) / bit_length_in;
+
+    this->h_comm_ = h_comm_in;
+    this->b_comm_ = b_comm_in;
+    this->t_comm_ = t_comm_in;
+
+    adet_comm_size = adet_comm_size_in;
+    bdet_comm_size = bdet_comm_size_in;
+
+    I0 = I0_in;
+    // copyin I1
+    I1_store.resize(I1_in.store.size());
+    thrust::copy_n(I1_in.store.begin(), I1_in.store.size(), I1_store.begin());
+    I1 = oneInt_Thrust<ElemT>(I1_store, I1_in.norbs);
+
+    // copyin I2
+    I2_store.resize(I2_in.store.size());
+    thrust::copy_n(I2_in.store.begin(), I2_in.store.size(), I2_store.begin());
+    I2_dm.resize(I2_in.DirectMat.size());
+    thrust::copy_n(I2_in.DirectMat.begin(), I2_in.DirectMat.size(), I2_dm.begin());
+    I2_em.resize(I2_in.ExchangeMat.size());
+    thrust::copy_n(I2_in.ExchangeMat.begin(), I2_in.ExchangeMat.size(), I2_em.begin());
+    I2 = twoInt_Thrust<ElemT>(I2_store, I2_in.norbs, I2_dm, I2_em, I2_in.zero, I2_in.maxEntry);
+
+    adets_size = 0;
+    bdets_size = 0;
+    bra_adets_begin = 0;
+    bra_adets_end = 0;
+    bra_bdets_begin = 0;
+    bra_bdets_end = 0;
+    ket_adets_begin = 0;
+    ket_adets_end = 0;
+    ket_bdets_begin = 0;
+    ket_bdets_end = 0;
+
+    use_precalculated_dets = use_pre_dets;
+    max_memory_gb_for_determinants = max_gb_dets;
+
+    // copyin helpers
+    helper.clear();
+    helper_storage.resize(helper_in.size());
+    CrAn_storage.resize(helper_in.size());
+    for (size_t task = 0; task < helper_in.size(); task++) {
+        helper.push_back(TaskHelpersThrust<ElemT>(helper_storage[task], CrAn_storage[task], helper_in[task], !use_precalculated_dets));
+
+        adets_size = std::max(adets_size, helper[task].braAlphaEnd - helper[task].braAlphaStart);
+        bdets_size = std::max(bdets_size, helper[task].braBetaEnd - helper[task].braBetaStart);
+    }
+
+    // copyin adets, bdets
+    adets.resize(this->D_size_ * adets_in.size());
+    bdets.resize(this->D_size_ * bdets_in.size());
+    for (int i = 0; i < adets_in.size(); i++) {
+        thrust::copy_n(adets_in[i].begin(), this->D_size_, adets.begin() + i * this->D_size_);
+    }
+    for (int i = 0; i < bdets_in.size(); i++) {
+        thrust::copy_n(bdets_in[i].begin(), this->D_size_, bdets.begin() + i * this->D_size_);
+    }
+
+    dets_size = 0;
+    if (use_precalculated_dets) {
+        for (size_t task = 0; task < helper.size(); task++) {
+            size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
+            size_t braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
+            dets_size = std::max(dets_size, std::max(helper[task].size_single_alpha, helper[task].size_double_alpha) * braBetaSize);
+            dets_size = std::max(dets_size, std::max(helper[task].size_single_beta, helper[task].size_double_beta) * braAlphaSize);
+            dets_size = std::max(dets_size, helper[task].size_single_alpha * helper[task].size_single_beta);
+        }
+        num_max_threads = dets_size;
+
+        // allocate pre-calculated DetI
+        dets.resize(this->D_size_ * adets_size * bdets_size);
+    } else {
+        for (size_t task = 0; task < helper.size(); task++) {
+            size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
+            size_t braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
+            dets_size = std::max(dets_size, braAlphaSize * braBetaSize);
+        }
+        num_max_threads = dets_size;
+
+        // number of max threads, this is enabled when per thread DetI and DetJ storage is used (non-pre calculate)
+        if (max_memory_gb_for_determinants > 0) {
+            if (dets_size * this->D_size_ * sizeof(size_t) > (size_t)max_memory_gb_for_determinants * 1024 * 1024 * 1024) {
+                dets_size = ((size_t)max_memory_gb_for_determinants * 1024 * 1024 * 1024 / (this->D_size_ * sizeof(size_t))) & (~1023ULL);
+                num_max_threads = dets_size;
+            }
+            std::cout << " num_max_threads = " << num_max_threads << std::endl;
+        }
+        // allocate per thread storage for DetI
+        dets.resize(this->D_size_ * dets_size);
+    }
+}
 
 
 template <typename ElemT>
-class MultKernelBase {
+class MultKernelBase : public DeterminantKernels<ElemT> {
 protected:
     ElemT *Wb;
     ElemT* T;
     size_t adets_size;
     size_t bdets_size;
-    ElemT I0;
-    oneInt_Thrust<ElemT> I1;
-    twoInt_Thrust<ElemT> I2;
-    size_t bit_length;
-    size_t norbs;
-    size_t size_D;
     size_t mpi_rank_h;
     size_t mpi_size_h;
     size_t* adets;
@@ -92,8 +206,8 @@ public:
 
     MultKernelBase( const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data
-                ) : I0(data.I0), I1(data.I1), I2(data.I2), bit_length(data.bit_length), norbs(data.norbs), size_D(data.size_D)
+                const MultTPBThrust<ElemT>& data
+                ) : DeterminantKernels<ElemT>(data.bit_length(), data.norbs(), data.I0, data.I1, data.I2)
     {
         Wb = (ElemT*)thrust::raw_pointer_cast(v_wb.data());
         T = (ElemT*)thrust::raw_pointer_cast(v_t.data());
@@ -105,8 +219,8 @@ public:
         bdets_size = data.bdets_size;
     }
 
-    MultKernelBase(const MultDataThrust<ElemT>& data)
-                 : I0(data.I0), I1(data.I1), I2(data.I2), bit_length(data.bit_length), norbs(data.norbs), size_D(data.size_D)
+    MultKernelBase(const MultTPBThrust<ElemT>& data)
+                 : DeterminantKernels<ElemT>(data.bit_length(), data.norbs(), data.I0, data.I1, data.I2)
     {
         adets = (size_t*)thrust::raw_pointer_cast(data.adets.data());
         bdets = (size_t*)thrust::raw_pointer_cast(data.bdets.data());
@@ -114,134 +228,6 @@ public:
 
         adets_size = data.adets_size;
         bdets_size = data.bdets_size;
-    }
-
-    __device__ __host__ void DetFromAlphaBeta(size_t *D, const size_t *A, const size_t *B)
-    {
-        size_t i;
-        for (i = 0; i < size_D; i++) {
-            D[i] = 0;
-        }
-        for (i = 0; i < norbs; i++) {
-            size_t block = i / bit_length;
-            size_t bit_pos = i % bit_length;
-            size_t new_block_A = (2 * i) / bit_length;
-            size_t new_bit_pos_A = (2 * i) % bit_length;
-            size_t new_block_B = (2 * i + 1) / bit_length;
-            size_t new_bit_pos_B = (2 * i + 1) % bit_length;
-
-            if (A[block] & (size_t(1) << bit_pos)) {
-                D[new_block_A] |= size_t(1) << new_bit_pos_A;
-            }
-            if (B[block] & (size_t(1) << bit_pos)) {
-                D[new_block_B] |= size_t(1) << new_bit_pos_B;
-            }
-        }
-    }
-
-    inline __device__ __host__ void parity(const size_t* dets, const int start, const int end, double& sgn)
-    {
-        size_t blockStart = start / bit_length;
-        size_t bitStart = start % bit_length;
-
-        size_t blockEnd = end / bit_length;
-        size_t bitEnd = end % bit_length;
-
-        size_t nonZeroBits = 0; // counter for nonzero bits
-
-        // 1. Count bits in the start block
-        if (blockStart == blockEnd) {
-            // the case where start and end is same block
-            size_t mask = ((size_t(1) << bitEnd) - 1) ^ ((size_t(1) << bitStart) - 1);
-            nonZeroBits += __popcll(dets[blockStart] & mask);
-        }
-        else {
-            // 2. Handle the partial bits in the start block
-            if (bitStart != 0) {
-                size_t mask = ~((size_t(1) << bitStart) - 1); // count after bitStart
-                nonZeroBits += __popcll(dets[blockStart] & mask);
-                blockStart++;
-            }
-
-            // 3. Handle full blocks in between
-            for (size_t i = blockStart; i < blockEnd; i++) {
-                nonZeroBits += __popcll(dets[i]);
-            }
-
-            // 4. Handle the partial bits in the end block
-            if (bitEnd != 0) {
-                size_t mask = (size_t(1) << bitEnd) - 1; // count before bitEnd
-                nonZeroBits += __popcll(dets[blockEnd] & mask);
-            }
-        }
-
-        // parity estimation
-        sgn *= (-2. * (nonZeroBits % 2) + 1);
-
-        // flip sign if start == 1
-        if ((dets[start / bit_length] >> (start % bit_length)) & 1) {
-            sgn *= -1.;
-        }
-    }
-
-  inline __device__ __host__ bool getocc(const size_t* det, int x)
-    {
-        size_t index = x / bit_length;
-        size_t bit_pos = x % bit_length;
-        return (det[index] >> bit_pos) & 1;
-    }
-
-    inline __device__ __host__ ElemT ZeroExcite(const size_t* det, const size_t L)
-    {
-        ElemT energy(0.0);
-
-        for (int i = 0; i < 2 * L; i++) {
-            if (getocc(det, i)) {
-                energy += I1.Value(i, i);
-                for (int j = i + 1; j < 2 * L; j++) {
-                    if (getocc(det, j)) {
-                        energy += I2.DirectValue(i / 2, j / 2);
-                        if ((i % 2) == (j % 2)) {
-                            energy -= I2.ExchangeValue(i / 2, j / 2);
-                        }
-                    }
-                }
-            }
-        }
-        return energy + I0;
-    }
-
-    inline __device__ __host__ ElemT OneExcite(const size_t* det, int i, int a)
-    {
-        double sgn = 1.0;
-        parity(det, std::min(i, a), std::max(i, a), sgn);
-        ElemT energy = I1.Value(a, i);
-        for (int x = 0; x < size_D; x++) {
-            size_t bits = det[x];
-            for (int pos = 0; pos < bit_length; pos++) {
-                if ((bits & 1ULL) == 1ULL) {
-                    int j = x * bit_length + pos;
-                    energy += (I2.Value(a, i, j, j) - I2.Value(a, j, j, i));
-                }
-                bits >>= 1;
-            }
-        }
-        energy *= ElemT(sgn);
-        return energy;
-    }
-
-    inline __device__ __host__ ElemT TwoExcite(const size_t* det, int i, int j, int a, int b)
-    {
-        double sgn = 1.0;
-        int I = std::min(i, j);
-        int J = std::max(i, j);
-        int A = std::min(a, b);
-        int B = std::max(a, b);
-        parity(det, std::min(I, A), std::max(I, A), sgn);
-        parity(det, std::min(J, B), std::max(J, B), sgn);
-        if (A > J || B < I)
-            sgn *= -1.0;
-        return ElemT(sgn) * (I2.Value(A, I, B, J) - I2.Value(A, J, B, I));
     }
 
     void set_mpi_size(size_t h_rank, size_t h_size)
@@ -258,7 +244,7 @@ protected:
     TaskHelpersThrust<ElemT> helper;
     bool update_I;
 public:
-    DetFromAlphaBetaKernel(const TaskHelpersThrust<ElemT>& h, const MultDataThrust<ElemT>& data, bool i)
+    DetFromAlphaBetaKernel(const TaskHelpersThrust<ElemT>& h, const MultTPBThrust<ElemT>& data, bool i)
                         : MultKernelBase<ElemT>(data)
     {
         helper = h;
@@ -272,15 +258,41 @@ public:
         size_t b = i - a * this->bdets_size;
         size_t* Det;
         if (update_I) {
-            Det = this->det_I + i * this->size_D;
+            Det = this->det_I + i * this->D_size;
             size_t ia = a + helper.braAlphaStart;
             size_t ib = b + helper.braBetaStart;
 
             if (ia < helper.braAlphaEnd && ib < helper.braBetaEnd)
-                this->DetFromAlphaBeta(Det, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+                this->DetFromAlphaBeta(Det, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
         }
     }
 };
+
+
+template <typename ElemT>
+void MultTPBThrust<ElemT>::UpdateDet(size_t task)
+{
+    // precalculate DetI (if update needed)
+    bool update_I =  bra_adets_begin != helper[task].braAlphaStart || bra_bdets_begin != helper[task].braBetaStart ||
+                    bra_adets_end != helper[task].braAlphaEnd || bra_bdets_end != helper[task].braBetaEnd;
+    if (update_I) {
+        bra_adets_begin = helper[task].braAlphaStart;
+        bra_bdets_begin = helper[task].braBetaStart;
+        bra_adets_end = helper[task].braAlphaEnd;
+        bra_bdets_end = helper[task].braBetaEnd;
+        ket_adets_begin = helper[task].ketAlphaStart;
+        ket_bdets_begin = helper[task].ketBetaStart;
+        ket_adets_end = helper[task].ketAlphaEnd;
+        ket_bdets_end = helper[task].ketBetaEnd;
+
+        DetFromAlphaBetaKernel det_kernel(helper[task], *this, update_I);
+        auto det_ci = thrust::counting_iterator<size_t>(0);
+        thrust::for_each_n(thrust::device, det_ci, adets_size * bdets_size, det_kernel);
+    }
+}
+
+
+
 
 
 template <typename ElemT>
@@ -293,7 +305,7 @@ public:
     MultAlphaBeta(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -317,7 +329,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
                 ElemT eij = this->TwoExcite(DetI,
                                             helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
@@ -339,7 +351,7 @@ public:
     MultSingleAlpha(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -363,7 +375,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
                 ElemT eij = this->OneExcite(DetI, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
                 atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
@@ -382,7 +394,7 @@ public:
     MultDoubleAlpha(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -405,7 +417,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
                 ElemT eij = this->TwoExcite(DetI,
                                             helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
@@ -426,7 +438,7 @@ public:
     MultSingleBeta(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -449,7 +461,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
                 ElemT eij = this->OneExcite(DetI, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
                 atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
@@ -468,7 +480,7 @@ public:
     MultDoubleBeta(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -491,7 +503,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->size_D;
+                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
                 ElemT eij = this->TwoExcite(DetI,
                                             helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
@@ -513,7 +525,7 @@ public:
     MultTask0(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -527,13 +539,13 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
         ElemT e = 0.0;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
                 size_t ja = helper.SinglesFromAlphaKetIndex[j];
@@ -562,7 +574,7 @@ public:
     MultTask1(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -576,13 +588,13 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
         ElemT e = 0.0;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
 
             for (size_t k = helper.SinglesFromBetaOffset[b]; k < helper.SinglesFromBetaOffset[b + 1]; k++) {
                 size_t ja = ia;
@@ -617,7 +629,7 @@ public:
     MultTask2(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultDataThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data, size_t o
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
@@ -631,13 +643,13 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->size_D;
+        size_t* DetI = this->det_I + i * this->D_size;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
         ElemT e = 0.0;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->size_D, this->bdets + ib * this->size_D);
+            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
                 size_t ja = helper.SinglesFromAlphaKetIndex[j];
@@ -683,6 +695,7 @@ public:
     }
 };
 
+#if 0
 template <typename ElemT>
 void mult(const std::vector<ElemT> &hii,
             const std::vector<ElemT> &Wk,
@@ -713,18 +726,13 @@ void mult(const std::vector<ElemT> &hii,
     // copyout Wb
     thrust::copy_n(Wb_dev.begin(), Wb_dev.size(), Wb.begin());
 }
-
+#endif
 
 template <typename ElemT>
-void mult(const thrust::device_vector<ElemT> &hii,
+void MultTPBThrust<ElemT>::run(
+            const thrust::device_vector<ElemT> &hii,
             const thrust::device_vector<ElemT> &Wk,
-            thrust::device_vector<ElemT> &Wb,
-            MultDataThrust<ElemT>& data,
-            const size_t adet_comm_size,
-            const size_t bdet_comm_size,
-            MPI_Comm h_comm,
-            MPI_Comm b_comm,
-            MPI_Comm t_comm)
+            thrust::device_vector<ElemT> &Wb)
 {
 
 #ifdef SBD_DEBUG_TUNING
@@ -733,24 +741,24 @@ void mult(const thrust::device_vector<ElemT> &hii,
 
     int mpi_rank_h = 0;
     int mpi_size_h = 1;
-    MPI_Comm_rank(h_comm, &mpi_rank_h);
-    MPI_Comm_size(h_comm, &mpi_size_h);
+    MPI_Comm_rank(this->h_comm_, &mpi_rank_h);
+    MPI_Comm_size(this->h_comm_, &mpi_size_h);
 
     int mpi_size_b;
-    MPI_Comm_size(b_comm, &mpi_size_b);
+    MPI_Comm_size(this->b_comm_, &mpi_size_b);
     int mpi_rank_b;
-    MPI_Comm_rank(b_comm, &mpi_rank_b);
+    MPI_Comm_rank(this->b_comm_, &mpi_rank_b);
     int mpi_size_t;
-    MPI_Comm_size(t_comm, &mpi_size_t);
+    MPI_Comm_size(this->t_comm_, &mpi_size_t);
     int mpi_rank_t;
-    MPI_Comm_rank(t_comm, &mpi_rank_t);
+    MPI_Comm_rank(this->t_comm_, &mpi_rank_t);
     size_t braAlphaSize = 0;
     size_t braBetaSize = 0;
 
     size_t adet_min = 0;
-    size_t adet_max = data.adets.size();
+    size_t adet_max = adets.size();
     size_t bdet_min = 0;
-    size_t bdet_max = data.bdets.size();
+    size_t bdet_max = bdets.size();
     get_mpi_range(adet_comm_size,0,adet_min,adet_max);
     get_mpi_range(bdet_comm_size,0,bdet_min,bdet_max);
     size_t max_det_size = (adet_max-adet_min)*(bdet_max-bdet_min);
@@ -762,10 +770,10 @@ void mult(const thrust::device_vector<ElemT> &hii,
     Mpi2dSlider<ElemT> mpi2dslider;
 
     auto time_copy_start = std::chrono::high_resolution_clock::now();
-    if (data.helper.size() != 0) {
+    if (helper.size() != 0) {
         if (mpi_size_b > 1) {
             Mpi2dSlide(Wk, T[active_T], adet_comm_size, bdet_comm_size,
-                        -data.helper[0].adetShift, -data.helper[0].bdetShift, b_comm);
+                        -helper[0].adetShift, -helper[0].bdetShift, this->b_comm_);
         } else {
             T[active_T] = Wk;
         }
@@ -780,16 +788,16 @@ void mult(const thrust::device_vector<ElemT> &hii,
     }
 
     double time_slid = 0.0;
-    for (size_t task = 0; task < data.helper.size(); task++) {
+    for (size_t task = 0; task < helper.size(); task++) {
 #ifdef SBD_DEBUG_MULT
         auto time_task_start = std::chrono::high_resolution_clock::now();
         std::cout << " Start multiplication for task " << task << " at (h,b,t) = ("
                     << mpi_rank_h << "," << mpi_rank_b << "," << mpi_rank_t << "): task type = "
-                    << data.helper[task].taskType << ", bra-adet range = ["
-                    << data.helper[task].braAlphaStart << "," << data.helper[task].braAlphaEnd << "), bra-bdet range = ["
-                    << data.helper[task].braBetaStart << "," << data.helper[task].braBetaEnd << "), ket-adet range = ["
-                    << data.helper[task].ketAlphaStart << "," << data.helper[task].ketAlphaEnd << "), ket-bdet range = ["
-                    << data.helper[task].ketBetaStart << "," << data.helper[task].ketBetaEnd << "), ket wf =";
+                    << helper[task].taskType << ", bra-adet range = ["
+                    << helper[task].braAlphaStart << "," << helper[task].braAlphaEnd << "), bra-bdet range = ["
+                    << helper[task].braBetaStart << "," << helper[task].braBetaEnd << "), ket-adet range = ["
+                    << helper[task].ketAlphaStart << "," << helper[task].ketAlphaEnd << "), ket-bdet range = ["
+                    << helper[task].ketBetaStart << "," << helper[task].ketBetaEnd << "), ket wf =";
         for (size_t i = 0; i < std::min(static_cast<size_t>(4), T[active_T].size()); i++) {
             std::cout << " " << T[active_T][i];
         }
@@ -811,15 +819,15 @@ void mult(const thrust::device_vector<ElemT> &hii,
             }
 
             // exchange T asynchronously for later tasks
-            for (size_t extask = task_sent; extask < data.helper.size() - 1; extask++) {
-                if (data.helper[extask].taskType == 0) {
+            for (size_t extask = task_sent; extask < helper.size() - 1; extask++) {
+                if (helper[extask].taskType == 0) {
 #ifdef SBD_DEBUG_MULT
                     size_t adet_rank = mpi_rank_b / bdet_comm_size;
                     size_t bdet_rank = mpi_rank_b % bdet_comm_size;
-                    size_t adet_rank_task = (adet_rank + data.helper[extask].adetShift) % adet_comm_size;
-                    size_t bdet_rank_task = (bdet_rank + data.helper[extask].bdetShift) % bdet_comm_size;
-                    size_t adet_rank_next = (adet_rank + data.helper[extask + 1].adetShift) % adet_comm_size;
-                    size_t bdet_rank_next = (bdet_rank + data.helper[extask + 1].bdetShift) % bdet_comm_size;
+                    size_t adet_rank_task = (adet_rank + helper[extask].adetShift) % adet_comm_size;
+                    size_t bdet_rank_task = (bdet_rank + helper[extask].bdetShift) % bdet_comm_size;
+                    size_t adet_rank_next = (adet_rank + helper[extask + 1].adetShift) % adet_comm_size;
+                    size_t bdet_rank_next = (bdet_rank + helper[extask + 1].bdetShift) % bdet_comm_size;
                     std::cout << " mult: task " << task << " at mpi process (h,b,t) = ("
                                 << mpi_rank_h << "," << mpi_rank_b << "," << mpi_rank_t
                                 << "): two-dimensional slide communication from ("
@@ -827,34 +835,34 @@ void mult(const thrust::device_vector<ElemT> &hii,
                                 << adet_rank_next << "," << bdet_rank_next << ")"
                                 << std::endl;
 #endif
-                    int adetslide = data.helper[extask].adetShift - data.helper[extask + 1].adetShift;
-                    int bdetslide = data.helper[extask].bdetShift - data.helper[extask + 1].bdetShift;
-                    mpi2dslider.ExchangeAsync(T[active_T], T[recv_T], adet_comm_size, bdet_comm_size, adetslide, bdetslide, b_comm, extask);
+                    int adetslide = helper[extask].adetShift - helper[extask + 1].adetShift;
+                    int bdetslide = helper[extask].bdetShift - helper[extask + 1].bdetShift;
+                    mpi2dslider.ExchangeAsync(T[active_T], T[recv_T], adet_comm_size, bdet_comm_size, adetslide, bdetslide, this->b_comm_, extask);
                     task_sent = extask + 1;
                     break;
                 }
             }
         }
 
-        braAlphaSize = data.helper[task].braAlphaEnd - data.helper[task].braAlphaStart;
-        braBetaSize = data.helper[task].braBetaEnd - data.helper[task].braBetaStart;
+        braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
+        braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
 
         size_t offset;
         size_t size;
-        if (data.use_precalculated_dets) {
+        if (use_precalculated_dets) {
             // precalculate DetI (if update needed)
-            data.UpdateDet(task);
+            UpdateDet(task);
 
-            if (data.helper[task].taskType == 2) {
+            if (helper[task].taskType == 2) {
                 offset = 0;
-                size = data.helper[task].size_single_alpha * braBetaSize;
+                size = helper[task].size_single_alpha * braBetaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultSingleAlpha single_kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultSingleAlpha single_kernel(helper[task], Wb, T[active_T], *this, offset);
                     single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto cis = thrust::counting_iterator<size_t>(0);
@@ -863,30 +871,30 @@ void mult(const thrust::device_vector<ElemT> &hii,
                 }
 
                 offset = 0;
-                size = data.helper[task].size_double_alpha * braBetaSize;
+                size = helper[task].size_double_alpha * braBetaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultDoubleAlpha double_kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultDoubleAlpha double_kernel(helper[task], Wb, T[active_T], *this, offset);
                     double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto cid = thrust::counting_iterator<size_t>(0);
                     thrust::for_each_n(thrust::device, cid, num_threads, double_kernel);
                     offset += num_threads;
                 }
-            } else if(data.helper[task].taskType == 1) {
+            } else if(helper[task].taskType == 1) {
                 offset = 0;
-                size = data.helper[task].size_single_beta * braAlphaSize;
+                size = helper[task].size_single_beta * braAlphaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultSingleBeta single_kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultSingleBeta single_kernel(helper[task], Wb, T[active_T], *this, offset);
                     single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto cis = thrust::counting_iterator<size_t>(0);
@@ -895,14 +903,14 @@ void mult(const thrust::device_vector<ElemT> &hii,
                 }
 
                 offset = 0;
-                size = data.helper[task].size_double_beta * braAlphaSize;
+                size = helper[task].size_double_beta * braAlphaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultDoubleBeta double_kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultDoubleBeta double_kernel(helper[task], Wb, T[active_T], *this, offset);
                     double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto cid = thrust::counting_iterator<size_t>(0);
@@ -911,14 +919,14 @@ void mult(const thrust::device_vector<ElemT> &hii,
                 }
             } else {
                 offset = 0;
-                size = data.helper[task].size_single_alpha * data.helper[task].size_single_beta;
+                size = helper[task].size_single_alpha * helper[task].size_single_beta;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultAlphaBeta kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultAlphaBeta kernel(helper[task], Wb, T[active_T], *this, offset);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -927,31 +935,31 @@ void mult(const thrust::device_vector<ElemT> &hii,
                 }
             }
         } else {    // non pre-calculated
-            if (data.helper[task].taskType == 2) {
+            if (helper[task].taskType == 2) {
                 offset = 0;
                 size = braAlphaSize * braBetaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
-                    MultTask2 kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultTask2 kernel(helper[task], Wb, T[active_T], *this, offset);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
                     thrust::for_each_n(thrust::device, ci, num_threads, kernel);
                     offset += num_threads;
                 }
-            } else if(data.helper[task].taskType == 1) {
+            } else if(helper[task].taskType == 1) {
                 offset = 0;
                 size = braAlphaSize * braBetaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultTask1 kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultTask1 kernel(helper[task], Wb, T[active_T], *this, offset);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -962,12 +970,12 @@ void mult(const thrust::device_vector<ElemT> &hii,
                 offset = 0;
                 size = braAlphaSize * braBetaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultTask0 kernel(data.helper[task], Wb, T[active_T], data, offset);
+                    MultTask0 kernel(helper[task], Wb, T[active_T], *this, offset);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -980,17 +988,17 @@ void mult(const thrust::device_vector<ElemT> &hii,
 #ifdef SBD_DEBUG_MULT
         auto time_task_end = std::chrono::high_resolution_clock::now();
         auto time_task_count = std::chrono::duration_cast<std::chrono::microseconds>(time_task_end - time_task_start).count();
-        std::cout << "     time for task " << task << " [" << data.helper[task].taskType << "] : " << 1.0e-6 * time_task_count << std::endl;
+        std::cout << "     time for task " << task << " [" << helper[task].taskType << "] : " << 1.0e-6 * time_task_count << std::endl;
 #endif
-    } // end for(size_t task=0; task < data.helper.size(); task++)
+    } // end for(size_t task=0; task < helper.size(); task++)
 
     auto time_mult_end = std::chrono::high_resolution_clock::now();
 
     auto time_comm_start = std::chrono::high_resolution_clock::now();
     if (mpi_size_t > 1)
-        MpiAllreduce(Wb, MPI_SUM, t_comm);
+        MpiAllreduce(Wb, MPI_SUM, this->t_comm_);
     if (mpi_size_h > 1)
-        MpiAllreduce(Wb, MPI_SUM, h_comm);
+        MpiAllreduce(Wb, MPI_SUM, this->h_comm_);
     auto time_comm_end = std::chrono::high_resolution_clock::now();
 
 #ifdef SBD_DEBUG_MULT
@@ -1009,130 +1017,6 @@ void mult(const thrust::device_vector<ElemT> &hii,
 
 } // end function
 
-
-
-// contructor for Mult data
-template <typename ElemT>
-void MultDataThrust<ElemT>::Init( const std::vector<std::vector<size_t>> &adets_in,
-    const std::vector<std::vector<size_t>> &bdets_in,
-    const size_t bit_length_in,
-    const size_t norbs_in,
-    const std::vector<TaskHelpers> &helper_in,
-    const ElemT &I0_in,
-    const oneInt<ElemT> &I1_in,
-    const twoInt<ElemT> &I2_in,
-    bool use_pre_dets,
-    int max_gb_dets)
-{
-    bit_length = bit_length_in;
-    norbs = norbs_in;
-    size_D = (2 * norbs + bit_length - 1) / bit_length;
-
-    I0 = I0_in;
-    // copyin I1
-    I1_store.resize(I1_in.store.size());
-    thrust::copy_n(I1_in.store.begin(), I1_in.store.size(), I1_store.begin());
-    I1 = oneInt_Thrust<ElemT>(I1_store, I1_in.norbs);
-
-    // copyin I2
-    I2_store.resize(I2_in.store.size());
-    thrust::copy_n(I2_in.store.begin(), I2_in.store.size(), I2_store.begin());
-    I2_dm.resize(I2_in.DirectMat.size());
-    thrust::copy_n(I2_in.DirectMat.begin(), I2_in.DirectMat.size(), I2_dm.begin());
-    I2_em.resize(I2_in.ExchangeMat.size());
-    thrust::copy_n(I2_in.ExchangeMat.begin(), I2_in.ExchangeMat.size(), I2_em.begin());
-    I2 = twoInt_Thrust<ElemT>(I2_store, I2_in.norbs, I2_dm, I2_em, I2_in.zero, I2_in.maxEntry);
-
-    adets_size = 0;
-    bdets_size = 0;
-    bra_adets_begin = 0;
-    bra_adets_end = 0;
-    bra_bdets_begin = 0;
-    bra_bdets_end = 0;
-    ket_adets_begin = 0;
-    ket_adets_end = 0;
-    ket_bdets_begin = 0;
-    ket_bdets_end = 0;
-
-    use_precalculated_dets = use_pre_dets;
-    max_memory_gb_for_determinants = max_gb_dets;
-
-    // copyin helpers
-    helper.clear();
-    helper_storage.resize(helper_in.size());
-    CrAn_storage.resize(helper_in.size());
-    for (size_t task = 0; task < helper_in.size(); task++) {
-        helper.push_back(TaskHelpersThrust<ElemT>(helper_storage[task], CrAn_storage[task], helper_in[task], !use_precalculated_dets));
-
-        adets_size = std::max(adets_size, helper[task].braAlphaEnd - helper[task].braAlphaStart);
-        bdets_size = std::max(bdets_size, helper[task].braBetaEnd - helper[task].braBetaStart);
-    }
-
-    // copyin adets, bdets
-    adets.resize(size_D * adets_in.size());
-    bdets.resize(size_D * bdets_in.size());
-    for (int i = 0; i < adets_in.size(); i++) {
-        thrust::copy_n(adets_in[i].begin(), size_D, adets.begin() + i * size_D);
-    }
-    for (int i = 0; i < bdets_in.size(); i++) {
-        thrust::copy_n(bdets_in[i].begin(), size_D, bdets.begin() + i * size_D);
-    }
-
-    dets_size = 0;
-    if (use_precalculated_dets) {
-        for (size_t task = 0; task < helper.size(); task++) {
-            size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
-            size_t braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
-            dets_size = std::max(dets_size, std::max(helper[task].size_single_alpha, helper[task].size_double_alpha) * braBetaSize);
-            dets_size = std::max(dets_size, std::max(helper[task].size_single_beta, helper[task].size_double_beta) * braAlphaSize);
-            dets_size = std::max(dets_size, helper[task].size_single_alpha * helper[task].size_single_beta);
-        }
-        num_max_threads = dets_size;
-
-        // allocate pre-calculated DetI
-        dets.resize(size_D * adets_size * bdets_size);
-    } else {
-        for (size_t task = 0; task < helper.size(); task++) {
-            size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
-            size_t braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
-            dets_size = std::max(dets_size, braAlphaSize * braBetaSize);
-        }
-        num_max_threads = dets_size;
-
-        // number of max threads, this is enabled when per thread DetI and DetJ storage is used (non-pre calculate)
-        if (max_memory_gb_for_determinants > 0) {
-            if (dets_size * size_D * sizeof(size_t) > (size_t)max_memory_gb_for_determinants * 1024 * 1024 * 1024) {
-                dets_size = ((size_t)max_memory_gb_for_determinants * 1024 * 1024 * 1024 / (size_D * sizeof(size_t))) & (~1023ULL);
-                num_max_threads = dets_size;
-            }
-            std::cout << " num_max_threads = " << num_max_threads << std::endl;
-        }
-        // allocate per thread storage for DetI
-        dets.resize(size_D * dets_size);
-    }
-}
-
-template <typename ElemT>
-void MultDataThrust<ElemT>::UpdateDet(size_t task)
-{
-    // precalculate DetI (if update needed)
-    bool update_I =  bra_adets_begin != helper[task].braAlphaStart || bra_bdets_begin != helper[task].braBetaStart ||
-                    bra_adets_end != helper[task].braAlphaEnd || bra_bdets_end != helper[task].braBetaEnd;
-    if (update_I) {
-        bra_adets_begin = helper[task].braAlphaStart;
-        bra_bdets_begin = helper[task].braBetaStart;
-        bra_adets_end = helper[task].braAlphaEnd;
-        bra_bdets_end = helper[task].braBetaEnd;
-        ket_adets_begin = helper[task].ketAlphaStart;
-        ket_bdets_begin = helper[task].ketBetaStart;
-        ket_adets_end = helper[task].ketAlphaEnd;
-        ket_bdets_end = helper[task].ketBetaEnd;
-
-        DetFromAlphaBetaKernel det_kernel(helper[task], *this, update_I);
-        auto det_ci = thrust::counting_iterator<size_t>(0);
-        thrust::for_each_n(thrust::device, det_ci, adets_size * bdets_size, det_kernel);
-    }
-}
 
 
 }

--- a/include/sbd/chemistry/tpb/sbdiag.h
+++ b/include/sbd/chemistry/tpb/sbdiag.h
@@ -141,7 +141,10 @@ namespace sbd {
       int N;
 
       int method = sbd_data.method;
-      int max_it = sbd_data.max_it;
+#ifdef SBD_THRUST
+	  method = method & 1;
+#endif
+	  int max_it = sbd_data.max_it;
       int max_nb = sbd_data.max_nb;
       double eps = sbd_data.eps;
       double max_time = sbd_data.max_time;
@@ -213,9 +216,10 @@ namespace sbd {
       }
 
 #ifdef SBD_THRUST
-	  // data storage for thrust implementation
-	  MultDataThrust<double> device_data;
+	// multiplyer class for TPB on Thrust
+	MultTPBThrust<double> device_mult;
 #endif
+
       /**
 	 Diagonalization
       */
@@ -232,17 +236,15 @@ namespace sbd {
 				helper,I0,I1,I2,hii,
 				h_comm,b_comm,t_comm);
 #ifdef SBD_THRUST
-	device_data.Init(adet, bdet, bit_length, static_cast<size_t>(L), helper, I0, I1, I2,
-	                 sbd_data.use_precalculated_dets, sbd_data.max_memory_gb_for_determinants);
+	device_mult.Init(adet, bdet, bit_length, static_cast<size_t>(L),
+					adet_comm_size,bdet_comm_size, helper, I0, I1, I2,
+					h_comm,b_comm,t_comm,
+	                sbd_data.use_precalculated_dets, sbd_data.max_memory_gb_for_determinants);
 	if( method == 0 ) {
-		sbd::Davidson(hii, W, device_data,
-				adet_comm_size, bdet_comm_size,
-				h_comm,b_comm,t_comm,
+		sbd::Davidson(hii, W, device_mult,
 				max_it,max_nb,eps,max_time);
 	} else {
-		sbd::Lanczos(hii, W, device_data,
-				adet_comm_size, bdet_comm_size,
-				h_comm,b_comm,t_comm,
+		sbd::Lanczos(hii, W, device_mult,
 				max_it,max_nb,eps);
 	}
 #else
@@ -284,9 +286,19 @@ namespace sbd {
 
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
 #ifdef SBD_THRUST
-	sbd::mult(hii, W, C, device_data,
-		  adet_comm_size, bdet_comm_size,
-		  h_comm, b_comm, t_comm);
+	// copyin hii
+    thrust::device_vector<double> hii_dev(hii.size());
+    thrust::copy_n(hii.begin(), hii.size(), hii_dev.begin());
+
+    // copyin W
+    thrust::device_vector<double> W_dev(W.size());
+    thrust::copy_n(W.begin(), W.size(), W_dev.begin());
+
+    thrust::device_vector<double> C_dev(C.size(), 0.0);
+
+	device_mult.run(hii_dev, W_dev, C_dev);
+
+	thrust::copy_n(C_dev.begin(), C_dev.size(), C.begin());
 #else
 	sbd::mult(hii,W,C,adet,bdet,bit_length,static_cast<size_t>(L),
 		  adet_comm_size,bdet_comm_size,helper,
@@ -318,15 +330,6 @@ namespace sbd {
 	auto time_start_diag = std::chrono::high_resolution_clock::now();
 	auto time_start_mkham = std::chrono::high_resolution_clock::now();
 	std::vector<double> hii;
-
-#ifdef SBD_THRUST
-	// initialize hii
-	sbd::makeQChamDiagTerms(adet, bdet, bit_length, L,
-				helper, I0, I1, I2, hii,
-				h_comm, b_comm, t_comm);
-	device_data.Init(adet, bdet, bit_length, static_cast<size_t>(L), helper, I0, I1, I2,
- 		             sbd_data.use_precalculated_dets, sbd_data.max_memory_gb_for_determinants);
-#else
 	std::vector<std::vector<size_t*>> ih;
 	std::vector<std::vector<size_t*>> jh;
 	std::vector<std::vector<double*>> hij;
@@ -341,7 +344,6 @@ namespace sbd {
 		       hii,ih,jh,hij,len,tasktype,adetshift,bdetshift,
 		       sharedSizeT,sharedElemT,
 		       h_comm,b_comm,t_comm);
-#endif
     auto time_end_mkham = std::chrono::high_resolution_clock::now();
 	auto elapsed_mkham_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mkham-time_start_mkham).count();
 	double elapsed_mkham = 0.000001 * elapsed_mkham_count;
@@ -351,19 +353,6 @@ namespace sbd {
 
 	auto time_start_davidson = std::chrono::high_resolution_clock::now();
 	sbd::BasisInitVector(W,adet,bdet,adet_comm_size,bdet_comm_size,h_comm,b_comm,t_comm,init);
-#ifdef SBD_THRUST
-	if( method < 2 ) {
-		sbd::Davidson(hii, W, device_data,
-				adet_comm_size, bdet_comm_size,
-				h_comm,b_comm,t_comm,
-				max_it,max_nb,eps,max_time);
-	} else {
-		sbd::Lanczos(hii, W, device_data,
-				adet_comm_size, bdet_comm_size,
-				h_comm,b_comm,t_comm,
-				max_it,max_nb,eps);
-	}
-#else
 	if( method == 1 ) {
 	  sbd::Davidson(hii,ih,jh,hij,len,tasktype,
 			adetshift,bdetshift,adet_comm_size,bdet_comm_size,
@@ -377,7 +366,6 @@ namespace sbd {
 		       h_comm,b_comm,t_comm,
 		       max_it,max_nb,bit_length,eps);
 	}
-#endif
 	auto time_end_davidson = std::chrono::high_resolution_clock::now();
 	auto elapsed_davidson_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_davidson-time_start_davidson).count();
 	double elapsed_davidson = 0.000001 * elapsed_davidson_count;
@@ -399,16 +387,10 @@ namespace sbd {
 	std::vector<double> C(W.size(),0.0);
 
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
-#ifdef SBD_THRUST
-	sbd::mult(hii, W, C, device_data,
-		  adet_comm_size, bdet_comm_size,
-		  h_comm, b_comm, t_comm);
-#else
 	sbd::mult(hii,ih,jh,hij,len,
 		  tasktype,adetshift,bdetshift,
 		  adet_comm_size,bdet_comm_size,
 		  W,C,bit_length,h_comm,b_comm,t_comm);
-#endif
 	auto time_end_mult = std::chrono::high_resolution_clock::now();
 	auto elapsed_mult_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mult-time_start_mult).count();
 	double elapsed_mult = 0.000001 * elapsed_mult_count;
@@ -473,9 +455,7 @@ namespace sbd {
 	auto time_start_meas = std::chrono::high_resolution_clock::now();
 #ifdef SBD_THRUST
 	Correlation(W,
-		adet_comm_size, bdet_comm_size,
-		device_data,
-		h_comm, b_comm, t_comm,
+		device_mult,
 		one_p_rdm,
 	    two_p_rdm);
 #else

--- a/include/sbd/framework/mpi_utility_thrust.h
+++ b/include/sbd/framework/mpi_utility_thrust.h
@@ -22,6 +22,119 @@ void MpiAllreduce(thrust::device_vector<ElemT> &A, MPI_Op op, MPI_Comm comm)
 }
 
 template <typename ElemT>
+void _MpiSlide(const ElemT* A,
+    thrust::device_vector<ElemT>& B,
+    size_t sizeA,
+    int slide,
+    MPI_Comm comm)
+{
+    int mpi_rank;
+    MPI_Comm_rank(comm,&mpi_rank);
+    int mpi_size;
+    MPI_Comm_size(comm,&mpi_size);
+    int mpi_dest   = (mpi_size+mpi_rank+slide) % mpi_size;
+    int mpi_source = (mpi_size+mpi_rank-slide) % mpi_size;
+
+    std::vector<MPI_Request> req_size(2);
+    std::vector<MPI_Status> sta_size(2);
+    std::vector<size_t> size_send(1);
+    std::vector<size_t> size_recv(1);
+    size_send[0] = sizeA;
+    MPI_Isend(size_send.data(),1,SBD_MPI_SIZE_T,mpi_dest,0,comm,&req_size[0]);
+    MPI_Irecv(size_recv.data(),1,SBD_MPI_SIZE_T,mpi_source,0,comm,&req_size[1]);
+    MPI_Waitall(2,req_size.data(),sta_size.data());
+
+    size_t send_size = size_send[0];
+    size_t recv_size = size_recv[0];
+    B.resize(recv_size);
+    std::vector<MPI_Request> req_data(2);
+    std::vector<MPI_Status> sta_data(2);
+
+    MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+    if( send_size != 0 ) {
+        MPI_Isend(A,send_size,DataT,mpi_dest,1,comm,&req_data[0]);
+    }
+    if( recv_size != 0 ) {
+        MPI_Irecv((ElemT*)thrust::raw_pointer_cast(B.data()),recv_size,DataT,mpi_source,1,comm,&req_data[1]);
+    }
+
+    if( send_size != 0 && recv_size != 0 ) {
+        MPI_Waitall(2,req_data.data(),sta_data.data());
+    } else if ( send_size != 0 && recv_size == 0 ) {
+        MPI_Waitall(1,&req_data[0],&sta_data[0]);
+    } else if ( send_size == 0 && recv_size != 0 ) {
+        MPI_Waitall(1,&req_data[1],&sta_data[1]);
+    }
+}
+
+template <typename ElemT>
+void MpiSlide(const thrust::device_vector<ElemT>& A,
+    thrust::device_vector<ElemT>& B,
+    int slide,
+    MPI_Comm comm)
+{
+    _MpiSlide((ElemT*)thrust::raw_pointer_cast(A.data()), B, A.size(), slide, comm);
+}
+
+template <typename ElemT>
+void MpiSlide(const std::vector<ElemT>& A,
+    thrust::device_vector<ElemT>& B,
+    int slide,
+    MPI_Comm comm)
+{
+    _MpiSlide(A.data(), B, A.size(), slide, comm);
+}
+
+
+
+template <>
+void MpiSlide(const thrust::device_vector<size_t> & A,
+    thrust::device_vector<size_t> & B,
+    int slide,
+    MPI_Comm comm)
+{
+    int mpi_rank;
+    MPI_Comm_rank(comm,&mpi_rank);
+    int mpi_size;
+    MPI_Comm_size(comm,&mpi_size);
+    int mpi_dest   = (mpi_size+mpi_rank+slide) % mpi_size;
+    int mpi_source = (mpi_size+mpi_rank-slide) % mpi_size;
+
+    std::vector<MPI_Request> req_size(2);
+    std::vector<MPI_Status> sta_size(2);
+    std::vector<size_t> size_send(1);
+    std::vector<size_t> size_recv(1);
+    size_send[0] = A.size();
+    MPI_Isend(size_send.data(),1,SBD_MPI_SIZE_T,mpi_dest,0,comm,&req_size[0]);
+    MPI_Irecv(size_recv.data(),1,SBD_MPI_SIZE_T,mpi_source,0,comm,&req_size[1]);
+    MPI_Waitall(2,req_size.data(),sta_size.data());
+
+    size_t send_size = size_send[0];
+    size_t recv_size = size_recv[0];
+    B.resize(recv_size);
+    std::vector<MPI_Request> req_data(2);
+    std::vector<MPI_Status> sta_data(2);
+
+    MPI_Datatype DataT = SBD_MPI_SIZE_T;
+    if( send_size != 0 ) {
+        MPI_Isend((size_t*)thrust::raw_pointer_cast(A.data()),send_size,DataT,mpi_dest,1,comm,&req_data[0]);
+    }
+    if( recv_size != 0 ) {
+        MPI_Irecv((size_t*)thrust::raw_pointer_cast(B.data()),recv_size,DataT,mpi_source,1,comm,&req_data[1]);
+    }
+
+    if( send_size != 0 && recv_size != 0 ) {
+        MPI_Waitall(2,req_data.data(),sta_data.data());
+    } else if ( send_size != 0 && recv_size == 0 ) {
+        MPI_Waitall(1,&req_data[0],&sta_data[0]);
+    } else if ( send_size == 0 && recv_size != 0 ) {
+        MPI_Waitall(1,&req_data[1],&sta_data[1]);
+    }
+}
+
+
+
+template <typename ElemT>
 void _Mpi2dSlide(const ElemT* A,
                 thrust::device_vector<ElemT> &B,
                 size_t sizeA,


### PR DESCRIPTION
This PR adds Thrust version of GDB

Also this PR refactors Thrust implementations:
- Moving `davidson_thrust` and `lanczos_thrust` to `sbd/chemistry/basic`
- Adding abstract class for `mult` used in Davidson and Lanczos

With this refactoring, the same Davidson and Lanczos codes can be used from both TPB and GDB