### PR TITLE
Stabilize Thrust code for large data

### DIFF
--- a/include/sbd/chemistry/basic/mult.h
+++ b/include/sbd/chemistry/basic/mult.h
@@ -24,9 +24,9 @@ public:
     MultBase() {}
 
     MultBase(size_t bit_length, size_t norbs, MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm)
-        : bit_length(bit_length), norbs(norbs), h_comm(h_comm), b_comm(b_comm), t_comm(t_comm)
+        : bit_length_(bit_length), norbs_(norbs), h_comm_(h_comm), b_comm_(b_comm), t_comm_(t_comm)
     {
-        D_size_ = (2 * norbs_ + bit_length_ - 1) / bit_length_;
+        D_size_ = (2 * norbs + bit_length - 1) / bit_length;
     }
 
     inline size_t bit_length(void) const

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -161,14 +161,6 @@ public:
             return -1;
         }
         return i;
-
-        /*
-        for(size_t i = BdetToDetOffset[jbst]; i < BdetToDetOffset[jbst + 1]; i++) {
-            if( BdetToAdetSM[i] >= jast) {
-                return (int64_t)i;
-            }
-        }
-        return -1;*/
     }
 
 

--- a/include/sbd/chemistry/tpb/correlation_thrust.h
+++ b/include/sbd/chemistry/tpb/correlation_thrust.h
@@ -39,11 +39,10 @@ public:
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
-                thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                thrust::device_vector<ElemT>& b2
+                ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
@@ -52,11 +51,9 @@ public:
         size_t braAlphaSize = helper.braAlphaEnd - helper.braAlphaStart;
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
 
-        if (i + offset < braAlphaSize * braBetaSize) {
-            if( ((i + offset) % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t* DetI = this->det_I + (i + offset) * this->D_size;
-                this->correlation.ZeroDiffCorrelation(DetI, this->Wb[i + offset]);
-            }
+        if( (i % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t* DetI = this->det_I + i * this->D_size;
+            this->correlation.ZeroDiffCorrelation(DetI, this->Wb[i]);
         }
     }
 };
@@ -67,6 +64,7 @@ class CorrelationInitNoCache : public CorrelationKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     CorrelationInitNoCache(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
@@ -74,10 +72,11 @@ public:
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
                 thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                size_t o, bool pre ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -87,12 +86,17 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
             this->correlation.ZeroDiffCorrelation(DetI, this->Wb[braIdx]);
         }
     }
@@ -104,45 +108,41 @@ class CorrelationAlphaBeta : public CorrelationKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     CorrelationAlphaBeta(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
-                thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                thrust::device_vector<ElemT>& b2
+                ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_single_alpha * helper.size_single_beta) {
-            size_t j = (i + offset) / helper.size_single_beta;
-            size_t k = (i + offset) - j * helper.size_single_beta;
+        size_t j = i / helper.size_single_beta;
+        size_t k = i - j * helper.size_single_beta;
 
-            size_t ia = helper.SinglesFromAlphaBraIndex[j];
-            size_t ja = helper.SinglesFromAlphaKetIndex[j];
-            size_t ib = helper.SinglesFromBetaBraIndex[k];
-            size_t jb = helper.SinglesFromBetaKetIndex[k];
+        size_t ia = helper.SinglesFromAlphaBraIndex[j];
+        size_t ja = helper.SinglesFromAlphaKetIndex[j];
+        size_t ib = helper.SinglesFromBetaBraIndex[k];
+        size_t jb = helper.SinglesFromBetaKetIndex[k];
 
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
-                ElemT WeightI = this->Wb[braIdx];
-                ElemT WeightJ = this->T[ketIdx];
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            ElemT WeightI = this->Wb[braIdx];
+            ElemT WeightJ = this->T[ketIdx];
 
-                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
-                                    helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
-                                    helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
-            }
+            this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                                helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
+                                helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
         }
     }
 };
@@ -153,41 +153,37 @@ class CorrelationSingleAlpha : public CorrelationKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     CorrelationSingleAlpha(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
-                thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                thrust::device_vector<ElemT>& b2
+                ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_single_alpha * (helper.braBetaEnd - helper.braBetaStart)) {
-            size_t k = (i + offset) / helper.size_single_alpha;
-            size_t j = (i + offset) - k * helper.size_single_alpha;
+        size_t k = i / helper.size_single_alpha;
+        size_t j = i - k * helper.size_single_alpha;
 
-            size_t ia = helper.SinglesFromAlphaBraIndex[j];
-            size_t ja = helper.SinglesFromAlphaKetIndex[j];
-            size_t ib = k + helper.braBetaStart;
-            size_t jb = ib;
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = helper.SinglesFromAlphaBraIndex[j];
+        size_t ja = helper.SinglesFromAlphaKetIndex[j];
+        size_t ib = k + helper.braBetaStart;
+        size_t jb = ib;
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
-                ElemT WeightI = this->Wb[braIdx];
-                ElemT WeightJ = this->T[ketIdx];
-                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
-            }
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            ElemT WeightI = this->Wb[braIdx];
+            ElemT WeightJ = this->T[ketIdx];
+            this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
         }
     }
 };
@@ -197,44 +193,40 @@ class CorrelationDoubleAlpha : public CorrelationKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     CorrelationDoubleAlpha(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
-                thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                thrust::device_vector<ElemT>& b2
+                ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_double_alpha * (helper.braBetaEnd - helper.braBetaStart)) {
-            size_t k = (i + offset) / helper.size_double_alpha;
-            size_t j = (i + offset) - k * helper.size_double_alpha;
+        size_t k = i / helper.size_double_alpha;
+        size_t j = i - k * helper.size_double_alpha;
 
-            size_t ia = helper.DoublesFromAlphaBraIndex[j];
-            size_t ja = helper.DoublesFromAlphaKetIndex[j];
-            size_t ib = k + helper.braBetaStart;
-            size_t jb = ib;
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = helper.DoublesFromAlphaBraIndex[j];
+        size_t ja = helper.DoublesFromAlphaKetIndex[j];
+        size_t ib = k + helper.braBetaStart;
+        size_t jb = ib;
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
-                ElemT WeightI = this->Wb[braIdx];
-                ElemT WeightJ = this->T[ketIdx];
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            ElemT WeightI = this->Wb[braIdx];
+            ElemT WeightJ = this->T[ketIdx];
 
-                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
-                                    helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
-                                    helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
-            }
+            this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                                helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
+                                helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
         }
     }
 };
@@ -244,41 +236,37 @@ class CorrelationSingleBeta : public CorrelationKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     CorrelationSingleBeta(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
-                thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                thrust::device_vector<ElemT>& b2
+                ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_single_beta * (helper.braAlphaEnd - helper.braAlphaStart)) {
-            size_t j = (i + offset) / helper.size_single_beta;
-            size_t k = (i + offset) - j * helper.size_single_beta;
+        size_t j = i / helper.size_single_beta;
+        size_t k = i - j * helper.size_single_beta;
 
-            size_t ia = j + helper.braAlphaStart;
-            size_t ja = ia;
-            size_t ib = helper.SinglesFromBetaBraIndex[k];
-            size_t jb = helper.SinglesFromBetaKetIndex[k];
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = j + helper.braAlphaStart;
+        size_t ja = ia;
+        size_t ib = helper.SinglesFromBetaBraIndex[k];
+        size_t jb = helper.SinglesFromBetaKetIndex[k];
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
-                ElemT WeightI = this->Wb[braIdx];
-                ElemT WeightJ = this->T[ketIdx];
-                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
-            }
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            ElemT WeightI = this->Wb[braIdx];
+            ElemT WeightJ = this->T[ketIdx];
+            this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
         }
     }
 };
@@ -288,44 +276,40 @@ class CorrelationDoubleBeta : public CorrelationKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     CorrelationDoubleBeta(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
-                thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                thrust::device_vector<ElemT>& b2
+                ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_double_beta * (helper.braAlphaEnd - helper.braAlphaStart)) {
-            size_t j = (i + offset) / helper.size_double_beta;
-            size_t k = (i + offset) - j * helper.size_double_beta;
+        size_t j = i / helper.size_double_beta;
+        size_t k = i - j * helper.size_double_beta;
 
-            size_t ia = j + helper.braAlphaStart;
-            size_t ja = ia;
-            size_t ib = helper.DoublesFromBetaBraIndex[k];
-            size_t jb = helper.DoublesFromBetaKetIndex[k];
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = j + helper.braAlphaStart;
+        size_t ja = ia;
+        size_t ib = helper.DoublesFromBetaBraIndex[k];
+        size_t jb = helper.DoublesFromBetaKetIndex[k];
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
-                ElemT WeightI = this->Wb[braIdx];
-                ElemT WeightJ = this->T[ketIdx];
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            ElemT WeightI = this->Wb[braIdx];
+            ElemT WeightJ = this->T[ketIdx];
 
-                this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
-                                            helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
-                                            helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
-            }
+            this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
+                                        helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
+                                        helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
         }
     }
 };
