### PR TITLE
gdb: fix OOB read in makeQChamDiagTerms thread count

### DIFF
--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -606,12 +606,15 @@ void MultGDBThrust<ElemT>::makeQChamDiagTerms(thrust::device_vector<ElemT> &hii)
     MPI_Comm_rank(this->h_comm_, &mpi_rank_h);
     MPI_Comm_size(this->h_comm_, &mpi_size_h);
 
-    hii.resize(dets_.size(), ElemT(0.0));
+    // dets_ packs n_dets bit-strings of length D_size_ each; iterate over
+    // n_dets, not dets_.size(), or the kernel will overrun dets_.
+    const size_t n_dets = dets_.size() / this->D_size_;
+    hii.resize(n_dets, ElemT(0.0));
 
     MakeQChamDiagTermKernel kernel(hii, *this);
 	kernel.set_mpi_size(mpi_rank_h, mpi_size_h);
     auto ci = thrust::counting_iterator<size_t>(0);
-    thrust::for_each_n(thrust::device, ci, dets_.size(), kernel);
+    thrust::for_each_n(thrust::device, ci, n_dets, kernel);
 }
 
 


### PR DESCRIPTION
## Summary
`MultGDBThrust<ElemT>::makeQChamDiagTerms()` resizes the diagonal-Hamiltonian
output `hii` and launches the diagonal-term kernel using `dets_.size()`,
which is the storage length (`D_size_ * n_dets`), not the determinant count.
This results in `D_size_x` too many threads; surplus threads index past the
end of `dets_`.

At small problem sizes the OOB read silently lands in adjacent mapped pages
and leaves results bitwise correct (caught on H2O 1e-3 with results matching
the reference to all bits). At larger sizes the kernel faults with
`cudaErrorIllegalAddress`. Reproduced on a single NVIDIA GH200 (NCSA DeltaAI,
PrgEnv-nvidia, Cray CC wrapper) on H2O cc-pVDZ at 1e-4 (~2.4M dets).

## Fix
Compute `n_dets = dets_.size() / D_size_` and use it for both the resize and
the `thrust::for_each_n` iteration count.

## Test plan
- [x] Bitwise-identical regression on H2O cc-pVDZ 1e-3 (1 GH200)
- [x] H2O cc-pVDZ 1e-4 (1 GH200): previously faulted; now completes; energy matches reference
- [x] Fe4S4 small case: matches reference energy