### PR TITLE
Add const accessor for sbd::ProductOp

### DIFF
--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -288,6 +288,7 @@ namespace sbd {
 
     size_t size() const { return fops_.size(); }
     int n_dag() const { return n_dag_; }
+    const CAOp& FOp(size_t i) const { return fops_[i]; }
     
     void dagger()
     {


### PR DESCRIPTION
This PR adds a read-only accessor for sbd::ProductOp

const CAOp& FOp(size_t i) const { return fops_[i]; }

This makes the stored value accessible without exposing mutable access.