@@ -337,6 +321,7 @@ class CorrelationTask0 : public CorrelationKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     CorrelationTask0(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
@@ -344,10 +329,11 @@ public:
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
                 thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                size_t o, bool pre ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -357,12 +343,17 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+             if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
             ElemT WeightI = this->Wb[braIdx];
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
@@ -387,6 +378,7 @@ class CorrelationTask1 : public CorrelationKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     CorrelationTask1(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
@@ -394,10 +386,11 @@ public:
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
                 thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                size_t o, bool pre ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -407,12 +400,17 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+             if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
             ElemT WeightI = this->Wb[braIdx];
 
             for (size_t k = helper.SinglesFromBetaOffset[b]; k < helper.SinglesFromBetaOffset[b + 1]; k++) {
@@ -421,7 +419,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
-                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_alpha]);
+                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
             }
             for (size_t k = helper.DoublesFromBetaOffset[b]; k < helper.DoublesFromBetaOffset[b + 1]; k++) {
                 size_t ja = ia;
@@ -430,8 +428,8 @@ public:
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
                 this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
-                                        helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_alpha],
-                                        helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_alpha], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_alpha]);
+                                        helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
+                                        helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
            }
         }
     }
@@ -443,6 +441,7 @@ class CorrelationTask2 : public CorrelationKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     CorrelationTask2(const TaskHelpersThrust<ElemT>& h,
                 const MultTPBThrust<ElemT>& data,
@@ -450,10 +449,11 @@ public:
                 const thrust::device_vector<ElemT>& v_t,
                 thrust::device_vector<ElemT>& b1,
                 thrust::device_vector<ElemT>& b2,
-                size_t o ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
+                size_t o, bool pre ) : CorrelationKernelBase<ElemT>(data, v_wb, v_t, b1, b2)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -463,12 +463,17 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+             if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
             ElemT WeightI = this->Wb[braIdx];
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
@@ -477,7 +482,7 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
-                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_beta]);
+                this->correlation.OneDiffCorrelation(DetI, WeightI, WeightJ, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
             }
             for (size_t j = helper.DoublesFromAlphaOffset[a]; j < helper.DoublesFromAlphaOffset[a + 1]; j++) {
                 size_t ja = helper.DoublesFromAlphaKetIndex[j];
@@ -486,8 +491,8 @@ public:
                                 + jb - helper.ketBetaStart;
                 ElemT WeightJ = this->T[ketIdx];
                 this->correlation.TwoDiffCorrelation(DetI, WeightI, WeightJ,
-                                    helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_beta],
-                                    helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_beta], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_beta]);
+                                    helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
+                                    helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
             }
         }
     }
@@ -497,40 +502,39 @@ public:
     Function to evaluate the two-particle correlation functions
 */
 template <typename ElemT>
