### PR TITLE
Free unused MPI communicators

### DIFF
--- a/include/sbd/chemistry/tpb/extend.h
+++ b/include/sbd/chemistry/tpb/extend.h
@@ -171,6 +171,9 @@ namespace sbd {
     }
     sort_bitarray(res_adet);
     sort_bitarray(res_bdet);
+
+    MPI_Comm_free(&adet_comm);
+    MPI_Comm_free(&bdet_comm);
   }
 
 
@@ -311,6 +314,9 @@ namespace sbd {
     }
     sort_bitarray(res_adet);
     sort_bitarray(res_bdet);
+
+    MPI_Comm_free(&adet_comm);
+    MPI_Comm_free(&bdet_comm);
   }
   
 }

--- a/include/sbd/chemistry/tpb/helper.h
+++ b/include/sbd/chemistry/tpb/helper.h
@@ -276,6 +276,7 @@ namespace sbd {
     MPI_Comm_split(basis_area_comm,t_comm_color,mpi_rank,&t_comm);
     MPI_Comm_split(basis_area_comm,b_comm_color,mpi_rank,&b_comm);
 
+    MPI_Comm_free(&basis_area_comm);
   }
 
   size_t SizeOfVector(TaskHelpers & helper) {

--- a/include/sbd/chemistry/tpb/rdmat.h
+++ b/include/sbd/chemistry/tpb/rdmat.h
@@ -55,6 +55,9 @@ namespace sbd {
     
     MpiAllreduce(D,MPI_SUM,adet_comm); // each elements are already obtained
     MpiAllreduce(D,MPI_SUM,bdet_comm); // fill the different elements
+
+    MPI_Comm_free(&adet_comm);
+    MPI_Comm_free(&bdet_comm);
   }
 
   template <typename ElemT, typename RealT>
@@ -179,6 +182,9 @@ namespace sbd {
     
     MpiAllreduce(D,MPI_SUM,adet_comm); // each elements are already obtained
     MpiAllreduce(D,MPI_SUM,bdet_comm); // fill the different elements
+
+    MPI_Comm_free(&adet_comm);
+    MPI_Comm_free(&bdet_comm);
   }
 
   template <typename ElemT, typename RealT>

--- a/include/sbd/chemistry/tpb/sbdiag.h
+++ b/include/sbd/chemistry/tpb/sbdiag.h
@@ -581,6 +581,9 @@ namespace sbd {
 
       FreeHelpers(helper);
 
+      MPI_Comm_free(&h_comm);
+      MPI_Comm_free(&b_comm);
+      MPI_Comm_free(&t_comm);
     } // end void diag function
 
     /**


### PR DESCRIPTION
I modified the code so that the communicator is released immediately when it is no longer in use. 

While this hasn’t caused any major issues so far, it results in a memory leak when the diagonalization function is called multiple times.