### PR TITLE
Fix communicator leak by freeing MPI_Comm_split communicator

### DIFF
--- a/include/sbd/caop/basic/helper.h
+++ b/include/sbd/caop/basic/helper.h
@@ -34,6 +34,7 @@ namespace sbd {
     int b_comm_color = mpi_rank_a / b_comm_size;
     MPI_Comm_split(a_comm,t_comm_color,mpi_rank,&t_comm);
     MPI_Comm_split(a_comm,b_comm_color,mpi_rank,&b_comm);
+    MPI_Comm_free(&a_comm);
     
   }
   

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -306,7 +306,10 @@ namespace sbd {
       if( !savename.empty() ) {
 	SaveWavefunction(savename,basis,h_comm,b_comm,t_comm,W);
       }
-    }
+			MPI_Comm_free(&h_comm);
+			MPI_Comm_free(&t_comm);
+			MPI_Comm_free(&b_comm);
+		}
 
     /**
        Main function to perform the diagonalization for selected basis on creation/annihilation operator model
@@ -409,7 +412,10 @@ namespace sbd {
       }
       diag(comm,sbd_data,hamiltonian,basis,loadname,savename,
 	   energy,co_basis);
-    }
+		 MPI_Comm_free(&h_comm); // my fix
+		 MPI_Comm_free(&t_comm); // my fix
+		 MPI_Comm_free(&b_comm); // my fix
+		}
   }
 }
 

--- a/include/sbd/framework/bit_manipulation.h
+++ b/include/sbd/framework/bit_manipulation.h
@@ -560,6 +560,7 @@ namespace sbd {
       int new_id = id + mpi_color * mpi_size_half;
       MPI_Comm_split(comm,mpi_color,mpi_key,&new_comm);
       mpi_sort_bitarray(config,config_begin,config_end,index_begin,index_end,total_bit_length,bit_length,new_comm,new_id);
+      MPI_Comm_free(&new_comm);
 
 #ifdef SBD_DEBUG_BIT
       // for(int rank=0; rank < mpi_size; rank++) {


### PR DESCRIPTION
This PR fixes a communicator leak in `sbd::caop::diag<ElemT>`

The code called `MPI_Comm_split` but never released the resulting communicator. When the routine was called repeatedly in a large loop, the program eventually failed with:

Too many communicators (0/32768 free on this process)

The fix adds MPI_Comm_free once the temporary communicator is no longer needed.

Fixes #38