-void Correlation(const std::vector<ElemT> &W_in,
-                    MultTPBThrust<ElemT>& data,
+void MultTPBThrust<ElemT>::correlation(const std::vector<ElemT> &W_in,
                     std::vector<std::vector<ElemT>> &onebody_out,
                     std::vector<std::vector<ElemT>> &twobody_out)
 {
-    thrust::device_vector<ElemT> onebody(data.norbs() * data.norbs() * 2, ElemT(0.0));
-    thrust::device_vector<ElemT> twobody(data.norbs() * data.norbs() * data.norbs() * data.norbs() * 4, ElemT(0.0));
+    thrust::device_vector<ElemT> onebody(this->norbs() * this->norbs() * 2, ElemT(0.0));
+    thrust::device_vector<ElemT> twobody(this->norbs() * this->norbs() * this->norbs() * this->norbs() * 4, ElemT(0.0));
 
     int mpi_rank_h = 0;
     int mpi_size_h = 1;
-    MPI_Comm_rank(data.h_comm(), &mpi_rank_h);
-    MPI_Comm_size(data.h_comm(), &mpi_size_h);
+    MPI_Comm_rank(this->h_comm(), &mpi_rank_h);
+    MPI_Comm_size(this->h_comm(), &mpi_size_h);
 
     int mpi_size_b;
-    MPI_Comm_size(data.b_comm(), &mpi_size_b);
+    MPI_Comm_size(this->b_comm(), &mpi_size_b);
     int mpi_rank_b;
-    MPI_Comm_rank(data.b_comm(), &mpi_rank_b);
+    MPI_Comm_rank(this->b_comm(), &mpi_rank_b);
     int mpi_size_t;
-    MPI_Comm_size(data.t_comm(), &mpi_size_t);
+    MPI_Comm_size(this->t_comm(), &mpi_size_t);
     int mpi_rank_t;
-    MPI_Comm_rank(data.t_comm(), &mpi_rank_t);
+    MPI_Comm_rank(this->t_comm(), &mpi_rank_t);
     size_t braAlphaSize = 0;
     size_t braBetaSize = 0;
-    if (data.helper.size() != 0) {
-        braAlphaSize = data.helper[0].braAlphaEnd - data.helper[0].braAlphaStart;
-        braBetaSize = data.helper[0].braBetaEnd - data.helper[0].braBetaStart;
+    if (helper.size() != 0) {
+        braAlphaSize = helper[0].braAlphaEnd - helper[0].braAlphaStart;
+        braBetaSize = helper[0].braBetaEnd - helper[0].braBetaStart;
     }
 
     size_t adet_min = 0;
-    size_t adet_max = data.adets.size();
+    size_t adet_max = adets.size();
     size_t bdet_min = 0;
-    size_t bdet_max = data.bdets.size();
-    get_mpi_range(data.adet_comm_size,0,adet_min,adet_max);
-    get_mpi_range(data.bdet_comm_size,0,bdet_min,bdet_max);
+    size_t bdet_max = bdets.size();
+    get_mpi_range(adet_comm_size,0,adet_min,adet_max);
+    get_mpi_range(bdet_comm_size,0,bdet_min,bdet_max);
     size_t max_det_size = (adet_max-adet_min)*(bdet_max-bdet_min);
 
     thrust::device_vector<ElemT> T(max_det_size);
@@ -538,43 +542,40 @@ void Correlation(const std::vector<ElemT> &W_in,
     thrust::device_vector<ElemT> W(W_in.size());
     thrust::copy_n(W_in.begin(), W_in.size(), W.begin());
 
-    if (data.helper.size() != 0) {
-        Mpi2dSlide(W, T, data.adet_comm_size, data.bdet_comm_size,
-                    -data.helper[0].adetShift, -data.helper[0].bdetShift, data.b_comm());
+    if (helper.size() != 0) {
+        Mpi2dSlide(W, T, adet_comm_size, bdet_comm_size,
+                    -helper[0].adetShift, -helper[0].bdetShift, this->b_comm());
     }
 
     size_t offset = 0;
     size_t size = 0;
     if (mpi_rank_t == 0) {
-        if (data.use_precalculated_dets) {
+        if (use_precalculated_dets && collapse_loop) {
             // precalculate DetI (if update needed)
-            data.UpdateDet(0);
+            UpdateDet(0);
 
-            offset = 0;
             size = braAlphaSize * braBetaSize;
-            while (offset < size) {
-                size_t num_threads = data.num_max_threads;
-                if (offset + num_threads > size) {
-                    num_threads = size - offset;
-                }
+            CorrelationInit kernel(helper[0], *this, W, T, onebody, twobody);
+            kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                CorrelationInit kernel(data.helper[0], data, W, T, onebody, twobody, offset);
-                kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                auto ci = thrust::counting_iterator<size_t>(0);
-                thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                offset += num_threads;
-            }
+            auto ci = thrust::counting_iterator<size_t>(0);
+            thrust::for_each_n(thrust::device, ci, size, kernel);
         } else {
-            offset = 0;
             size = braAlphaSize * braBetaSize;
+            if (use_precalculated_dets) {
+                num_max_threads = size;
+                // precalculate DetI (if update needed)
+                UpdateDet(0);
+            }
+
+            offset = 0;
             while (offset < size) {
-                size_t num_threads = data.num_max_threads;
+                size_t num_threads = num_max_threads;
                 if (offset + num_threads > size) {
                     num_threads = size - offset;
                 }
 
-                CorrelationInitNoCache kernel(data.helper[0], data, W, T, onebody, twobody, offset);
+                CorrelationInitNoCache kernel(helper[0], *this, W, T, onebody, twobody, offset, use_precalculated_dets);
                 kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                 auto ci = thrust::counting_iterator<size_t>(0);
@@ -584,73 +585,82 @@ void Correlation(const std::vector<ElemT> &W_in,
         }
     }
 
-    for (size_t task = 0; task < data.helper.size(); task++) {
-        size_t ketAlphaSize = data.helper[task].ketAlphaEnd - data.helper[task].ketAlphaStart;
-        size_t ketBetaSize = data.helper[task].ketBetaEnd - data.helper[task].ketBetaStart;
+    for (size_t task = 0; task < helper.size(); task++) {
+        size_t ketAlphaSize = helper[task].ketAlphaEnd - helper[task].ketAlphaStart;
+        size_t ketBetaSize = helper[task].ketBetaEnd - helper[task].ketBetaStart;
 
-        if (data.use_precalculated_dets) {
+        if (use_precalculated_dets && collapse_loop) {
             // precalculate DetI (if update needed)
-            data.UpdateDet(task);
+            UpdateDet(task);
 
-            if (data.helper[task].taskType == 2) { // beta range are same
-                offset = 0;
-                size = data.helper[task].size_single_alpha * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
+            if (helper[task].taskType == 2) { // beta range are same
+                size = helper[task].size_single_alpha * braBetaSize;
+                CorrelationSingleAlpha single_kernel(helper[task], *this, W, T, onebody, twobody);
+                single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                    CorrelationSingleAlpha kernel(data.helper[task], data, W, T, onebody, twobody, offset);
-                    kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+                auto cis = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cis, size, single_kernel);
 
-                    auto ci = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                    offset += num_threads;
-                }
+                size = helper[task].size_double_alpha * braBetaSize;
+                CorrelationDoubleAlpha double_kernel(helper[task], *this, W, T, onebody, twobody);
+                double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                offset = 0;
-                size = data.helper[task].size_double_alpha * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
-
-                    CorrelationDoubleAlpha kernel(data.helper[task], data, W, T, onebody, twobody, offset);
-                    kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                    auto ci = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                    offset += num_threads;
-                }
+                auto cid = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cid, size, double_kernel);
             }
-            else if (data.helper[task].taskType == 1) {
+            else if (helper[task].taskType == 1) {
+                size = helper[task].size_single_beta * braAlphaSize;
+                CorrelationSingleBeta single_kernel(helper[task], *this, W, T, onebody, twobody);
+                single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+                auto cis = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cis, size, single_kernel);
+
+                size = helper[task].size_double_beta * braAlphaSize;
+                CorrelationDoubleBeta double_kernel(helper[task], *this, W, T, onebody, twobody);
+                double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+                auto cid = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cid, size, double_kernel);
+            } else {
+                size = helper[task].size_single_alpha * helper[task].size_single_beta;
+                CorrelationAlphaBeta kernel(helper[task], *this, W, T, onebody, twobody);
+                kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+
+                auto ci = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, ci, size, kernel);
+            }
+        } else {    // no collapse
+            size = braAlphaSize * braBetaSize;
+            if (use_precalculated_dets) {
+                num_max_threads = size;
+                // precalculate DetI (if update needed)
+                UpdateDet(0);
+            }
+
+            if (helper[task].taskType == 2) {
                 offset = 0;
-                size = data.helper[task].size_single_beta * braAlphaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
-
-                    CorrelationSingleBeta kernel(data.helper[task], data, W, T, onebody, twobody, offset);
+                    CorrelationTask2 kernel(helper[task], *this, W, T, onebody, twobody, offset, use_precalculated_dets);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
                     thrust::for_each_n(thrust::device, ci, num_threads, kernel);
                     offset += num_threads;
                 }
-
+            } else if(helper[task].taskType == 1) {
                 offset = 0;
-                size = data.helper[task].size_double_beta * braAlphaSize;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    CorrelationDoubleBeta kernel(data.helper[task], data, W, T, onebody, twobody, offset);
+                    CorrelationTask1 kernel(helper[task], *this, W, T, onebody, twobody, offset, use_precalculated_dets);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -659,63 +669,13 @@ void Correlation(const std::vector<ElemT> &W_in,
                 }
             } else {
                 offset = 0;
-                size = data.helper[task].size_single_alpha * data.helper[task].size_single_beta;
                 while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
+                    size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    CorrelationAlphaBeta kernel(data.helper[task], data, W, T, onebody, twobody, offset);
-                    kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                    auto ci = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                    offset += num_threads;
-                }
-            } // if ( helper[task].taskType ==  )
-        } else {    // no det cache
-            if (data.helper[task].taskType == 2) {
-                offset = 0;
-                size = braAlphaSize * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
-                    CorrelationTask2 kernel(data.helper[task], data, W, T, onebody, twobody, offset);
-                    kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                    auto ci = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                    offset += num_threads;
-                }
-            } else if(data.helper[task].taskType == 1) {
-                offset = 0;
-                size = braAlphaSize * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
-
-                    CorrelationTask1 kernel(data.helper[task], data, W, T, onebody, twobody, offset);
-                    kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                    auto ci = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                    offset += num_threads;
-                }
-            } else {
-                offset = 0;
-                size = braAlphaSize * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = data.num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
-
-                    CorrelationTask0 kernel(data.helper[task], data, W, T, onebody, twobody, offset);
+                    CorrelationTask0 kernel(helper[task], *this, W, T, onebody, twobody, offset, use_precalculated_dets);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -725,33 +685,33 @@ void Correlation(const std::vector<ElemT> &W_in,
             }
         }
 
-        if (data.helper[task].taskType == 0 && task != data.helper.size() - 1) {
-            int adetslide = data.helper[task].adetShift - data.helper[task + 1].adetShift;
-            int bdetslide = data.helper[task].bdetShift - data.helper[task + 1].bdetShift;
+        if (helper[task].taskType == 0 && task != helper.size() - 1) {
+            int adetslide = helper[task].adetShift - helper[task + 1].adetShift;
+            int bdetslide = helper[task].bdetShift - helper[task + 1].bdetShift;
             R.resize(T.size());
             R = T;
-            Mpi2dSlide(R, T, data.adet_comm_size, data.bdet_comm_size, adetslide, bdetslide, data.b_comm());
+            Mpi2dSlide(R, T, adet_comm_size, bdet_comm_size, adetslide, bdetslide, this->b_comm());
         }
     } // end for(size_t task=0; task < helper.size(); task++)
 
     if (mpi_size_b > 1)
-        MpiAllreduce(onebody, MPI_SUM, data.b_comm());
+        MpiAllreduce(onebody, MPI_SUM, this->b_comm());
     if (mpi_size_t > 1)
-        MpiAllreduce(onebody, MPI_SUM, data.t_comm());
+        MpiAllreduce(onebody, MPI_SUM, this->t_comm());
     if (mpi_size_h > 1)
-        MpiAllreduce(onebody, MPI_SUM, data.h_comm());
+        MpiAllreduce(onebody, MPI_SUM, this->h_comm());
 
     if (mpi_size_b > 1)
-        MpiAllreduce(twobody, MPI_SUM, data.b_comm());
+        MpiAllreduce(twobody, MPI_SUM, this->b_comm());
     if (mpi_size_t > 1)
-        MpiAllreduce(twobody, MPI_SUM, data.t_comm());
+        MpiAllreduce(twobody, MPI_SUM, this->t_comm());
     if (mpi_size_h > 1)
-        MpiAllreduce(twobody, MPI_SUM, data.h_comm());
+        MpiAllreduce(twobody, MPI_SUM, this->h_comm());
 
 
     // copy out onebody, twobody
     onebody_out.resize(2);
-    size = data.norbs() * data.norbs();
+    size = this->norbs() * this->norbs();
     offset = 0;
     for(int s=0; s < 2; s++) {
         onebody_out[s].resize(size, ElemT(0.0));
@@ -760,7 +720,7 @@ void Correlation(const std::vector<ElemT> &W_in,
     }
 
     twobody_out.resize(4);
-    size = data.norbs() * data.norbs() * data.norbs() * data.norbs();
+    size = this->norbs() * this->norbs() * this->norbs() * this->norbs();
     offset = 0;
     for(int s=0; s < 4; s++) {
         twobody_out[s].resize(size, ElemT(0.0));

--- a/include/sbd/chemistry/tpb/helper_thrust.h
+++ b/include/sbd/chemistry/tpb/helper_thrust.h
@@ -114,40 +114,57 @@ public:
 
         size_t size = 0;
         size_t size_cran = 0;
-        // storage for offsets
-        if (store_offset) {
-            size += ((braAlphaSize + 1) + (braBetaSize + 1)) * 2;
-        }
 
         size_single_alpha = 0;
         size_double_alpha = 0;
         size_single_beta = 0;
         size_double_beta = 0;
+
         std::vector<size_t> offset_single_alpha(braAlphaSize + 1);
         std::vector<size_t> offset_double_alpha(braAlphaSize + 1);
-        for(size_t i=0; i < braAlphaSize; i++) {
-            offset_single_alpha[i] = size_single_alpha;
-            offset_double_alpha[i] = size_double_alpha;
-            size_single_alpha += helper.SinglesFromAlphaLen[i];
-            size_double_alpha += helper.DoublesFromAlphaLen[i];
+        if (taskType != 1) {
+            for(size_t i=0; i < braAlphaSize; i++) {
+                offset_single_alpha[i] = size_single_alpha;
+                size_single_alpha += helper.SinglesFromAlphaLen[i];
+                if (taskType == 2) {
+                    offset_double_alpha[i] = size_double_alpha;
+                    size_double_alpha += helper.DoublesFromAlphaLen[i];
+                }
+            }
+            offset_single_alpha[braAlphaSize] = size_single_alpha;
+            offset_double_alpha[braAlphaSize] = size_double_alpha;
+            size += size_single_alpha + size_double_alpha;
+            size_cran += size_single_alpha * 2 + size_double_alpha * 4;
+
+            if (store_offset) {
+                size += (braAlphaSize + 1);
+                if (taskType == 2)
+                    size += (braAlphaSize + 1);
+            }
         }
-        offset_single_alpha[braAlphaSize] = size_single_alpha;
-        offset_double_alpha[braAlphaSize] = size_double_alpha;
-        size += size_single_alpha + size_double_alpha;
-        size_cran += size_single_alpha * 2 + size_double_alpha * 4;
 
         std::vector<size_t> offset_single_beta(braBetaSize + 1);
         std::vector<size_t> offset_double_beta(braBetaSize + 1);
-        for(size_t i=0; i < braBetaSize; i++) {
-            offset_single_beta[i] = size_single_beta;
-            offset_double_beta[i] = size_double_beta;
-            size_single_beta += helper.SinglesFromBetaLen[i];
-            size_double_beta += helper.DoublesFromBetaLen[i];
+        if (taskType != 2) {
+            for(size_t i=0; i < braBetaSize; i++) {
+                offset_single_beta[i] = size_single_beta;
+                size_single_beta += helper.SinglesFromBetaLen[i];
+                if (taskType == 1) {
+                    offset_double_beta[i] = size_double_beta;
+                    size_double_beta += helper.DoublesFromBetaLen[i];
+                }
+            }
+            offset_single_beta[braBetaSize] = size_single_beta;
+            offset_double_beta[braBetaSize] = size_double_beta;
+            size += size_single_beta + size_double_beta;
+            size_cran += size_single_beta * 2 + size_double_beta * 4;
+
+            if (store_offset) {
+                size += (braBetaSize + 1);
+                if (taskType == 1)
+                    size += (braBetaSize + 1);
+            }
         }
-        offset_single_beta[braBetaSize] = size_single_beta;
-        offset_double_beta[braBetaSize] = size_double_beta;
-        size += size_single_beta + size_double_beta;
-        size_cran += size_single_beta * 2 + size_double_beta * 4;
 
         if (!store_offset)
             size *= 2;
@@ -156,83 +173,99 @@ public:
 
         size_t count = 0;
         if (store_offset) {
-            // store offsets for non-balanced
-            SinglesFromAlphaOffset = base_memory + count;
-            thrust::copy_n(offset_single_alpha.begin(), braAlphaSize + 1, storage.begin() + count);
-            count += braAlphaSize + 1;
+            // store offsets for non-collapsed loop calculation
+            if (taskType != 1) {
+                SinglesFromAlphaOffset = base_memory + count;
+                thrust::copy_n(offset_single_alpha.begin(), braAlphaSize + 1, storage.begin() + count);
+                count += braAlphaSize + 1;
 
-            DoublesFromAlphaOffset = base_memory + count;
-            thrust::copy_n(offset_double_alpha.begin(), braAlphaSize + 1, storage.begin() + count);
-            count += braAlphaSize + 1;
+                if (taskType == 2) {
+                    DoublesFromAlphaOffset = base_memory + count;
+                    thrust::copy_n(offset_double_alpha.begin(), braAlphaSize + 1, storage.begin() + count);
+                    count += braAlphaSize + 1;
+                }
+            }
 
-            SinglesFromBetaOffset = base_memory + count;
-            thrust::copy_n(offset_single_beta.begin(), braBetaSize + 1, storage.begin() + count);
-            count += braBetaSize + 1;
+            if (taskType != 2) {
+                SinglesFromBetaOffset = base_memory + count;
+                thrust::copy_n(offset_single_beta.begin(), braBetaSize + 1, storage.begin() + count);
+                count += braBetaSize + 1;
 
-            DoublesFromBetaOffset = base_memory + count;
-            thrust::copy_n(offset_double_beta.begin(), braBetaSize + 1, storage.begin() + count);
-            count += braBetaSize + 1;
+                if (taskType == 1) {
+                    DoublesFromBetaOffset = base_memory + count;
+                    thrust::copy_n(offset_double_beta.begin(), braBetaSize + 1, storage.begin() + count);
+                    count += braBetaSize + 1;
+                }
+            }
         }
 
-        if (store_offset) {
-            SinglesFromAlphaKetIndex = base_memory + count;
-        } else {
-            SinglesFromAlphaBraIndex = base_memory + count + size_single_alpha;
-            SinglesFromAlphaKetIndex = base_memory + count;
-        }
-        for(size_t i=0; i < braAlphaSize; i++) {
-            thrust::copy_n(helper.SinglesFromAlphaSM[i], helper.SinglesFromAlphaLen[i], storage.begin() + count + offset_single_alpha[i]);
+        if (taskType != 1) {
+            if (store_offset) {
+                SinglesFromAlphaKetIndex = base_memory + count;
+            } else {
+                SinglesFromAlphaBraIndex = base_memory + count + size_single_alpha;
+                SinglesFromAlphaKetIndex = base_memory + count;
+            }
+            for(size_t i=0; i < braAlphaSize; i++) {
+                thrust::copy_n(helper.SinglesFromAlphaSM[i], helper.SinglesFromAlphaLen[i], storage.begin() + count + offset_single_alpha[i]);
+                if (!store_offset)
+                    thrust::fill_n(storage.begin() + size_single_alpha + count + offset_single_alpha[i], helper.SinglesFromAlphaLen[i], i + helper.braAlphaStart);
+            }
             if (!store_offset)
-                thrust::fill_n(storage.begin() + size_single_alpha + count + offset_single_alpha[i], helper.SinglesFromAlphaLen[i], i + helper.braAlphaStart);
-        }
-        if (!store_offset)
+                count += size_single_alpha;
             count += size_single_alpha;
-        count += size_single_alpha;
 
-        if (store_offset) {
-            DoublesFromAlphaKetIndex = base_memory + count;
-        } else {
-            DoublesFromAlphaBraIndex = base_memory + count + size_double_alpha;
-            DoublesFromAlphaKetIndex = base_memory + count;
+            if (taskType == 2) {
+                if (store_offset) {
+                    DoublesFromAlphaKetIndex = base_memory + count;
+                } else {
+                    DoublesFromAlphaBraIndex = base_memory + count + size_double_alpha;
+                    DoublesFromAlphaKetIndex = base_memory + count;
+                }
+                for(size_t i=0; i < braAlphaSize; i++) {
+                    thrust::copy_n(helper.DoublesFromAlphaSM[i], helper.DoublesFromAlphaLen[i], storage.begin() + count + offset_double_alpha[i]);
+                    if (!store_offset)
+                        thrust::fill_n(storage.begin() + count + size_double_alpha + offset_double_alpha[i], helper.DoublesFromAlphaLen[i], i + helper.braAlphaStart);
+                }
+                if (!store_offset)
+                    count += size_double_alpha;
+                count += size_double_alpha;
+            }
         }
-        for(size_t i=0; i < braAlphaSize; i++) {
-            thrust::copy_n(helper.DoublesFromAlphaSM[i], helper.DoublesFromAlphaLen[i], storage.begin() + count + offset_double_alpha[i]);
-            if (!store_offset)
-                thrust::fill_n(storage.begin() + count + size_double_alpha + offset_double_alpha[i], helper.DoublesFromAlphaLen[i], i + helper.braAlphaStart);
-        }
-        if (!store_offset)
-            count += size_double_alpha;
-        count += size_double_alpha;
 
-        if (store_offset) {
-            SinglesFromBetaKetIndex = base_memory + count;
-        } else {
-            SinglesFromBetaBraIndex = base_memory + count + size_single_beta;
-            SinglesFromBetaKetIndex = base_memory + count;
-        }
-        for(size_t i=0; i < braBetaSize; i++) {
-            thrust::copy_n(helper.SinglesFromBetaSM[i], helper.SinglesFromBetaLen[i], storage.begin() + count + offset_single_beta[i]);
+        if (taskType != 2) {
+            if (store_offset) {
+                SinglesFromBetaKetIndex = base_memory + count;
+            } else {
+                SinglesFromBetaBraIndex = base_memory + count + size_single_beta;
+                SinglesFromBetaKetIndex = base_memory + count;
+            }
+            for(size_t i=0; i < braBetaSize; i++) {
+                thrust::copy_n(helper.SinglesFromBetaSM[i], helper.SinglesFromBetaLen[i], storage.begin() + count + offset_single_beta[i]);
+                if (!store_offset)
+                    thrust::fill_n(storage.begin() + count + size_single_beta + offset_single_beta[i], helper.SinglesFromBetaLen[i], i + helper.braBetaStart);
+            }
             if (!store_offset)
-                thrust::fill_n(storage.begin() + count + size_single_beta + offset_single_beta[i], helper.SinglesFromBetaLen[i], i + helper.braBetaStart);
-        }
-        if (!store_offset)
+                count += size_single_beta;
             count += size_single_beta;
-        count += size_single_beta;
 
-        if (store_offset) {
-            DoublesFromBetaKetIndex = base_memory + count;
-        } else {
-            DoublesFromBetaBraIndex = base_memory + count + size_double_beta;
-            DoublesFromBetaKetIndex = base_memory + count;
+            if (taskType == 1) {
+                if (store_offset) {
+                    DoublesFromBetaKetIndex = base_memory + count;
+                } else {
+                    DoublesFromBetaBraIndex = base_memory + count + size_double_beta;
+                    DoublesFromBetaKetIndex = base_memory + count;
+                }
+                for(size_t i=0; i < braBetaSize; i++) {
+                    thrust::copy_n(helper.DoublesFromBetaSM[i], helper.DoublesFromBetaLen[i], storage.begin() + count + offset_double_beta[i]);
+                    if (!store_offset)
+                        thrust::fill_n(storage.begin() + count + size_double_beta + offset_double_beta[i], helper.DoublesFromBetaLen[i], i + helper.braBetaStart);
+                }
+                if (!store_offset)
+                    count += size_double_beta;
+                count += size_double_beta;
+            }
         }
-        for(size_t i=0; i < braBetaSize; i++) {
-            thrust::copy_n(helper.DoublesFromBetaSM[i], helper.DoublesFromBetaLen[i], storage.begin() + count + offset_double_beta[i]);
-            if (!store_offset)
-                thrust::fill_n(storage.begin() + count + size_double_beta + offset_double_beta[i], helper.DoublesFromBetaLen[i], i + helper.braBetaStart);
-        }
-        if (!store_offset)
-            count += size_double_beta;
-        count += size_double_beta;
 
         // convert CrAn from AoS to SoA
         size_t count_cran = 0;
@@ -241,57 +274,65 @@ public:
         cran_storage.resize(size_cran);
         base_cran = (int*)thrust::raw_pointer_cast(cran_storage.data());
 
-        SinglesAlphaCrAnSM = base_cran + count_cran;
-        buf.resize(size_single_alpha * 2);
+        if (taskType != 1) {
+            SinglesAlphaCrAnSM = base_cran + count_cran;
+            buf.resize(size_single_alpha * 2);
 #pragma omp parallel for
-        for(size_t i=0; i < braAlphaSize; i++) {
-            for (int j=0; j < helper.SinglesFromAlphaLen[i]; j++) {
-                buf[offset_single_alpha[i] + j] = helper.SinglesAlphaCrAnSM[i][j * 2];
-                buf[size_single_alpha + offset_single_alpha[i] + j] = helper.SinglesAlphaCrAnSM[i][j * 2 + 1];
+            for(size_t i=0; i < braAlphaSize; i++) {
+                for (int j=0; j < helper.SinglesFromAlphaLen[i]; j++) {
+                    buf[offset_single_alpha[i] + j] = helper.SinglesAlphaCrAnSM[i][j * 2];
+                    buf[size_single_alpha + offset_single_alpha[i] + j] = helper.SinglesAlphaCrAnSM[i][j * 2 + 1];
+                }
             }
-        }
-        thrust::copy_n(buf.begin(), size_single_alpha * 2, cran_storage.begin() + count_cran);
-        count_cran += size_single_alpha * 2;
+            thrust::copy_n(buf.begin(), size_single_alpha * 2, cran_storage.begin() + count_cran);
+            count_cran += size_single_alpha * 2;
 
-        DoublesAlphaCrAnSM = base_cran + count_cran;
-        buf.resize(size_double_alpha * 4);
+            if (taskType == 2) {
+                DoublesAlphaCrAnSM = base_cran + count_cran;
+                buf.resize(size_double_alpha * 4);
 #pragma omp parallel for
-        for(size_t i=0; i < braAlphaSize; i++) {
-            for (int j=0; j < helper.DoublesFromAlphaLen[i]; j++) {
-                buf[offset_double_alpha[i] + j] = helper.DoublesAlphaCrAnSM[i][j * 4];
-                buf[offset_double_alpha[i] + j + size_double_alpha] = helper.DoublesAlphaCrAnSM[i][j * 4 + 1];
-                buf[offset_double_alpha[i] + j + size_double_alpha * 2] = helper.DoublesAlphaCrAnSM[i][j * 4 + 2];
-                buf[offset_double_alpha[i] + j + size_double_alpha * 3] = helper.DoublesAlphaCrAnSM[i][j * 4 + 3];
+                for(size_t i=0; i < braAlphaSize; i++) {
+                    for (int j=0; j < helper.DoublesFromAlphaLen[i]; j++) {
+                        buf[offset_double_alpha[i] + j] = helper.DoublesAlphaCrAnSM[i][j * 4];
+                        buf[offset_double_alpha[i] + j + size_double_alpha] = helper.DoublesAlphaCrAnSM[i][j * 4 + 1];
+                        buf[offset_double_alpha[i] + j + size_double_alpha * 2] = helper.DoublesAlphaCrAnSM[i][j * 4 + 2];
+                        buf[offset_double_alpha[i] + j + size_double_alpha * 3] = helper.DoublesAlphaCrAnSM[i][j * 4 + 3];
+                    }
+                }
+                thrust::copy_n(buf.begin(), size_double_alpha * 4, cran_storage.begin() + count_cran);
+                count_cran += size_double_alpha * 4;
             }
         }
-        thrust::copy_n(buf.begin(), size_double_alpha * 4, cran_storage.begin() + count_cran);
-        count_cran += size_double_alpha * 4;
 
-        SinglesBetaCrAnSM = base_cran + count_cran;
-        buf.resize(size_single_beta * 2);
+        if (taskType != 2) {
+            SinglesBetaCrAnSM = base_cran + count_cran;
+            buf.resize(size_single_beta * 2);
 #pragma omp parallel for
-        for(size_t i=0; i < braBetaSize; i++) {
-            for (int j=0; j < helper.SinglesFromBetaLen[i]; j++) {
-                buf[offset_single_beta[i] + j] = helper.SinglesBetaCrAnSM[i][j * 2];
-                buf[size_single_beta + offset_single_beta[i] + j] = helper.SinglesBetaCrAnSM[i][j * 2 + 1];
+            for(size_t i=0; i < braBetaSize; i++) {
+                for (int j=0; j < helper.SinglesFromBetaLen[i]; j++) {
+                    buf[offset_single_beta[i] + j] = helper.SinglesBetaCrAnSM[i][j * 2];
+                    buf[size_single_beta + offset_single_beta[i] + j] = helper.SinglesBetaCrAnSM[i][j * 2 + 1];
+                }
             }
-        }
-        thrust::copy_n(buf.begin(), size_single_beta * 2, cran_storage.begin() + count_cran);
-        count_cran += size_single_beta * 2;
+            thrust::copy_n(buf.begin(), size_single_beta * 2, cran_storage.begin() + count_cran);
+            count_cran += size_single_beta * 2;
 
-        DoublesBetaCrAnSM = base_cran + count_cran;
-        buf.resize(size_double_beta * 4);
+            if (taskType == 1) {
+                DoublesBetaCrAnSM = base_cran + count_cran;
+                buf.resize(size_double_beta * 4);
 #pragma omp parallel for
-        for(size_t i=0; i < braBetaSize; i++) {
-            for (int j=0; j < helper.DoublesFromBetaLen[i]; j++) {
-                buf[offset_double_beta[i] + j] = helper.DoublesBetaCrAnSM[i][j * 4];
-                buf[offset_double_beta[i] + j + size_double_beta] = helper.DoublesBetaCrAnSM[i][j * 4 + 1];
-                buf[offset_double_beta[i] + j + size_double_beta * 2] = helper.DoublesBetaCrAnSM[i][j * 4 + 2];
-                buf[offset_double_beta[i] + j + size_double_beta * 3] = helper.DoublesBetaCrAnSM[i][j * 4 + 3];
+                for(size_t i=0; i < braBetaSize; i++) {
+                    for (int j=0; j < helper.DoublesFromBetaLen[i]; j++) {
+                        buf[offset_double_beta[i] + j] = helper.DoublesBetaCrAnSM[i][j * 4];
+                        buf[offset_double_beta[i] + j + size_double_beta] = helper.DoublesBetaCrAnSM[i][j * 4 + 1];
+                        buf[offset_double_beta[i] + j + size_double_beta * 2] = helper.DoublesBetaCrAnSM[i][j * 4 + 2];
+                        buf[offset_double_beta[i] + j + size_double_beta * 3] = helper.DoublesBetaCrAnSM[i][j * 4 + 3];
+                    }
+                }
+                thrust::copy_n(buf.begin(), size_double_beta * 4, cran_storage.begin() + count_cran);
+                count_cran += size_double_beta * 4;
             }
         }
-        thrust::copy_n(buf.begin(), size_double_beta * 4, cran_storage.begin() + count_cran);
-        count_cran += size_double_beta * 4;
     }
 };
 

--- a/include/sbd/chemistry/tpb/mult_thrust.h
+++ b/include/sbd/chemistry/tpb/mult_thrust.h
@@ -43,7 +43,8 @@ public:
     std::vector<thrust::device_vector<int>> CrAn_storage;
     size_t num_max_threads;
     std::vector<TaskHelpersThrust<ElemT>> helper;
-    bool use_precalculated_dets;
+    bool use_precalculated_dets = true;
+    bool collapse_loop = true;
     int max_memory_gb_for_determinants;
     size_t adet_comm_size;
     size_t bdet_comm_size;
@@ -65,7 +66,8 @@ public:
         MPI_Comm b_comm_in,
         MPI_Comm t_comm_in,
         bool use_pre_dets,
-        int max_gb_dets);
+        int max_gb_dets,
+        bool collapse);
 
     void UpdateDet(size_t task);
 
@@ -74,6 +76,10 @@ public:
                     thrust::device_vector<ElemT> &Wb) override;
 
     void makeQChamDiagTerms(thrust::device_vector<ElemT> &hii);
+
+	void correlation(const std::vector<ElemT> & w,
+				std::vector<std::vector<ElemT>> & onebody_out,
+				std::vector<std::vector<ElemT>> & twobody_out);
 };
 
 // contructor for Mult data
@@ -93,7 +99,8 @@ void MultTPBThrust<ElemT>::Init(
 	MPI_Comm b_comm_in,
 	MPI_Comm t_comm_in,
     bool use_pre_dets,
-    int max_gb_dets)
+    int max_gb_dets,
+    bool collapse)
 {
     this->bit_length_ = bit_length_in;
     this->norbs_ = norbs_in;
@@ -134,13 +141,14 @@ void MultTPBThrust<ElemT>::Init(
 
     use_precalculated_dets = use_pre_dets;
     max_memory_gb_for_determinants = max_gb_dets;
+    collapse_loop = collapse;
 
     // copyin helpers
     helper.clear();
     helper_storage.resize(helper_in.size());
     CrAn_storage.resize(helper_in.size());
     for (size_t task = 0; task < helper_in.size(); task++) {
-        helper.push_back(TaskHelpersThrust<ElemT>(helper_storage[task], CrAn_storage[task], helper_in[task], !use_precalculated_dets));
+        helper.push_back(TaskHelpersThrust<ElemT>(helper_storage[task], CrAn_storage[task], helper_in[task], (!use_precalculated_dets) || (!collapse_loop)));
 
         adets_size = std::max(adets_size, helper[task].braAlphaEnd - helper[task].braAlphaStart);
         bdets_size = std::max(bdets_size, helper[task].braBetaEnd - helper[task].braBetaStart);
@@ -158,17 +166,47 @@ void MultTPBThrust<ElemT>::Init(
 
     dets_size = 0;
     if (use_precalculated_dets) {
-        for (size_t task = 0; task < helper.size(); task++) {
-            size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
-            size_t braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
-            dets_size = std::max(dets_size, std::max(helper[task].size_single_alpha, helper[task].size_double_alpha) * braBetaSize);
-            dets_size = std::max(dets_size, std::max(helper[task].size_single_beta, helper[task].size_double_beta) * braAlphaSize);
-            dets_size = std::max(dets_size, helper[task].size_single_alpha * helper[task].size_single_beta);
-        }
-        num_max_threads = dets_size;
-
         // allocate pre-calculated DetI
         dets.resize(this->D_size_ * adets_size * bdets_size);
+
+        num_max_threads = 0;
+
+        // check overflow
+        if (collapse_loop) {
+            for (size_t task = 0; task < helper.size(); task++) {
+                size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
+                size_t braBetaSize = helper[task].braBetaEnd - helper[task].braBetaStart;
+                if (helper[task].taskType == 2) {
+                    size_t s = helper[task].size_single_alpha * braBetaSize;
+                    if (s / helper[task].size_single_alpha != braBetaSize) {
+                        collapse_loop = false;
+                        break;
+                    }
+                    s = helper[task].size_double_alpha * braBetaSize;
+                    if (s / helper[task].size_double_alpha != braBetaSize) {
+                        collapse_loop = false;
+                        break;
+                    }
+                } else if (helper[task].taskType == 1) {
+                    size_t s = helper[task].size_single_beta * braAlphaSize;
+                    if (s / helper[task].size_single_beta != braAlphaSize) {
+                        collapse_loop = false;
+                        break;
+                    }
+                    s = helper[task].size_double_beta * braAlphaSize;
+                    if (s / helper[task].size_double_beta != braAlphaSize) {
+                        collapse_loop = false;
+                        break;
+                    }
+                } else {
+                    size_t s = helper[task].size_single_alpha * helper[task].size_single_beta;
+                    if (s / helper[task].size_single_alpha != helper[task].size_single_beta) {
+                        collapse_loop = false;
+                        break;
+                    }
+                }
+            }
+        }
     } else {
         for (size_t task = 0; task < helper.size(); task++) {
             size_t braAlphaSize = helper[task].braAlphaEnd - helper[task].braAlphaStart;
@@ -183,7 +221,6 @@ void MultTPBThrust<ElemT>::Init(
                 dets_size = ((size_t)max_memory_gb_for_determinants * 1024 * 1024 * 1024 / (this->D_size_ * sizeof(size_t))) & (~1023ULL);
                 num_max_threads = dets_size;
             }
-            std::cout << " num_max_threads = " << num_max_threads << std::endl;
         }
         // allocate per thread storage for DetI
         dets.resize(this->D_size_ * dets_size);
@@ -302,42 +339,38 @@ class MultAlphaBeta : public MultKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     MultAlphaBeta(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_single_alpha * helper.size_single_beta) {
-            size_t j = (i + offset) / helper.size_single_beta;
-            size_t k = (i + offset) - j * helper.size_single_beta;
+        size_t j = i / helper.size_single_beta;
+        size_t k = i - j * helper.size_single_beta;
 
-            size_t ia = helper.SinglesFromAlphaBraIndex[j];
-            size_t ja = helper.SinglesFromAlphaKetIndex[j];
-            size_t ib = helper.SinglesFromBetaBraIndex[k];
-            size_t jb = helper.SinglesFromBetaKetIndex[k];
+        size_t ia = helper.SinglesFromAlphaBraIndex[j];
+        size_t ja = helper.SinglesFromAlphaKetIndex[j];
+        size_t ib = helper.SinglesFromBetaBraIndex[k];
+        size_t jb = helper.SinglesFromBetaKetIndex[k];
 
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
-                ElemT eij = this->TwoExcite(DetI,
-                                            helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
-                                            helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
-                atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
-            }
+            ElemT eij = this->TwoExcite(DetI,
+                                        helper.SinglesAlphaCrAnSM[j], helper.SinglesBetaCrAnSM[k],
+                                        helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
+            atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
         }
     }
 };
@@ -348,40 +381,36 @@ class MultSingleAlpha : public MultKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     MultSingleAlpha(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_single_alpha * (helper.braBetaEnd - helper.braBetaStart)) {
-            size_t k = (i + offset) / helper.size_single_alpha;
-            size_t j = (i + offset) - k * helper.size_single_alpha;
+        size_t k = i / helper.size_single_alpha;
+        size_t j = i - k * helper.size_single_alpha;
 
-            size_t ia = helper.SinglesFromAlphaBraIndex[j];
-            size_t ja = helper.SinglesFromAlphaKetIndex[j];
-            size_t ib = k + helper.braBetaStart;
-            size_t jb = ib;
+        size_t ia = helper.SinglesFromAlphaBraIndex[j];
+        size_t ja = helper.SinglesFromAlphaKetIndex[j];
+        size_t ib = k + helper.braBetaStart;
+        size_t jb = ib;
 
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
-                ElemT eij = this->OneExcite(DetI, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
-                atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
-            }
+            ElemT eij = this->OneExcite(DetI, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
+            atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
         }
     }
 };
@@ -391,41 +420,37 @@ class MultDoubleAlpha : public MultKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     MultDoubleAlpha(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_double_alpha * (helper.braBetaEnd - helper.braBetaStart)) {
-            size_t k = (i + offset) / helper.size_double_alpha;
-            size_t j = (i + offset) - k * helper.size_double_alpha;
+        size_t k = i / helper.size_double_alpha;
+        size_t j = i - k * helper.size_double_alpha;
 
-            size_t ia = helper.DoublesFromAlphaBraIndex[j];
-            size_t ja = helper.DoublesFromAlphaKetIndex[j];
-            size_t ib = k + helper.braBetaStart;
-            size_t jb = ib;
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = helper.DoublesFromAlphaBraIndex[j];
+        size_t ja = helper.DoublesFromAlphaKetIndex[j];
+        size_t ib = k + helper.braBetaStart;
+        size_t jb = ib;
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
-                ElemT eij = this->TwoExcite(DetI,
-                                            helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
-                                            helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
-                atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
-            }
+            ElemT eij = this->TwoExcite(DetI,
+                                        helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
+                                        helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
+            atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
         }
     }
 };
@@ -435,39 +460,35 @@ class MultSingleBeta : public MultKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     MultSingleBeta(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_single_beta * (helper.braAlphaEnd - helper.braAlphaStart)) {
-            size_t j = (i + offset) / helper.size_single_beta;
-            size_t k = (i + offset) - j * helper.size_single_beta;
+        size_t j = i / helper.size_single_beta;
+        size_t k = i - j * helper.size_single_beta;
 
-            size_t ia = j + helper.braAlphaStart;
-            size_t ja = ia;
-            size_t ib = helper.SinglesFromBetaBraIndex[k];
-            size_t jb = helper.SinglesFromBetaKetIndex[k];
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = j + helper.braAlphaStart;
+        size_t ja = ia;
+        size_t ib = helper.SinglesFromBetaBraIndex[k];
+        size_t jb = helper.SinglesFromBetaKetIndex[k];
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
-                ElemT eij = this->OneExcite(DetI, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
-                atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
-            }
+            ElemT eij = this->OneExcite(DetI, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
+            atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
         }
     }
 };
@@ -477,41 +498,37 @@ class MultDoubleBeta : public MultKernelBase<ElemT>
 {
 protected:
     TaskHelpersThrust<ElemT> helper;
-    size_t offset;
 public:
     MultDoubleBeta(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
+                const MultTPBThrust<ElemT>& data
                 ) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
-        offset = o;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i + offset < helper.size_double_beta * (helper.braAlphaEnd - helper.braAlphaStart)) {
-            size_t j = (i + offset) / helper.size_double_beta;
-            size_t k = (i + offset) - j * helper.size_double_beta;
+        size_t j = i / helper.size_double_beta;
+        size_t k = i - j * helper.size_double_beta;
 
-            size_t ia = j + helper.braAlphaStart;
-            size_t ja = ia;
-            size_t ib = helper.DoublesFromBetaBraIndex[k];
-            size_t jb = helper.DoublesFromBetaKetIndex[k];
-            size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
-            if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-                size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
-                                + jb - helper.ketBetaStart;
+        size_t ia = j + helper.braAlphaStart;
+        size_t ja = ia;
+        size_t ib = helper.DoublesFromBetaBraIndex[k];
+        size_t jb = helper.DoublesFromBetaKetIndex[k];
+        size_t braIdx = (ia - helper.braAlphaStart) * (helper.braBetaEnd - helper.braBetaStart) + ib - helper.braBetaStart;
+        if( (braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
+            size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
+                            + jb - helper.ketBetaStart;
 
-                size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
+            size_t* DetI = this->det_I + ((ia - helper.braAlphaStart) * this->bdets_size + ib - helper.braBetaStart) * this->D_size;
 
-                ElemT eij = this->TwoExcite(DetI,
-                                            helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
-                                            helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
-                atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
-            }
+            ElemT eij = this->TwoExcite(DetI,
+                                        helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
+                                        helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
+            atomicAdd(this->Wb + braIdx, eij * this->T[ketIdx]);
         }
     }
 };
@@ -523,15 +540,17 @@ class MultTask0 : public MultKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     MultTask0(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
-                ) : MultKernelBase<ElemT>(v_wb, v_t, data)
+                const MultTPBThrust<ElemT>& data, size_t o,
+                bool pre) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -541,13 +560,18 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
         ElemT e = 0.0;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
                 size_t ja = helper.SinglesFromAlphaKetIndex[j];
@@ -572,15 +596,17 @@ class MultTask1 : public MultKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     MultTask1(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
-                ) : MultKernelBase<ElemT>(v_wb, v_t, data)
+                const MultTPBThrust<ElemT>& data, size_t o,
+                bool pre) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -590,20 +616,25 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
         ElemT e = 0.0;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
 
             for (size_t k = helper.SinglesFromBetaOffset[b]; k < helper.SinglesFromBetaOffset[b + 1]; k++) {
                 size_t ja = ia;
                 size_t jb = helper.SinglesFromBetaKetIndex[k];
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
-                ElemT eij = this->OneExcite(DetI, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_alpha]);
+                ElemT eij = this->OneExcite(DetI, helper.SinglesBetaCrAnSM[k], helper.SinglesBetaCrAnSM[k + helper.size_single_beta]);
                 e += eij * this->T[ketIdx];
             }
             for (size_t k = helper.DoublesFromBetaOffset[b]; k < helper.DoublesFromBetaOffset[b + 1]; k++) {
@@ -612,8 +643,8 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT eij = this->TwoExcite(DetI,
-                                    helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_alpha],
-                                    helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_alpha], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_alpha]);
+                                    helper.DoublesBetaCrAnSM[k], helper.DoublesBetaCrAnSM[k + helper.size_double_beta],
+                                    helper.DoublesBetaCrAnSM[k + 2 * helper.size_double_beta], helper.DoublesBetaCrAnSM[k + 3 * helper.size_double_beta]);
                 e += eij * this->T[ketIdx];
             }
             this->Wb[braIdx] += e;
@@ -627,15 +658,17 @@ class MultTask2 : public MultKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     size_t offset;
+    bool use_pre_dets;
 public:
     MultTask2(const TaskHelpersThrust<ElemT>& h,
                 const thrust::device_vector<ElemT>& v_wb,
                 const thrust::device_vector<ElemT>& v_t,
-                const MultTPBThrust<ElemT>& data, size_t o
-                ) : MultKernelBase<ElemT>(v_wb, v_t, data)
+                const MultTPBThrust<ElemT>& data, size_t o,
+                bool pre) : MultKernelBase<ElemT>(v_wb, v_t, data)
     {
         helper = h;
         offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
@@ -645,20 +678,25 @@ public:
         size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
         size_t a = braIdx / braBetaSize;
         size_t b = braIdx - a * braBetaSize;
-        size_t* DetI = this->det_I + i * this->D_size;
+        size_t* DetI;
         size_t ia = a + helper.braAlphaStart;
         size_t ib = b + helper.braBetaStart;
         ElemT e = 0.0;
 
         if ((braIdx % this->mpi_size_h) == this->mpi_rank_h ) {
-            this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            if (use_pre_dets)
+                DetI = this->det_I + braIdx * this->D_size;
+            else {
+                DetI = this->det_I + i * this->D_size;
+                this->DetFromAlphaBeta(DetI, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
 
             for (size_t j = helper.SinglesFromAlphaOffset[a]; j < helper.SinglesFromAlphaOffset[a + 1]; j++) {
                 size_t ja = helper.SinglesFromAlphaKetIndex[j];
                 size_t jb = ib;
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
-                ElemT eij = this->OneExcite(DetI, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_beta]);
+                ElemT eij = this->OneExcite(DetI, helper.SinglesAlphaCrAnSM[j], helper.SinglesAlphaCrAnSM[j + helper.size_single_alpha]);
                 e += eij * this->T[ketIdx];
             }
             for (size_t j = helper.DoublesFromAlphaOffset[a]; j < helper.DoublesFromAlphaOffset[a + 1]; j++) {
@@ -667,8 +705,8 @@ public:
                 size_t ketIdx = (ja - helper.ketAlphaStart) * (helper.ketBetaEnd - helper.ketBetaStart)
                                 + jb - helper.ketBetaStart;
                 ElemT eij = this->TwoExcite(DetI,
-                                    helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_beta],
-                                    helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_beta], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_beta]);
+                                    helper.DoublesAlphaCrAnSM[j], helper.DoublesAlphaCrAnSM[j + helper.size_double_alpha],
+                                    helper.DoublesAlphaCrAnSM[j + 2 * helper.size_double_alpha], helper.DoublesAlphaCrAnSM[j + 3 * helper.size_double_alpha]);
                 e += eij * this->T[ketIdx];
             }
             this->Wb[braIdx] += e;
@@ -778,7 +816,7 @@ void MultTPBThrust<ElemT>::run(
         if (task_sent == task) {
             if (task_sent != 0) {
                 auto time_slid_start = std::chrono::high_resolution_clock::now();
-                if (mpi2dslider.Sync()) {
+                if (mpi2dslider.Sync(this->b_comm_)) {
                     int t = active_T;
                     active_T = recv_T;
                     recv_T = t;
@@ -819,101 +857,63 @@ void MultTPBThrust<ElemT>::run(
 
         size_t offset;
         size_t size;
-        if (use_precalculated_dets) {
+        if (use_precalculated_dets && collapse_loop) {
             // precalculate DetI (if update needed)
             UpdateDet(task);
 
             if (helper[task].taskType == 2) {
-                offset = 0;
                 size = helper[task].size_single_alpha * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
+                MultSingleAlpha single_kernel(helper[task], Wb, T[active_T], *this);
+                single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                    MultSingleAlpha single_kernel(helper[task], Wb, T[active_T], *this, offset);
-                    single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+                auto cis = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cis, size, single_kernel);
 
-                    auto cis = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, cis, num_threads, single_kernel);
-                    offset += num_threads;
-                }
-
-                offset = 0;
                 size = helper[task].size_double_alpha * braBetaSize;
-                while (offset < size) {
-                    size_t num_threads = num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
+                MultDoubleAlpha double_kernel(helper[task], Wb, T[active_T], *this);
+                double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                    MultDoubleAlpha double_kernel(helper[task], Wb, T[active_T], *this, offset);
-                    double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                    auto cid = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, cid, num_threads, double_kernel);
-                    offset += num_threads;
-                }
+                auto cid = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cid, size, double_kernel);
             } else if(helper[task].taskType == 1) {
-                offset = 0;
                 size = helper[task].size_single_beta * braAlphaSize;
-                while (offset < size) {
-                    size_t num_threads = num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
+                MultSingleBeta single_kernel(helper[task], Wb, T[active_T], *this);
+                single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                    MultSingleBeta single_kernel(helper[task], Wb, T[active_T], *this, offset);
-                    single_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+                auto cis = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cis, size, single_kernel);
 
-                    auto cis = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, cis, num_threads, single_kernel);
-                    offset += num_threads;
-                }
-
-                offset = 0;
                 size = helper[task].size_double_beta * braAlphaSize;
-                while (offset < size) {
-                    size_t num_threads = num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
+                MultDoubleBeta double_kernel(helper[task], Wb, T[active_T], *this);
+                double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                    MultDoubleBeta double_kernel(helper[task], Wb, T[active_T], *this, offset);
-                    double_kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-                    auto cid = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, cid, num_threads, double_kernel);
-                    offset += num_threads;
-                }
+                auto cid = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, cid, size, double_kernel);
             } else {
-                offset = 0;
                 size = helper[task].size_single_alpha * helper[task].size_single_beta;
-                while (offset < size) {
-                    size_t num_threads = num_max_threads;
-                    if (offset + num_threads > size) {
-                        num_threads = size - offset;
-                    }
 
-                    MultAlphaBeta kernel(helper[task], Wb, T[active_T], *this, offset);
-                    kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+                MultAlphaBeta kernel(helper[task], Wb, T[active_T], *this);
+                kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
-                    auto ci = thrust::counting_iterator<size_t>(0);
-                    thrust::for_each_n(thrust::device, ci, num_threads, kernel);
-                    offset += num_threads;
-                }
+                auto ci = thrust::counting_iterator<size_t>(0);
+                thrust::for_each_n(thrust::device, ci, size, kernel);
             }
-        } else {    // non pre-calculated
+        } else {
+            size = braAlphaSize * braBetaSize;
+            if (use_precalculated_dets) {
+                num_max_threads = size;
+                // precalculate DetI (if update needed)
+                UpdateDet(task);
+            }
+
             if (helper[task].taskType == 2) {
                 offset = 0;
-                size = braAlphaSize * braBetaSize;
                 while (offset < size) {
                     size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
-                    MultTask2 kernel(helper[task], Wb, T[active_T], *this, offset);
+                    MultTask2 kernel(helper[task], Wb, T[active_T], *this, offset, use_precalculated_dets);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -922,14 +922,13 @@ void MultTPBThrust<ElemT>::run(
                 }
             } else if(helper[task].taskType == 1) {
                 offset = 0;
-                size = braAlphaSize * braBetaSize;
                 while (offset < size) {
                     size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultTask1 kernel(helper[task], Wb, T[active_T], *this, offset);
+                    MultTask1 kernel(helper[task], Wb, T[active_T], *this, offset, use_precalculated_dets);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -938,14 +937,13 @@ void MultTPBThrust<ElemT>::run(
                 }
             } else {
                 offset = 0;
-                size = braAlphaSize * braBetaSize;
                 while (offset < size) {
                     size_t num_threads = num_max_threads;
                     if (offset + num_threads > size) {
                         num_threads = size - offset;
                     }
 
-                    MultTask0 kernel(helper[task], Wb, T[active_T], *this, offset);
+                    MultTask0 kernel(helper[task], Wb, T[active_T], *this, offset, use_precalculated_dets);
                     kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
 
                     auto ci = thrust::counting_iterator<size_t>(0);
@@ -994,20 +992,33 @@ class MakeQChamDiagTermKernel : public MultKernelBase<ElemT>
 protected:
     TaskHelpersThrust<ElemT> helper;
     ElemT* hii;
+    size_t offset;
+    bool use_pre_dets;
 public:
-    MakeQChamDiagTermKernel(thrust::device_vector<ElemT>& hii_in, const TaskHelpersThrust<ElemT>& h, const MultTPBThrust<ElemT>& data)
+    MakeQChamDiagTermKernel(thrust::device_vector<ElemT>& hii_in, const TaskHelpersThrust<ElemT>& h, const MultTPBThrust<ElemT>& data, size_t o, bool pre)
                         : MultKernelBase<ElemT>(data)
     {
         helper = h;
         hii = (ElemT*)thrust::raw_pointer_cast(hii_in.data());
+        offset = o;
+        use_pre_dets = pre;
     }
 
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-        if (i % this->mpi_size_h == this->mpi_rank_h) {
+        size_t braIdx = i + offset;
+        if (braIdx % this->mpi_size_h == this->mpi_rank_h) {
             size_t* Det = this->det_I + i * this->D_size;
-            hii[i] = this->ZeroExcite(Det);
+            if (!use_pre_dets) {
+                size_t braBetaSize = helper.braBetaEnd - helper.braBetaStart;
+                size_t a = braIdx / braBetaSize;
+                size_t b = braIdx - a * braBetaSize;
+                size_t ia = a + helper.braAlphaStart;
+                size_t ib = b + helper.braBetaStart;
+                this->DetFromAlphaBeta(Det, this->adets + ia * this->D_size, this->bdets + ib * this->D_size);
+            }
+            hii[braIdx] = this->ZeroExcite(Det);
         }
     }
 };
@@ -1029,14 +1040,31 @@ void MultTPBThrust<ElemT>::makeQChamDiagTerms(thrust::device_vector<ElemT> &hii)
     }
     size_t braSize = braAlphaSize * braBetaSize;
 
-    UpdateDet(0);
+    if (use_precalculated_dets)
+        UpdateDet(0);
 
     hii.resize(braSize, ElemT(0.0));
 
-    MakeQChamDiagTermKernel kernel(hii, helper[0], *this);
-	kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
-    auto ci = thrust::counting_iterator<size_t>(0);
-    thrust::for_each_n(thrust::device, ci, braSize, kernel);
+    if (use_precalculated_dets) {
+        MakeQChamDiagTermKernel kernel(hii, helper[0], *this, 0, true);
+        kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+        auto ci = thrust::counting_iterator<size_t>(0);
+        thrust::for_each_n(thrust::device, ci, braSize, kernel);
+    } else {
+        size_t offset = 0;
+        while (offset < braSize) {
+            size_t num_threads = num_max_threads;
+            if (offset + num_threads > braSize) {
+                num_threads = braSize - offset;
+            }
+
+            MakeQChamDiagTermKernel kernel(hii, helper[0], *this, offset, use_precalculated_dets);
+            kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
+            auto ci = thrust::counting_iterator<size_t>(0);
+            thrust::for_each_n(thrust::device, ci, num_threads, kernel);
+            offset += num_threads;
+        }
+    }
 }
 
 

--- a/include/sbd/chemistry/tpb/sbdiag.h
+++ b/include/sbd/chemistry/tpb/sbdiag.h
@@ -34,6 +34,7 @@ namespace sbd {
 #ifdef SBD_THRUST
 	  bool use_precalculated_dets = true;
 	  int max_memory_gb_for_determinants = -1;
+	  bool thrust_collapse_loops = true;
 #endif
 	};
 
@@ -92,6 +93,10 @@ namespace sbd {
 	}
 	if( std::string(argv[i]) == "--max_memory_gb_for_determinants" ) {
 	  sbd_data.max_memory_gb_for_determinants = std::atoi(argv[i+1]);
+	  i++;
+	}
+	if( std::string(argv[i]) == "--thrust_collapse_loops" ) {
+	  sbd_data.thrust_collapse_loops = std::atoi(argv[i+1]) == 1;
 	  i++;
 	}
 #endif
@@ -237,7 +242,7 @@ namespace sbd {
 	device_mult.Init(adet, bdet, bit_length, static_cast<size_t>(L),
 					adet_comm_size,bdet_comm_size, helper, I0, I1, I2,
 					h_comm,b_comm,t_comm,
-	                sbd_data.use_precalculated_dets, sbd_data.max_memory_gb_for_determinants);
+	                sbd_data.use_precalculated_dets, sbd_data.max_memory_gb_for_determinants, sbd_data.thrust_collapse_loops);
 	auto time_end_mult_init = std::chrono::high_resolution_clock::now();
 	auto elapsed_mult_init_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mult_init-time_start_mult_init).count();
 	double elapsed_mult_init = 1.0e-6 * elapsed_mult_init_count;
@@ -471,8 +476,7 @@ namespace sbd {
 
 	auto time_start_meas = std::chrono::high_resolution_clock::now();
 #ifdef SBD_THRUST
-	Correlation(W,
-		device_mult,
+	device_mult.correlation(W,
 		one_p_rdm,
 	    two_p_rdm);
 #else

--- a/include/sbd/framework/mpi_utility_thrust.h
+++ b/include/sbd/framework/mpi_utility_thrust.h
@@ -278,6 +278,8 @@ public:
                 << "), source rank = " << mpi_source << " = (" << x_source << "," << y_source
                 << ")" << std::endl;
 #endif
+        MPI_Barrier(comm);
+
         std::vector<MPI_Request> req_size(2);
         std::vector<MPI_Status> sta_size(2);
         std::vector<size_t> size_send(1);
@@ -304,7 +306,7 @@ public:
         }
     }
 
-    bool Sync(void)
+    bool Sync(MPI_Comm comm)
     {
         bool recv = false;
         if (send_size > 0) {
@@ -318,6 +320,7 @@ public:
             MPI_Wait(&req_recv, &st);
             recv = true;
         }
+        MPI_Barrier(comm);
 
         send_size = 0;
         recv_size = 0;


### PR DESCRIPTION
This PR stabilizes Thrust implementation for large determinants.

- Remove unused indices in helper storages
- Add runtime option `--thrust_collapse_loops` for TPB, setting `--thrust_collapse_loops 0` to disable loop collapsing, this decreases thread number


