### PR TITLE
gdb: multiple CUDA kernel and MPI optimizations for 70% Davidson runtime reduction

### DIFF
--- a/include/sbd/chemistry/basic/determinants_thrust.h
+++ b/include/sbd/chemistry/basic/determinants_thrust.h
@@ -161,6 +161,35 @@ public:
             sgn *= -1.0;
         return ElemT(sgn) * (I2.Value(A, I, B, J) - I2.Value(A, J, B, I));
     }
+
+    // O(1) parity of open interval (start, end) using a precomputed inclusive
+    // prefix-parity array (detsum). detsum[k] = parity of bits [0, k] of the
+    // determinant bit string, stored as a single bit in the same word layout as
+    // the determinant itself. Parity of (start, end) = detsum_bit[end-1] XOR
+    // detsum_bit[start]; no start-bit correction needed because the inclusive
+    // scan already excludes the start orbital from the interval count.
+    inline __device__ __host__ void parity_fast(const size_t* detsum, int start, int end, double& sgn)
+    {
+        if (start >= end) return;
+        size_t p_start = (detsum[start       / bit_length] >> (start       % bit_length)) & 1;
+        size_t p_end1  = (detsum[(end - 1)   / bit_length] >> ((end - 1)   % bit_length)) & 1;
+        if (p_start ^ p_end1) sgn *= -1.0;
+    }
+
+    inline __device__ __host__ ElemT TwoExciteFast(const size_t* detsum,
+                                                    int i, int j, int a, int b)
+    {
+        double sgn = 1.0;
+        int I = std::min(i, j);
+        int J = std::max(i, j);
+        int A = std::min(a, b);
+        int B = std::max(a, b);
+        parity_fast(detsum, std::min(I, A), std::max(I, A), sgn);
+        parity_fast(detsum, std::min(J, B), std::max(J, B), sgn);
+        if (A > J || B < I)
+            sgn *= -1.0;
+        return ElemT(sgn) * (I2.Value(A, I, B, J) - I2.Value(A, J, B, I));
+    }
 };
 
 }

--- a/include/sbd/chemistry/basic/determinants_thrust.h
+++ b/include/sbd/chemistry/basic/determinants_thrust.h
@@ -168,27 +168,27 @@ public:
     // the determinant itself. Parity of (start, end) = detsum_bit[end-1] XOR
     // detsum_bit[start]; no start-bit correction needed because the inclusive
     // scan already excludes the start orbital from the interval count.
-    inline __device__ __host__ void parity_fast(const size_t* detsum, int start, int end, double& sgn)
+    // Returns true if the interval contains an odd number of occupied orbitals
+    // (i.e., the parity contributes a sign flip).
+    inline __device__ __host__ bool parity_fast(const size_t* detsum, int start, int end)
     {
-        if (start >= end) return;
+        if (start >= end) return false;
         size_t p_start = (detsum[start       / bit_length] >> (start       % bit_length)) & 1;
         size_t p_end1  = (detsum[(end - 1)   / bit_length] >> ((end - 1)   % bit_length)) & 1;
-        if (p_start ^ p_end1) sgn *= -1.0;
+        return (p_start ^ p_end1) != 0;
     }
 
     inline __device__ __host__ ElemT TwoExciteFast(const size_t* detsum,
                                                     int i, int j, int a, int b)
     {
-        double sgn = 1.0;
         int I = std::min(i, j);
         int J = std::max(i, j);
         int A = std::min(a, b);
         int B = std::max(a, b);
-        parity_fast(detsum, std::min(I, A), std::max(I, A), sgn);
-        parity_fast(detsum, std::min(J, B), std::max(J, B), sgn);
-        if (A > J || B < I)
-            sgn *= -1.0;
-        return ElemT(sgn) * (I2.Value(A, I, B, J) - I2.Value(A, J, B, I));
+        bool parity_I_A = parity_fast(detsum, std::min(I, A), std::max(I, A));
+        bool parity_J_B = parity_fast(detsum, std::min(J, B), std::max(J, B));
+        const ElemT sgn = ((A > J || B < I) ^ parity_I_A ^ parity_J_B) ? ElemT(-1) : ElemT(1);
+        return sgn * (I2.Value(A, I, B, J) - I2.Value(A, J, B, I));
     }
 };
 

--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -80,10 +80,8 @@ public:
 			// single alpha excitations
 			for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 				uint32_t jast = exidx.SinglesFromAdetSM[ja];
-				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
-				if (idxa >= 0) {
-					if (jast != tidxmap.BdetToAdetSM[idxa])
-						continue;
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
@@ -126,10 +124,8 @@ public:
 			// double alpha excitations
 			for (uint32_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
 				uint32_t jast = exidx.DoublesFromAdetSM[ja];
-				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
-				if (idxa >= 0) {
-					if (jast != tidxmap.BdetToAdetSM[idxa])
-						continue;
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
@@ -175,10 +171,8 @@ public:
 			// single beta excitations
 			for (uint32_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
@@ -221,10 +215,8 @@ public:
 			// double beta excitations
 			for (uint32_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
 				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
@@ -268,26 +260,17 @@ public:
 		// alpha-beta two-particle excitations
 		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			uint32_t jast = exidx.SinglesFromAdetSM[ja];
-			size_t start_idx = 0;
-			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
 			for (uint32_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[k];
-				if (start_idx >= end_idx)
-					break;
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
-					start_idx = static_cast<size_t>(idxb) - tidxmap.AdetToDetOffset[jast];
-					if (start_idx < end_idx) {
-						uint32_t jdet = tidxmap.AdetToDetSM[idxb];
-						this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
-											this->wb[idet], this->twk[jdet],
-												exidx.SinglesAdetCrAnSM[ja],
-												exidx.SinglesBdetCrAnSM[k],
-												exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
-												exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
-					}
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				if (found_b) {
+					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
+					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
+										this->wb[idet], this->twk[jdet],
+											exidx.SinglesAdetCrAnSM[ja],
+											exidx.SinglesBdetCrAnSM[k],
+											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
+											exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
 				}
 			}
 		}

--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -45,9 +45,7 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		if( (i % this->mpi_size_h) == this->mpi_rank_h ) {
-			this->correlation.ZeroDiffCorrelation(this->det + i * this->D_size, this->wb[i]);
-        }
+        this->correlation.ZeroDiffCorrelation(this->det + i * this->D_size, this->wb[i]);
     }
 };
 
@@ -76,8 +74,6 @@ public:
 		uint32_t idet = idxmap.AdetToDetSM[i];
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
 			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
@@ -124,8 +120,6 @@ public:
 		uint32_t idet = idxmap.AdetToDetSM[i];
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
 			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
@@ -175,8 +169,6 @@ public:
 		uint32_t idet = idxmap.BdetToDetSM[i];
 		uint32_t ib   = idxmap.BdetIndex[i];
 		uint32_t ibst = ib;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
 			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
@@ -223,8 +215,6 @@ public:
 		uint32_t idet = idxmap.BdetToDetSM[i];
 		uint32_t ib   = idxmap.BdetIndex[i];
 		uint32_t ibst = ib;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
 			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
@@ -274,8 +264,6 @@ public:
 		uint32_t idet = idxmap.AdetToDetSM[i];
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		// alpha-beta two-particle excitations
 		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {

--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -80,10 +80,10 @@ public:
 			return;
 
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
 			// single alpha excitations
-			for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
-				size_t jast = exidx.SinglesFromAdetSM[ja];
+			for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+				uint32_t jast = exidx.SinglesFromAdetSM[ja];
 				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
@@ -128,10 +128,10 @@ public:
 			return;
 
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
 			// double alpha excitations
-			for (size_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
-				size_t jast = exidx.DoublesFromAdetSM[ja];
+			for (uint32_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
+				uint32_t jast = exidx.DoublesFromAdetSM[ja];
 				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
@@ -179,10 +179,10 @@ public:
 			return;
 
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
-			// single alpha excitations
-			for (size_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
-				size_t jbst = exidx.SinglesFromBdetSM[jb];
+			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			// single beta excitations
+			for (uint32_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
+				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
@@ -227,10 +227,10 @@ public:
 			return;
 
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
-			// double alpha excitations
-			for (size_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
-				size_t jbst = exidx.DoublesFromBdetSM[jb];
+			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			// double beta excitations
+			for (uint32_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
+				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
@@ -278,12 +278,12 @@ public:
 			return;
 
 		// alpha-beta two-particle excitations
-		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
-			size_t jast = exidx.SinglesFromAdetSM[ja];
+		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+			uint32_t jast = exidx.SinglesFromAdetSM[ja];
 			size_t start_idx = 0;
 			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
-			for (size_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
-				size_t jbst = exidx.SinglesFromBdetSM[k];
+			for (uint32_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
+				uint32_t jbst = exidx.SinglesFromBdetSM[k];
 				if (start_idx >= end_idx)
 					break;
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);

--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -75,12 +75,18 @@ public:
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
 
-		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+		const uint32_t self_lo = exidx.SelfFromBdetOffset[ibst];
+		const uint32_t self_hi = exidx.SelfFromBdetOffset[ibst + 1];
+		const uint32_t ja_lo   = exidx.SinglesFromAdetOffset[ia];
+		const uint32_t ja_hi   = exidx.SinglesFromAdetOffset[ia + 1];
+		if (self_lo != self_hi && ja_lo != ja_hi) {
+			uint32_t jbst = exidx.SelfFromBdetSM[self_lo];
+			const uint32_t bdet_lo = tidxmap.BdetToDetOffset[jbst];
+			const uint32_t bdet_hi = tidxmap.BdetToDetOffset[jbst + 1];
 			// single alpha excitations
-			for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+			for (uint32_t ja = ja_lo; ja < ja_hi; ja++) {
 				uint32_t jast = exidx.SinglesFromAdetSM[ja];
-				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(bdet_lo, bdet_hi, jast);
 				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
@@ -119,12 +125,18 @@ public:
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
 
-		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+		const uint32_t self_lo = exidx.SelfFromBdetOffset[ibst];
+		const uint32_t self_hi = exidx.SelfFromBdetOffset[ibst + 1];
+		const uint32_t ja_lo   = exidx.DoublesFromAdetOffset[ia];
+		const uint32_t ja_hi   = exidx.DoublesFromAdetOffset[ia + 1];
+		if (self_lo != self_hi && ja_lo != ja_hi) {
+			uint32_t jbst = exidx.SelfFromBdetSM[self_lo];
+			const uint32_t bdet_lo = tidxmap.BdetToDetOffset[jbst];
+			const uint32_t bdet_hi = tidxmap.BdetToDetOffset[jbst + 1];
 			// double alpha excitations
-			for (uint32_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
+			for (uint32_t ja = ja_lo; ja < ja_hi; ja++) {
 				uint32_t jast = exidx.DoublesFromAdetSM[ja];
-				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(bdet_lo, bdet_hi, jast);
 				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
@@ -166,12 +178,18 @@ public:
 		uint32_t ib   = idxmap.BdetIndex[i];
 		uint32_t ibst = ib;
 
-		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+		const uint32_t self_lo = exidx.SelfFromAdetOffset[iast];
+		const uint32_t self_hi = exidx.SelfFromAdetOffset[iast + 1];
+		const uint32_t jb_lo   = exidx.SinglesFromBdetOffset[ib];
+		const uint32_t jb_hi   = exidx.SinglesFromBdetOffset[ib + 1];
+		if (self_lo != self_hi && jb_lo != jb_hi) {
+			uint32_t jast = exidx.SelfFromAdetSM[self_lo];
+			const uint32_t adet_lo = tidxmap.AdetToDetOffset[jast];
+			const uint32_t adet_hi = tidxmap.AdetToDetOffset[jast + 1];
 			// single beta excitations
-			for (uint32_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
+			for (uint32_t jb = jb_lo; jb < jb_hi; jb++) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
-				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(adet_lo, adet_hi, jbst);
 				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
@@ -210,12 +228,18 @@ public:
 		uint32_t ib   = idxmap.BdetIndex[i];
 		uint32_t ibst = ib;
 
-		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+		const uint32_t self_lo = exidx.SelfFromAdetOffset[iast];
+		const uint32_t self_hi = exidx.SelfFromAdetOffset[iast + 1];
+		const uint32_t jb_lo   = exidx.DoublesFromBdetOffset[ib];
+		const uint32_t jb_hi   = exidx.DoublesFromBdetOffset[ib + 1];
+		if (self_lo != self_hi && jb_lo != jb_hi) {
+			uint32_t jast = exidx.SelfFromAdetSM[self_lo];
+			const uint32_t adet_lo = tidxmap.AdetToDetOffset[jast];
+			const uint32_t adet_hi = tidxmap.AdetToDetOffset[jast + 1];
 			// double beta excitations
-			for (uint32_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
+			for (uint32_t jb = jb_lo; jb < jb_hi; jb++) {
 				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
-				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(adet_lo, adet_hi, jbst);
 				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
@@ -258,11 +282,17 @@ public:
 		uint32_t iast = ia;
 
 		// alpha-beta two-particle excitations
-		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+		const uint32_t ja_lo = exidx.SinglesFromAdetOffset[ia];
+		const uint32_t ja_hi = exidx.SinglesFromAdetOffset[ia + 1];
+		const uint32_t k_lo  = exidx.SinglesFromBdetOffset[ibst];
+		const uint32_t k_hi  = exidx.SinglesFromBdetOffset[ibst + 1];
+		if (k_lo != k_hi) for (uint32_t ja = ja_lo; ja < ja_hi; ja++) {
 			uint32_t jast = exidx.SinglesFromAdetSM[ja];
-			for (uint32_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
+			const uint32_t adet_lo = tidxmap.AdetToDetOffset[jast];
+			const uint32_t adet_hi = tidxmap.AdetToDetOffset[jast + 1];
+			for (uint32_t k = k_lo; k < k_hi; k++) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[k];
-				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(adet_lo, adet_hi, jbst);
 				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,

--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -72,10 +72,10 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		size_t ibst = idxmap.AdetToBdetSM[i];
-		size_t idet = idxmap.AdetToDetSM[i];
-		size_t ia = idxmap.AdetIndex[i];
-		size_t iast = ia;
+		uint32_t ibst = idxmap.AdetToBdetSM[i];
+		uint32_t idet = idxmap.AdetToDetSM[i];
+		uint32_t ia   = idxmap.AdetIndex[i];
+		uint32_t iast = ia;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -88,7 +88,7 @@ public:
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
 						continue;
-					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
 											exidx.SinglesAdetCrAnSM[ja],
@@ -120,10 +120,10 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		size_t ibst = idxmap.AdetToBdetSM[i];
-		size_t idet = idxmap.AdetToDetSM[i];
-		size_t ia = idxmap.AdetIndex[i];
-		size_t iast = ia;
+		uint32_t ibst = idxmap.AdetToBdetSM[i];
+		uint32_t idet = idxmap.AdetToDetSM[i];
+		uint32_t ia   = idxmap.AdetIndex[i];
+		uint32_t iast = ia;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -136,7 +136,7 @@ public:
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
 						continue;
-					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
 											exidx.DoublesAdetCrAnSM[ja],
@@ -171,10 +171,10 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		size_t iast = idxmap.BdetToAdetSM[i];
-		size_t idet = idxmap.BdetToDetSM[i];
-		size_t ib = idxmap.BdetIndex[i];
-		size_t ibst = ib;
+		uint32_t iast = idxmap.BdetToAdetSM[i];
+		uint32_t idet = idxmap.BdetToDetSM[i];
+		uint32_t ib   = idxmap.BdetIndex[i];
+		uint32_t ibst = ib;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -187,7 +187,7 @@ public:
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.OneDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
 											exidx.SinglesBdetCrAnSM[jb],
@@ -219,10 +219,10 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		size_t iast = idxmap.BdetToAdetSM[i];
-		size_t idet = idxmap.BdetToDetSM[i];
-		size_t ib = idxmap.BdetIndex[i];
-		size_t ibst = ib;
+		uint32_t iast = idxmap.BdetToAdetSM[i];
+		uint32_t idet = idxmap.BdetToDetSM[i];
+		uint32_t ib   = idxmap.BdetIndex[i];
+		uint32_t ibst = ib;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -235,7 +235,7 @@ public:
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
 											exidx.DoublesBdetCrAnSM[jb],
@@ -270,10 +270,10 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		size_t ibst = idxmap.AdetToBdetSM[i];
-		size_t idet = idxmap.AdetToDetSM[i];
-		size_t ia = idxmap.AdetIndex[i];
-		size_t iast = ia;
+		uint32_t ibst = idxmap.AdetToBdetSM[i];
+		uint32_t idet = idxmap.AdetToDetSM[i];
+		uint32_t ia   = idxmap.AdetIndex[i];
+		uint32_t iast = ia;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -290,9 +290,9 @@ public:
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					start_idx = idxb - tidxmap.AdetToDetOffset[jast];
+					start_idx = static_cast<size_t>(idxb) - tidxmap.AdetToDetOffset[jast];
 					if (start_idx < end_idx) {
-						size_t jdet = tidxmap.AdetToDetSM[idxb];
+						uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 						this->correlation.TwoDiffCorrelation(this->det + idet * this->D_size,
 											this->wb[idet], this->twk[jdet],
 												exidx.SinglesAdetCrAnSM[ja],
@@ -332,7 +332,7 @@ void MultGDBThrust<ElemT>::correlation(const std::vector<ElemT> & w_in,
 	thrust::device_vector<ElemT> w(w_in.size());
 	thrust::device_vector<ElemT> tw(w_in.size());
 	thrust::device_vector<ElemT> rw;
-	thrust::device_vector<size_t> tidxmap_storage;
+	thrust::device_vector<uint32_t> tidxmap_storage;
 	DetIndexMapThrust tidxmap;
 
     thrust::copy_n(w_in.begin(), w_in.size(), w.begin());
@@ -396,7 +396,7 @@ void MultGDBThrust<ElemT>::correlation(const std::vector<ElemT> & w_in,
 			sbd::MpiSlide(rw, tw, slide, this->b_comm());
 			sbd::gdb::MpiSlide(idxmap, idxmap_storage, tidxmap, tidxmap_storage, -exidx[0].slide, this->b_comm());
 
-			thrust::device_vector<size_t> ridxmap_storage;
+			thrust::device_vector<uint32_t> ridxmap_storage;
 			DetIndexMapThrust ridxmap;
 			ridxmap.copy(ridxmap_storage, tidxmap, tidxmap_storage);
 			sbd::gdb::MpiSlide(ridxmap, ridxmap_storage, tidxmap, tidxmap_storage, slide, this->b_comm());

--- a/include/sbd/chemistry/gdb/helper.h
+++ b/include/sbd/chemistry/gdb/helper.h
@@ -712,13 +712,18 @@ namespace sbd {
       getHalfDets(det,bit_length,norb,adet,bdet,adet_count,bdet_count);
       makeDetIndexMap(det,adet,bdet,adet_count,bdet_count,
 		      bit_length,norb,idxmap);
-      
+
+      // Persistent scratch buffers for MpiSlide<det> flat packing.
+      // Reusing across the initial slide and 3 task-loop rounds avoids
+      // repeated zero-initialization of the 60.8 MB send/recv buffers.
+      std::vector<size_t> det_scratch_send, det_scratch_recv;
+
       std::vector<std::vector<size_t>> ket_det;
       std::vector<std::vector<size_t>> ket_adet;
       std::vector<std::vector<size_t>> ket_bdet;
       if ( task_begin != static_cast<size_t>(0) ) {
 	int slide = - exidx[0].slide;
-	sbd::MpiSlide(det,ket_det,slide,b_comm);
+	sbd::MpiSlideWithScratch(det,ket_det,slide,b_comm,det_scratch_send,det_scratch_recv);
 	sbd::MpiSlide(adet,ket_adet,slide,b_comm);
 	sbd::MpiSlide(bdet,ket_bdet,slide,b_comm);
       } else {
@@ -760,7 +765,7 @@ namespace sbd {
 	  std::swap(ket_adet,send_adet);
 	  std::swap(ket_bdet,send_bdet);
 	  int slide = exidx[task-task_begin].slide - exidx[task+1-task_begin].slide;
-	  sbd::MpiSlide(send_det,ket_det,slide,b_comm);
+	  sbd::MpiSlideWithScratch(send_det,ket_det,slide,b_comm,det_scratch_send,det_scratch_recv);
 	  sbd::MpiSlide(send_adet,ket_adet,slide,b_comm);
 	  sbd::MpiSlide(send_bdet,ket_bdet,slide,b_comm);
 #ifdef SBD_DEBUG_HELPER

--- a/include/sbd/chemistry/gdb/helper.h
+++ b/include/sbd/chemistry/gdb/helper.h
@@ -758,16 +758,14 @@ namespace sbd {
 	dumpExcitationLookup(exidx_task_file,exidx[task-task_begin]);
 #endif
 	if( task != task_end-1 ) {
-	  std::vector<std::vector<size_t>> send_det;
-	  std::vector<std::vector<size_t>> send_adet;
-	  std::vector<std::vector<size_t>> send_bdet;
-	  std::swap(ket_det,send_det);
-	  std::swap(ket_adet,send_adet);
-	  std::swap(ket_bdet,send_bdet);
 	  int slide = exidx[task-task_begin].slide - exidx[task+1-task_begin].slide;
-	  sbd::MpiSlideWithScratch(send_det,ket_det,slide,b_comm,det_scratch_send,det_scratch_recv);
-	  sbd::MpiSlide(send_adet,ket_adet,slide,b_comm);
-	  sbd::MpiSlide(send_bdet,ket_bdet,slide,b_comm);
+	  // In-place slide: pass ket_det/ket_adet/ket_bdet as both A and B.
+	  // Safe because MpiSlideWithScratch packs A into scratch before B.resize(),
+	  // so the existing capacity survives intact until pack is done.
+	  // When ranks hold equal det counts (balanced), B.resize() is a no-op.
+	  sbd::MpiSlideWithScratch(ket_det,ket_det,slide,b_comm,det_scratch_send,det_scratch_recv);
+	  sbd::MpiSlide(ket_adet,ket_adet,slide,b_comm);
+	  sbd::MpiSlide(ket_bdet,ket_bdet,slide,b_comm);
 #ifdef SBD_DEBUG_HELPER
 	  DetIndexMap send_idxmap;
 	  sbd::gdb::MpiSlide(send_idxmap,ket_idxmap,slide,b_comm);

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -135,10 +135,9 @@ public:
         size_bdet = idxmap.size_bdet;
     }
 
-    inline __device__ __host__ std::pair<bool, uint32_t> adet_lower_bound(uint32_t jast, uint32_t jbst)
+    inline __device__ __host__ std::pair<bool, uint32_t> adet_lower_bound(uint32_t i_lower, uint32_t i_upper, uint32_t jbst)
     {
-        uint32_t is = AdetToDetOffset[jast];
-        const uint32_t i_upper = AdetToDetOffset[jast + 1];
+        uint32_t is = i_lower;
         uint32_t ie = i_upper;
         while (is != ie) {
             uint32_t i = (is + ie) / 2;
@@ -150,10 +149,9 @@ public:
         return {ie != i_upper && AdetToBdetSM[ie] == jbst, ie};
     }
 
-    inline __device__ __host__ std::pair<bool, uint32_t> bdet_lower_bound(uint32_t jbst, uint32_t jast)
+    inline __device__ __host__ std::pair<bool, uint32_t> bdet_lower_bound(uint32_t i_lower, uint32_t i_upper, uint32_t jast)
     {
-        uint32_t is = BdetToDetOffset[jbst];
-        const uint32_t i_upper = BdetToDetOffset[jbst + 1];
+        uint32_t is = i_lower;
         uint32_t ie = i_upper;
         while (is != ie) {
             uint32_t i = (is + ie) / 2;

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -460,6 +460,16 @@ protected:
     MPI_Request req_recv;
     MPI_Request req_send_map;
     MPI_Request req_recv_map;
+    MPI_Request req_size_send;
+    MPI_Request req_size_recv;
+    std::vector<size_t> send_offset_buf;
+    std::vector<size_t> recv_offset_buf;
+    DetIndexMapThrust*  recv_map_ptr;
+    uint32_t*           recv_map_base_saved;
+    bool have_req_send;
+    bool have_req_recv;
+    bool have_req_send_map;
+    bool have_req_recv_map;
     size_t send_size;
     size_t recv_size;
     size_t send_size_map;
@@ -471,6 +481,14 @@ public:
         recv_size = 0;
         send_size_map = 0;
         recv_size_map = 0;
+        send_offset_buf.resize(12, 0);
+        recv_offset_buf.resize(12, 0);
+        recv_map_ptr = nullptr;
+        recv_map_base_saved = nullptr;
+        have_req_send = false;
+        have_req_recv = false;
+        have_req_send_map = false;
+        have_req_recv_map = false;
     }
 
     // Return the ket/map recv sizes recorded by the most recent ExchangeAsync call.
@@ -516,135 +534,131 @@ public:
         int mpi_dest   = (mpi_size+mpi_rank+slide) % mpi_size;
         int mpi_source = (mpi_size+mpi_rank-slide) % mpi_size;
 
-        // exchange data size to be sent
-        std::vector<MPI_Request> req_size(2);
-        std::vector<MPI_Status> sta_size(2);
-        std::vector<size_t> send_offset(12);
-        std::vector<size_t> recv_offset(12);
-        // Use the caller-supplied logical sizes, not send.size() /
-        // send_map_storage.size(), which may equal global_max after
-        // pre-allocation rather than the actual ket/map element count.
-        send_offset[0] = send_ket_size;
-        send_offset[1] = send_map_size;
-
-        // exchange idxmap offset
+        // Build the 12-element offset packet to send:
+        //   [0]  = send_ket_size  (actual ket elements, not global_max)
+        //   [1]  = send_map_size  (actual map elements, not global_max)
+        //   [2..9] = recv_map field byte-offsets relative to send_map_storage base
+        //   [10] = size_adet, [11] = size_bdet
+        // send_offset_buf is a member so its lifetime extends through Sync().
+        send_offset_buf[0] = send_ket_size;
+        send_offset_buf[1] = send_map_size;
         {
             const uint32_t* send_base = thrust::raw_pointer_cast(send_map_storage.data());
-            send_offset[2] = (size_t)(send_map.AdetToDetOffset - send_base);
-            send_offset[3] = (size_t)(send_map.BdetToDetOffset - send_base);
-            send_offset[4] = (size_t)(send_map.AdetIndex - send_base);
-            send_offset[5] = (size_t)(send_map.BdetIndex - send_base);
-            send_offset[6] = (size_t)(send_map.AdetToBdetSM - send_base);
-            send_offset[7] = (size_t)(send_map.AdetToDetSM - send_base);
-            send_offset[8] = (size_t)(send_map.BdetToAdetSM - send_base);
-            send_offset[9] = (size_t)(send_map.BdetToDetSM - send_base);
+            send_offset_buf[2] = (size_t)(send_map.AdetToDetOffset - send_base);
+            send_offset_buf[3] = (size_t)(send_map.BdetToDetOffset - send_base);
+            send_offset_buf[4] = (size_t)(send_map.AdetIndex - send_base);
+            send_offset_buf[5] = (size_t)(send_map.BdetIndex - send_base);
+            send_offset_buf[6] = (size_t)(send_map.AdetToBdetSM - send_base);
+            send_offset_buf[7] = (size_t)(send_map.AdetToDetSM - send_base);
+            send_offset_buf[8] = (size_t)(send_map.BdetToAdetSM - send_base);
+            send_offset_buf[9] = (size_t)(send_map.BdetToDetSM - send_base);
         }
-        send_offset[10] = (size_t)send_map.size_adet;
-        send_offset[11] = (size_t)send_map.size_bdet;
+        send_offset_buf[10] = (size_t)send_map.size_adet;
+        send_offset_buf[11] = (size_t)send_map.size_bdet;
 
-        {
-            MPI_Isend(send_offset.data(),12,SBD_MPI_SIZE_T,mpi_dest,id*4,comm,&req_size[0]);
-        }
-        {
-            MPI_Irecv(recv_offset.data(),12,SBD_MPI_SIZE_T,mpi_source,id*4,comm,&req_size[1]);
-        }
-        {
-            MPI_Waitall(2,req_size.data(),sta_size.data());
-        }
+        // Post offset send and recv non-blocking.  The Waitall is deferred to
+        // Sync() so ExchangeAsync returns immediately without stalling on the
+        // ring-sender having called ExchangeAsync itself.
+        MPI_Isend(send_offset_buf.data(),12,SBD_MPI_SIZE_T,mpi_dest,id*4,comm,&req_size_send);
+        MPI_Irecv(recv_offset_buf.data(),12,SBD_MPI_SIZE_T,mpi_source,id*4,comm,&req_size_recv);
+        // No MPI_Waitall here — Sync() will wait for the offset and then set
+        // recv_size, recv_size_map, and recv_map field pointers.
 
-        send_size = send_offset[0];
-        recv_size = recv_offset[0];
-        send_size_map = send_offset[1];
-        recv_size_map = recv_offset[1];
+        send_size     = send_ket_size;
+        send_size_map = send_map_size;
+        // recv_size and recv_size_map are unknown until Sync() reads recv_offset_buf.
 
-        // Post async send/recv without any resize or fill kernel.
-        // recv and recv_map_storage are pre-allocated to global_max by the caller.
+        // Post large ket and map sends/recvs.
+        // MPI_Irecv count uses recv.size() / recv_map_storage.size() (= global_max),
+        // which is always >= the actual recv_size the sender will send.  MPI allows
+        // receive count >= send count; only the sent elements are written.
         MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
-        if( send_size != 0 ) {
-            {
-                MPI_Isend((ElemT*)thrust::raw_pointer_cast(send.data()),send_size,DataT,mpi_dest,id*4+2,comm,&req_send);
-            }
+        have_req_send = (send_size != 0);
+        if (have_req_send) {
+            MPI_Isend((ElemT*)thrust::raw_pointer_cast(send.data()),send_size,DataT,mpi_dest,id*4+2,comm,&req_send);
         }
-        if( recv_size != 0 ) {
-            // No resize: recv is pre-allocated to global_max_ket_size by the caller.
-            // MPI_Irecv writes recv_size elements directly into the device buffer.
-            {
-                MPI_Irecv((ElemT*)thrust::raw_pointer_cast(recv.data()),recv_size,DataT,mpi_source,id*4+2,comm,&req_recv);
-            }
-        }
-        // recv_size == 0: nothing to receive; Sync() will return false for ket.
-
-        if( send_size_map != 0 ) {
-            {
-                MPI_Isend((uint32_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,MPI_UINT32_T,mpi_dest,id*4+3,comm,&req_send_map);
-            }
+        size_t max_recv_ket = recv.size();
+        have_req_recv = (max_recv_ket != 0);
+        if (have_req_recv) {
+            MPI_Irecv((ElemT*)thrust::raw_pointer_cast(recv.data()),max_recv_ket,DataT,mpi_source,id*4+2,comm,&req_recv);
         }
 
-        // recv_map_base: pointer used to set up recv_map field offsets below.
-        uint32_t* recv_map_base;
-        if( recv_size_map != 0 ) {
-            // No resize: recv_map_storage is pre-allocated to global_max_map_size.
-            {
-                MPI_Irecv((uint32_t*)thrust::raw_pointer_cast(recv_map_storage.data()),recv_size_map,MPI_UINT32_T,mpi_source,id*4+3,comm,&req_recv_map);
-            }
-            recv_map_base = thrust::raw_pointer_cast(recv_map_storage.data());
-        } else {
-            // recv_size_map == 0: degenerate case; point recv_map at send's map.
-            // Sync() will not swap if recv_size is also 0.
-            recv_offset = send_offset;
-            recv_map_base = const_cast<uint32_t*>(thrust::raw_pointer_cast(send_map_storage.data()));
+        have_req_send_map = (send_size_map != 0);
+        if (have_req_send_map) {
+            MPI_Isend((uint32_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,MPI_UINT32_T,mpi_dest,id*4+3,comm,&req_send_map);
         }
-        recv_map.AdetToDetOffset = recv_map_base + recv_offset[2];
-        recv_map.BdetToDetOffset = recv_map_base + recv_offset[3];
-        recv_map.AdetIndex = recv_map_base + recv_offset[4];
-        recv_map.BdetIndex = recv_map_base + recv_offset[5];
-        recv_map.AdetToBdetSM = recv_map_base + recv_offset[6];
-        recv_map.AdetToDetSM = recv_map_base + recv_offset[7];
-        recv_map.BdetToAdetSM = recv_map_base + recv_offset[8];
-        recv_map.BdetToDetSM = recv_map_base + recv_offset[9];
-        recv_map.size_adet = static_cast<uint32_t>(recv_offset[10]);
-        recv_map.size_bdet = static_cast<uint32_t>(recv_offset[11]);
+        size_t max_recv_map = recv_map_storage.size();
+        have_req_recv_map = (max_recv_map != 0);
+        if (have_req_recv_map) {
+            MPI_Irecv((uint32_t*)thrust::raw_pointer_cast(recv_map_storage.data()),max_recv_map,MPI_UINT32_T,mpi_source,id*4+3,comm,&req_recv_map);
+        }
+
+        // Save recv_map pointer and base address so Sync() can set up the field
+        // pointers after the offset message arrives with the actual offsets.
+        recv_map_ptr        = &recv_map;
+        recv_map_base_saved = thrust::raw_pointer_cast(recv_map_storage.data());
     }
 
     bool Sync(void)
     {
-        bool recv = false;
-        if (send_size > 0) {
+        // Wait for the offset message from the ring-sender.  Previously this
+        // Waitall was inside ExchangeAsync, blocking before GPU kernels started.
+        // Moving it here overlaps the offset handshake with GPU kernel execution.
+        {
             MPI_Status st;
-
-            {
-                MPI_Wait(&req_send, &st);
-            }
+            MPI_Wait(&req_size_recv, &st);
         }
-        if (recv_size > 0) {
-            MPI_Status st;
+        recv_size     = recv_offset_buf[0];
+        recv_size_map = recv_offset_buf[1];
 
-            {
-                MPI_Wait(&req_recv, &st);
-            }
-            recv = true;
+        // Set up recv_map field pointers from the received offsets.
+        if (recv_map_ptr) {
+            uint32_t* base = recv_map_base_saved;
+            recv_map_ptr->AdetToDetOffset = base + recv_offset_buf[2];
+            recv_map_ptr->BdetToDetOffset = base + recv_offset_buf[3];
+            recv_map_ptr->AdetIndex       = base + recv_offset_buf[4];
+            recv_map_ptr->BdetIndex       = base + recv_offset_buf[5];
+            recv_map_ptr->AdetToBdetSM    = base + recv_offset_buf[6];
+            recv_map_ptr->AdetToDetSM     = base + recv_offset_buf[7];
+            recv_map_ptr->BdetToAdetSM    = base + recv_offset_buf[8];
+            recv_map_ptr->BdetToDetSM     = base + recv_offset_buf[9];
+            recv_map_ptr->size_adet       = static_cast<uint32_t>(recv_offset_buf[10]);
+            recv_map_ptr->size_bdet       = static_cast<uint32_t>(recv_offset_buf[11]);
+            recv_map_ptr        = nullptr;
+            recv_map_base_saved = nullptr;
         }
-        if (send_size_map > 0) {
-            MPI_Status st;
 
-            {
-                MPI_Wait(&req_send_map, &st);
-            }
+        if (have_req_send) {
+            MPI_Status st;
+            MPI_Wait(&req_send, &st);
+            have_req_send = false;
         }
-        if (recv_size_map > 0) {
+        if (have_req_recv) {
             MPI_Status st;
-
-            {
-                MPI_Wait(&req_recv_map, &st);
-            }
-            recv = true;
+            MPI_Wait(&req_recv, &st);
+            have_req_recv = false;
+        }
+        if (have_req_send_map) {
+            MPI_Status st;
+            MPI_Wait(&req_send_map, &st);
+            have_req_send_map = false;
+        }
+        if (have_req_recv_map) {
+            MPI_Status st;
+            MPI_Wait(&req_recv_map, &st);
+            have_req_recv_map = false;
+        }
+        // Wait for offset send last — send_offset_buf must stay alive until here.
+        {
+            MPI_Status st;
+            MPI_Wait(&req_size_send, &st);
         }
 
         send_size = 0;
-        recv_size = 0;
         send_size_map = 0;
-        recv_size_map = 0;
-        return recv;
+        // recv_size and recv_size_map remain valid for get_recv_size() /
+        // get_recv_size_map() calls after Sync() returns.
+        return (recv_size > 0);
     }
 };
 

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -135,44 +135,32 @@ public:
         size_bdet = idxmap.size_bdet;
     }
 
-    inline __device__ __host__ int64_t adet_lower_bound(size_t jast, size_t jbst, size_t start = 0)
+    inline __device__ __host__ std::pair<bool, uint32_t> adet_lower_bound(uint32_t jast, uint32_t jbst)
     {
-        uint32_t is = AdetToDetOffset[jast] + static_cast<uint32_t>(start);
+        uint32_t is = AdetToDetOffset[jast];
         uint32_t ie = AdetToDetOffset[jast + 1];
-        uint32_t i = (is + ie) / 2;
         while (is != ie) {
-            if (AdetToBdetSM[i] < static_cast<uint32_t>(jbst)) {
+            uint32_t i = (is + ie) / 2;
+            if (AdetToBdetSM[i] < jbst)
                 is = i + 1;
-                i = (is + ie) / 2;
-            } else {
+            else
                 ie = i;
-                i = (is + ie) / 2;
-            }
         }
-        if (ie == AdetToDetOffset[jast + 1]) {
-            return -1;
-        }
-        return static_cast<int64_t>(i);
+        return {ie != AdetToDetOffset[jast + 1] && AdetToBdetSM[ie] == jbst, ie};
     }
 
-    inline __device__ __host__ int64_t bdet_lower_bound(size_t jbst, size_t jast)
+    inline __device__ __host__ std::pair<bool, uint32_t> bdet_lower_bound(uint32_t jbst, uint32_t jast)
     {
         uint32_t is = BdetToDetOffset[jbst];
         uint32_t ie = BdetToDetOffset[jbst + 1];
-        uint32_t i = (is + ie) / 2;
         while (is != ie) {
-            if (BdetToAdetSM[i] < static_cast<uint32_t>(jast)) {
+            uint32_t i = (is + ie) / 2;
+            if (BdetToAdetSM[i] < jast)
                 is = i + 1;
-                i = (is + ie) / 2;
-            } else {
+            else
                 ie = i;
-                i = (is + ie) / 2;
-            }
         }
-        if (ie == BdetToDetOffset[jbst + 1]) {
-            return -1;
-        }
-        return static_cast<int64_t>(i);
+        return {ie != BdetToDetOffset[jbst + 1] && BdetToAdetSM[ie] == jast, ie};
     }
 
 

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -599,6 +599,88 @@ public:
         recv_map_base_saved = thrust::raw_pointer_cast(recv_map_storage.data());
     }
 
+    // CPU-staging variant of ExchangeAsync.
+    //
+    // MPI send/recv use CPU-pinned host pointers so the NIC reads/writes CPU
+    // DRAM (LPDDR5X) rather than GPU HBM, eliminating bandwidth contention with
+    // the compute kernels.  After Sync() the caller copies h_recv/h_recv_map to
+    // GPU via cudaMemcpyAsync on a copy_stream, then records a cudaEvent that
+    // the compute_stream waits on before launching the next task's kernels.
+    //
+    // send_gpu_base: thrust::raw_pointer_cast(tidxmap_storage[active_buf].data())
+    //   — needed to encode field offsets into the offset packet (same as
+    //   ExchangeAsync uses send_map_storage.data() for this).
+    // recv_map_gpu_base: thrust::raw_pointer_cast(tidxmap_storage[recv_buf].data())
+    //   — Sync() applies received offsets to this GPU base to fix up recv_map
+    //   field pointers.  The caller's subsequent cudaMemcpyAsync fills that GPU
+    //   storage, making the pointers valid before compute_stream uses them.
+    void ExchangeAsyncHost(
+                const ElemT*             h_send,
+                size_t                   send_ket_size,
+                ElemT*                   h_recv,
+                size_t                   max_recv_ket,
+                const DetIndexMapThrust& send_map,
+                const uint32_t*          send_gpu_base,
+                const uint32_t*          h_send_map,
+                size_t                   send_map_size,
+                DetIndexMapThrust&       recv_map,
+                uint32_t*                h_recv_map,
+                size_t                   max_recv_map,
+                uint32_t*                recv_map_gpu_base,
+                int slide,
+                MPI_Comm comm,
+                int id)
+    {
+        int mpi_rank; MPI_Comm_rank(comm, &mpi_rank);
+        int mpi_size; MPI_Comm_size(comm, &mpi_size);
+        int mpi_dest   = (mpi_size + mpi_rank + slide) % mpi_size;
+        int mpi_source = (mpi_size + mpi_rank - slide) % mpi_size;
+
+        // Offset packet encoding — identical to ExchangeAsync, using the GPU
+        // base pointer for field-offset arithmetic (layout is the same).
+        send_offset_buf[0]  = send_ket_size;
+        send_offset_buf[1]  = send_map_size;
+        send_offset_buf[2]  = (size_t)(send_map.AdetToDetOffset - send_gpu_base);
+        send_offset_buf[3]  = (size_t)(send_map.BdetToDetOffset - send_gpu_base);
+        send_offset_buf[4]  = (size_t)(send_map.AdetIndex       - send_gpu_base);
+        send_offset_buf[5]  = (size_t)(send_map.BdetIndex       - send_gpu_base);
+        send_offset_buf[6]  = (size_t)(send_map.AdetToBdetSM    - send_gpu_base);
+        send_offset_buf[7]  = (size_t)(send_map.AdetToDetSM     - send_gpu_base);
+        send_offset_buf[8]  = (size_t)(send_map.BdetToAdetSM    - send_gpu_base);
+        send_offset_buf[9]  = (size_t)(send_map.BdetToDetSM     - send_gpu_base);
+        send_offset_buf[10] = (size_t)send_map.size_adet;
+        send_offset_buf[11] = (size_t)send_map.size_bdet;
+
+        MPI_Isend(send_offset_buf.data(), 12, SBD_MPI_SIZE_T, mpi_dest,   id*4, comm, &req_size_send);
+        MPI_Irecv(recv_offset_buf.data(), 12, SBD_MPI_SIZE_T, mpi_source, id*4, comm, &req_size_recv);
+
+        send_size     = send_ket_size;
+        send_size_map = send_map_size;
+
+        // Data send/recv via host pointers — NIC reads/writes CPU DRAM only.
+        MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+        have_req_send = (send_size != 0);
+        if (have_req_send)
+            MPI_Isend(const_cast<ElemT*>(h_send), static_cast<int>(send_size),
+                      DataT, mpi_dest, id*4+2, comm, &req_send);
+        have_req_recv = (max_recv_ket != 0);
+        if (have_req_recv)
+            MPI_Irecv(h_recv, static_cast<int>(max_recv_ket),
+                      DataT, mpi_source, id*4+2, comm, &req_recv);
+
+        have_req_send_map = (send_size_map != 0);
+        if (have_req_send_map)
+            MPI_Isend(const_cast<uint32_t*>(h_send_map), static_cast<int>(send_size_map),
+                      MPI_UINT32_T, mpi_dest, id*4+3, comm, &req_send_map);
+        have_req_recv_map = (max_recv_map != 0);
+        if (have_req_recv_map)
+            MPI_Irecv(h_recv_map, static_cast<int>(max_recv_map),
+                      MPI_UINT32_T, mpi_source, id*4+3, comm, &req_recv_map);
+
+        recv_map_ptr        = &recv_map;
+        recv_map_base_saved = recv_map_gpu_base;
+    }
+
     bool Sync(void)
     {
         // Wait for the offset message from the ring-sender.  Previously this

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -19,16 +19,16 @@ namespace gdb
 class DetIndexMapThrust
 {
 public:
-    size_t* AdetToDetOffset;
-    size_t* BdetToDetOffset;
-    size_t* AdetIndex;
-    size_t* BdetIndex;
-    size_t* AdetToBdetSM;
-    size_t* AdetToDetSM;
-    size_t* BdetToAdetSM;
-    size_t* BdetToDetSM;
-    size_t size_adet = 0;
-    size_t size_bdet = 0;
+    uint32_t* AdetToDetOffset;
+    uint32_t* BdetToDetOffset;
+    uint32_t* AdetIndex;
+    uint32_t* BdetIndex;
+    uint32_t* AdetToBdetSM;
+    uint32_t* AdetToDetSM;
+    uint32_t* BdetToAdetSM;
+    uint32_t* BdetToDetSM;
+    uint32_t size_adet = 0;
+    uint32_t size_bdet = 0;
 
     DetIndexMapThrust() {}
 
@@ -46,30 +46,36 @@ public:
         size_bdet = other.size_bdet;
     }
 
-    DetIndexMapThrust(thrust::device_vector<size_t>& storage, const DetIndexMap& idxmap)
+    DetIndexMapThrust(thrust::device_vector<uint32_t>& storage, const DetIndexMap& idxmap)
     {
-        size_t size = 0;
+        const size_t n_adet = idxmap.AdetToDetLen.size();
+        const size_t n_bdet = idxmap.BdetToDetLen.size();
 
-        std::vector<size_t> offset_adet(idxmap.AdetToDetLen.size() + 1);
-        std::vector<size_t> offset_bdet(idxmap.BdetToDetLen.size() + 1);
-        for(size_t i=0; i < idxmap.AdetToDetLen.size(); i++) {
+        assert(n_adet <= UINT32_MAX);
+        assert(n_bdet <= UINT32_MAX);
+
+        std::vector<uint32_t> offset_adet(n_adet + 1);
+        std::vector<uint32_t> offset_bdet(n_bdet + 1);
+        for (size_t i = 0; i < n_adet; i++) {
             offset_adet[i] = size_adet;
-            size_adet += idxmap.AdetToDetLen[i];
+            assert(idxmap.AdetToDetLen[i] <= UINT32_MAX - (size_t)size_adet);
+            size_adet += static_cast<uint32_t>(idxmap.AdetToDetLen[i]);
         }
-        offset_adet[idxmap.AdetToDetLen.size()] = size_adet;
+        offset_adet[n_adet] = size_adet;
 
-        for(size_t i=0; i < idxmap.BdetToDetLen.size(); i++) {
+        for (size_t i = 0; i < n_bdet; i++) {
             offset_bdet[i] = size_bdet;
-            size_bdet += idxmap.BdetToDetLen[i];
+            assert(idxmap.BdetToDetLen[i] <= UINT32_MAX - (size_t)size_bdet);
+            size_bdet += static_cast<uint32_t>(idxmap.BdetToDetLen[i]);
         }
-        offset_bdet[idxmap.BdetToDetLen.size()] = size_bdet;
+        offset_bdet[n_bdet] = size_bdet;
 
-        size = idxmap.AdetToDetLen.size() + 1 + idxmap.BdetToDetLen.size() + 1 + size_adet * 3 + size_bdet * 3;
+        size_t size = (n_adet + 1) + (n_bdet + 1) + (size_t)size_adet * 3 + (size_t)size_bdet * 3;
         storage.resize(size);
-        size_t* base_memory = (size_t*)thrust::raw_pointer_cast(storage.data());
+        uint32_t* base_memory = thrust::raw_pointer_cast(storage.data());
 
         size_t count = 0;
-        // store offset
+        // store offsets
         AdetToDetOffset = base_memory + count;
         thrust::copy_n(offset_adet.begin(), offset_adet.size(), storage.begin() + count);
         count += offset_adet.size();
@@ -78,21 +84,29 @@ public:
         thrust::copy_n(offset_bdet.begin(), offset_bdet.size(), storage.begin() + count);
         count += offset_bdet.size();
 
-        // set Adet, Bdet indices
+        // set Adet, Bdet indices — per-element fill_n, one kernel per segment
         AdetIndex = base_memory + count;
-        for(size_t i=0; i < idxmap.AdetToDetLen.size(); i++) {
-            thrust::fill_n(storage.begin() + count + offset_adet[i], idxmap.AdetToDetLen[i], i);
+        for (size_t i = 0; i < n_adet; i++) {
+            thrust::fill_n(storage.begin() + count + offset_adet[i],
+                           idxmap.AdetToDetLen[i], static_cast<uint32_t>(i));
         }
         count += size_adet;
 
         BdetIndex = base_memory + count;
-        for(size_t i=0; i < idxmap.BdetToDetLen.size(); i++) {
-            thrust::fill_n(storage.begin() + count + offset_bdet[i], idxmap.BdetToDetLen[i], i);
+        for (size_t i = 0; i < n_bdet; i++) {
+            thrust::fill_n(storage.begin() + count + offset_bdet[i],
+                           idxmap.BdetToDetLen[i], static_cast<uint32_t>(i));
         }
         count += size_bdet;
 
-        // copy SMs
-        thrust::copy_n(idxmap.storage.begin(), size_adet * 2 + size_bdet * 2, storage.begin() + count);
+        // copy SMs: convert size_t CPU data to uint32_t on device
+        const size_t sm_size = (size_t)size_adet * 2 + (size_t)size_bdet * 2;
+        std::vector<uint32_t> sm_buf(sm_size);
+        for (size_t i = 0; i < sm_size; i++) {
+            assert(idxmap.storage[i] <= UINT32_MAX);
+            sm_buf[i] = static_cast<uint32_t>(idxmap.storage[i]);
+        }
+        thrust::copy_n(sm_buf.begin(), sm_buf.size(), storage.begin() + count);
         AdetToDetSM = base_memory + count;
         count += size_adet;
         AdetToBdetSM = base_memory + count;
@@ -102,12 +116,12 @@ public:
         BdetToAdetSM = base_memory + count;
     }
 
-    void copy(thrust::device_vector<size_t>& storage, const DetIndexMapThrust& idxmap, const thrust::device_vector<size_t>& src_storage)
+    void copy(thrust::device_vector<uint32_t>& storage, const DetIndexMapThrust& idxmap, const thrust::device_vector<uint32_t>& src_storage)
     {
         storage = src_storage;
 
-        size_t* base = (size_t*)thrust::raw_pointer_cast(storage.data());
-        size_t* src_base = (size_t*)thrust::raw_pointer_cast(src_storage.data());
+        uint32_t* base = thrust::raw_pointer_cast(storage.data());
+        const uint32_t* src_base = thrust::raw_pointer_cast(src_storage.data());
 
         AdetToDetOffset = base + (idxmap.AdetToDetOffset - src_base);
         BdetToDetOffset = base + (idxmap.BdetToDetOffset - src_base);
@@ -123,11 +137,11 @@ public:
 
     inline __device__ __host__ int64_t adet_lower_bound(size_t jast, size_t jbst, size_t start = 0)
     {
-        size_t is = AdetToDetOffset[jast] + start;
-        size_t ie = AdetToDetOffset[jast + 1];
-        size_t i = (is + ie) / 2;
-        while(is != ie) {
-            if( AdetToBdetSM[i] < jbst) {
+        uint32_t is = AdetToDetOffset[jast] + static_cast<uint32_t>(start);
+        uint32_t ie = AdetToDetOffset[jast + 1];
+        uint32_t i = (is + ie) / 2;
+        while (is != ie) {
+            if (AdetToBdetSM[i] < static_cast<uint32_t>(jbst)) {
                 is = i + 1;
                 i = (is + ie) / 2;
             } else {
@@ -136,19 +150,18 @@ public:
             }
         }
         if (ie == AdetToDetOffset[jast + 1]) {
-            // not found
             return -1;
         }
-        return i;
+        return static_cast<int64_t>(i);
     }
 
     inline __device__ __host__ int64_t bdet_lower_bound(size_t jbst, size_t jast)
     {
-        size_t is = BdetToDetOffset[jbst];
-        size_t ie = BdetToDetOffset[jbst + 1];
-        size_t i = (is + ie) / 2;
-        while(is != ie) {
-            if( BdetToAdetSM[i] < jast) {
+        uint32_t is = BdetToDetOffset[jbst];
+        uint32_t ie = BdetToDetOffset[jbst + 1];
+        uint32_t i = (is + ie) / 2;
+        while (is != ie) {
+            if (BdetToAdetSM[i] < static_cast<uint32_t>(jast)) {
                 is = i + 1;
                 i = (is + ie) / 2;
             } else {
@@ -157,10 +170,9 @@ public:
             }
         }
         if (ie == BdetToDetOffset[jbst + 1]) {
-            // not found
             return -1;
         }
-        return i;
+        return static_cast<int64_t>(i);
     }
 
 
@@ -400,31 +412,33 @@ public:
 
 
 void MpiSlide(const DetIndexMapThrust& send_map,
-        const thrust::device_vector<size_t>& send_storage,
+        const thrust::device_vector<uint32_t>& send_storage,
         DetIndexMapThrust& recv_map,
-        thrust::device_vector<size_t>& recv_storage,
+        thrust::device_vector<uint32_t>& recv_storage,
         int slide,
         MPI_Comm comm)
 {
     std::vector<size_t> send_offset;
     std::vector<size_t> recv_offset;
 
-    size_t* base = (size_t*)thrust::raw_pointer_cast(send_storage.data());
-    send_offset.push_back((size_t)(send_map.AdetToDetOffset - base));
-    send_offset.push_back((size_t)(send_map.BdetToDetOffset - base));
-    send_offset.push_back((size_t)(send_map.AdetIndex - base));
-    send_offset.push_back((size_t)(send_map.BdetIndex - base));
-    send_offset.push_back((size_t)(send_map.AdetToBdetSM - base));
-    send_offset.push_back((size_t)(send_map.AdetToDetSM - base));
-    send_offset.push_back((size_t)(send_map.BdetToAdetSM - base));
-    send_offset.push_back((size_t)(send_map.BdetToDetSM - base));
-    send_offset.push_back(send_map.size_adet);
-    send_offset.push_back(send_map.size_bdet);
+    {
+        const uint32_t* send_base = thrust::raw_pointer_cast(send_storage.data());
+        send_offset.push_back((size_t)(send_map.AdetToDetOffset - send_base));
+        send_offset.push_back((size_t)(send_map.BdetToDetOffset - send_base));
+        send_offset.push_back((size_t)(send_map.AdetIndex - send_base));
+        send_offset.push_back((size_t)(send_map.BdetIndex - send_base));
+        send_offset.push_back((size_t)(send_map.AdetToBdetSM - send_base));
+        send_offset.push_back((size_t)(send_map.AdetToDetSM - send_base));
+        send_offset.push_back((size_t)(send_map.BdetToAdetSM - send_base));
+        send_offset.push_back((size_t)(send_map.BdetToDetSM - send_base));
+    }
+    send_offset.push_back((size_t)send_map.size_adet);
+    send_offset.push_back((size_t)send_map.size_bdet);
 
     sbd::MpiSlide(send_storage, recv_storage, slide, comm);
     sbd::MpiSlide(send_offset, recv_offset, slide, comm);
 
-    base = (size_t*)thrust::raw_pointer_cast(recv_storage.data());
+    uint32_t* base = thrust::raw_pointer_cast(recv_storage.data());
     recv_map.AdetToDetOffset = base + recv_offset[0];
     recv_map.BdetToDetOffset = base + recv_offset[1];
     recv_map.AdetIndex = base + recv_offset[2];
@@ -433,8 +447,8 @@ void MpiSlide(const DetIndexMapThrust& send_map,
     recv_map.AdetToDetSM = base + recv_offset[5];
     recv_map.BdetToAdetSM = base + recv_offset[6];
     recv_map.BdetToDetSM = base + recv_offset[7];
-    recv_map.size_adet = recv_offset[8];
-    recv_map.size_bdet = recv_offset[9];
+    recv_map.size_adet = static_cast<uint32_t>(recv_offset[8]);
+    recv_map.size_bdet = static_cast<uint32_t>(recv_offset[9]);
 }
 
 
@@ -462,9 +476,9 @@ public:
     void ExchangeAsync(const thrust::device_vector<ElemT> &send,
                 thrust::device_vector<ElemT> &recv,
                 const DetIndexMapThrust& send_map,
-                const thrust::device_vector<size_t> &send_map_storage,
+                const thrust::device_vector<uint32_t> &send_map_storage,
                 DetIndexMapThrust& recv_map,
-                thrust::device_vector<size_t> &recv_map_storage,
+                thrust::device_vector<uint32_t> &recv_map_storage,
                 int slide,
                 MPI_Comm comm,
                 int id)
@@ -485,17 +499,19 @@ public:
         send_offset[1] = send_map_storage.size();
 
         // exchange idxmap offset
-        size_t* base = (size_t*)thrust::raw_pointer_cast(send_map_storage.data());
-        send_offset[2] = (size_t)(send_map.AdetToDetOffset - base);
-        send_offset[3] = (size_t)(send_map.BdetToDetOffset - base);
-        send_offset[4] = (size_t)(send_map.AdetIndex - base);
-        send_offset[5] = (size_t)(send_map.BdetIndex - base);
-        send_offset[6] = (size_t)(send_map.AdetToBdetSM - base);
-        send_offset[7] = (size_t)(send_map.AdetToDetSM - base);
-        send_offset[8] = (size_t)(send_map.BdetToAdetSM - base);
-        send_offset[9] = (size_t)(send_map.BdetToDetSM - base);
-        send_offset[10] = send_map.size_adet;
-        send_offset[11] = send_map.size_bdet;
+        {
+            const uint32_t* send_base = thrust::raw_pointer_cast(send_map_storage.data());
+            send_offset[2] = (size_t)(send_map.AdetToDetOffset - send_base);
+            send_offset[3] = (size_t)(send_map.BdetToDetOffset - send_base);
+            send_offset[4] = (size_t)(send_map.AdetIndex - send_base);
+            send_offset[5] = (size_t)(send_map.BdetIndex - send_base);
+            send_offset[6] = (size_t)(send_map.AdetToBdetSM - send_base);
+            send_offset[7] = (size_t)(send_map.AdetToDetSM - send_base);
+            send_offset[8] = (size_t)(send_map.BdetToAdetSM - send_base);
+            send_offset[9] = (size_t)(send_map.BdetToDetSM - send_base);
+        }
+        send_offset[10] = (size_t)send_map.size_adet;
+        send_offset[11] = (size_t)send_map.size_bdet;
 
         MPI_Isend(send_offset.data(),12,SBD_MPI_SIZE_T,mpi_dest,id*4,comm,&req_size[0]);
         MPI_Irecv(recv_offset.data(),12,SBD_MPI_SIZE_T,mpi_source,id*4,comm,&req_size[1]);
@@ -519,17 +535,17 @@ public:
         }
 
         if( send_size_map != 0 ) {
-            MPI_Isend((size_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,SBD_MPI_SIZE_T,mpi_dest,id*4+3,comm,&req_send_map);
+            MPI_Isend((uint32_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,MPI_UINT32_T,mpi_dest,id*4+3,comm,&req_send_map);
         }
         if( recv_size_map != 0 ) {
             recv_map_storage.resize(recv_size_map);
-            MPI_Irecv((size_t*)thrust::raw_pointer_cast(recv_map_storage.data()),recv_size_map,SBD_MPI_SIZE_T,mpi_source,id*4+3,comm,&req_recv_map);
+            MPI_Irecv((uint32_t*)thrust::raw_pointer_cast(recv_map_storage.data()),recv_size_map,MPI_UINT32_T,mpi_source,id*4+3,comm,&req_recv_map);
 
         } else {
             recv_map_storage = send_map_storage;
             recv_offset = send_offset;
         }
-        base = (size_t*)thrust::raw_pointer_cast(recv_map_storage.data());
+        uint32_t* base = thrust::raw_pointer_cast(recv_map_storage.data());
         recv_map.AdetToDetOffset = base + recv_offset[2];
         recv_map.BdetToDetOffset = base + recv_offset[3];
         recv_map.AdetIndex = base + recv_offset[4];
@@ -538,8 +554,8 @@ public:
         recv_map.AdetToDetSM = base + recv_offset[7];
         recv_map.BdetToAdetSM = base + recv_offset[8];
         recv_map.BdetToDetSM = base + recv_offset[9];
-        recv_map.size_adet = recv_offset[10];
-        recv_map.size_bdet = recv_offset[11];
+        recv_map.size_adet = static_cast<uint32_t>(recv_offset[10]);
+        recv_map.size_bdet = static_cast<uint32_t>(recv_offset[11]);
     }
 
     bool Sync(void)

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -185,28 +185,28 @@ class ExcitationLookupThrust
 {
 public:
     int slide;
-    size_t* SelfFromAdetOffset;
-    size_t* SelfFromBdetOffset;
-    size_t* SinglesFromAdetOffset;
-    size_t* SinglesFromBdetOffset;
-    size_t* DoublesFromAdetOffset;
-    size_t* DoublesFromBdetOffset;
-    size_t* SelfFromAdetSM;
-    size_t* SelfFromBdetSM;
-    size_t* SinglesFromAdetSM;
+    uint32_t* SelfFromAdetOffset;
+    uint32_t* SelfFromBdetOffset;
+    uint32_t* SinglesFromAdetOffset;
+    uint32_t* SinglesFromBdetOffset;
+    uint32_t* DoublesFromAdetOffset;
+    uint32_t* DoublesFromBdetOffset;
+    uint32_t* SelfFromAdetSM;
+    uint32_t* SelfFromBdetSM;
+    uint32_t* SinglesFromAdetSM;
     int* SinglesAdetCrAnSM;
-    size_t* SinglesFromBdetSM;
+    uint32_t* SinglesFromBdetSM;
     int* SinglesBdetCrAnSM;
-    size_t* DoublesFromAdetSM;
+    uint32_t* DoublesFromAdetSM;
     int* DoublesAdetCrAnSM;
-    size_t* DoublesFromBdetSM;
+    uint32_t* DoublesFromBdetSM;
     int* DoublesBdetCrAnSM;
-    size_t size_self_adet = 0;
-    size_t size_self_bdet = 0;
-    size_t size_single_adet = 0;
-    size_t size_single_bdet = 0;
-    size_t size_double_adet = 0;
-    size_t size_double_bdet = 0;
+    uint32_t size_self_adet = 0;
+    uint32_t size_self_bdet = 0;
+    uint32_t size_single_adet = 0;
+    uint32_t size_single_bdet = 0;
+    uint32_t size_double_adet = 0;
+    uint32_t size_double_bdet = 0;
 
     ExcitationLookupThrust() {}
 
@@ -238,68 +238,74 @@ public:
         size_double_bdet = other.size_double_bdet;
     }
 
-    ExcitationLookupThrust(thrust::device_vector<size_t>& storage, thrust::device_vector<int>& cran_storage, const ExcitationLookup& exidx)
+    ExcitationLookupThrust(thrust::device_vector<uint32_t>& storage, thrust::device_vector<int>& cran_storage, const ExcitationLookup& exidx)
     {
         size_t size = 0;
 
         slide = exidx.slide;
 
-        std::vector<size_t> offset_self_adet(exidx.SelfFromAdetLen.size() + 1);
+        std::vector<uint32_t> offset_self_adet(exidx.SelfFromAdetLen.size() + 1);
         for(size_t i=0; i < exidx.SelfFromAdetLen.size(); i++) {
             offset_self_adet[i] = size_self_adet;
-            size_self_adet += exidx.SelfFromAdetLen[i];
+            assert(exidx.SelfFromAdetLen[i] <= UINT32_MAX - (size_t)size_self_adet);
+            size_self_adet += static_cast<uint32_t>(exidx.SelfFromAdetLen[i]);
             size++;
         }
         offset_self_adet[exidx.SelfFromAdetLen.size()] = size_self_adet;
-        size += size_self_adet + 1;
+        size += (size_t)size_self_adet + 1;
 
-        std::vector<size_t> offset_self_bdet(exidx.SelfFromBdetLen.size() + 1);
+        std::vector<uint32_t> offset_self_bdet(exidx.SelfFromBdetLen.size() + 1);
         for(size_t i=0; i < exidx.SelfFromBdetLen.size(); i++) {
             offset_self_bdet[i] = size_self_bdet;
-            size_self_bdet += exidx.SelfFromBdetLen[i];
+            assert(exidx.SelfFromBdetLen[i] <= UINT32_MAX - (size_t)size_self_bdet);
+            size_self_bdet += static_cast<uint32_t>(exidx.SelfFromBdetLen[i]);
             size++;
         }
         offset_self_bdet[exidx.SelfFromBdetLen.size()] = size_self_bdet;
-        size += size_self_bdet + 1;
+        size += (size_t)size_self_bdet + 1;
 
-        std::vector<size_t> offset_single_adet(exidx.SinglesFromAdetLen.size() + 1);
+        std::vector<uint32_t> offset_single_adet(exidx.SinglesFromAdetLen.size() + 1);
         for(size_t i=0; i < exidx.SinglesFromAdetLen.size(); i++) {
             offset_single_adet[i] = size_single_adet;
-            size_single_adet += exidx.SinglesFromAdetLen[i];
+            assert(exidx.SinglesFromAdetLen[i] <= UINT32_MAX - (size_t)size_single_adet);
+            size_single_adet += static_cast<uint32_t>(exidx.SinglesFromAdetLen[i]);
             size++;
         }
         offset_single_adet[exidx.SinglesFromAdetLen.size()] = size_single_adet;
-        size += size_single_adet + 1;
+        size += (size_t)size_single_adet + 1;
 
-        std::vector<size_t> offset_double_adet(exidx.DoublesFromAdetLen.size() + 1);
+        std::vector<uint32_t> offset_double_adet(exidx.DoublesFromAdetLen.size() + 1);
         for(size_t i=0; i < exidx.DoublesFromAdetLen.size(); i++) {
             offset_double_adet[i] = size_double_adet;
-            size_double_adet += exidx.DoublesFromAdetLen[i];
+            assert(exidx.DoublesFromAdetLen[i] <= UINT32_MAX - (size_t)size_double_adet);
+            size_double_adet += static_cast<uint32_t>(exidx.DoublesFromAdetLen[i]);
             size++;
         }
         offset_double_adet[exidx.DoublesFromAdetLen.size()] = size_double_adet;
-        size += size_double_adet + 1;
+        size += (size_t)size_double_adet + 1;
 
-        std::vector<size_t> offset_single_bdet(exidx.SinglesFromBdetLen.size() + 1);
+        std::vector<uint32_t> offset_single_bdet(exidx.SinglesFromBdetLen.size() + 1);
         for(size_t i=0; i < exidx.SinglesFromBdetLen.size(); i++) {
             offset_single_bdet[i] = size_single_bdet;
-            size_single_bdet += exidx.SinglesFromBdetLen[i];
+            assert(exidx.SinglesFromBdetLen[i] <= UINT32_MAX - (size_t)size_single_bdet);
+            size_single_bdet += static_cast<uint32_t>(exidx.SinglesFromBdetLen[i]);
             size++;
         }
         offset_single_bdet[exidx.SinglesFromBdetLen.size()] = size_single_bdet;
-        size += size_single_bdet + 1;
+        size += (size_t)size_single_bdet + 1;
 
-        std::vector<size_t> offset_double_bdet(exidx.DoublesFromBdetLen.size() + 1);
+        std::vector<uint32_t> offset_double_bdet(exidx.DoublesFromBdetLen.size() + 1);
         for(size_t i=0; i < exidx.DoublesFromBdetLen.size(); i++) {
             offset_double_bdet[i] = size_double_bdet;
-            size_double_bdet += exidx.DoublesFromBdetLen[i];
+            assert(exidx.DoublesFromBdetLen[i] <= UINT32_MAX - (size_t)size_double_bdet);
+            size_double_bdet += static_cast<uint32_t>(exidx.DoublesFromBdetLen[i]);
             size++;
         }
         offset_double_bdet[exidx.DoublesFromBdetLen.size()] = size_double_bdet;
-        size += size_double_bdet + 1;
+        size += (size_t)size_double_bdet + 1;
 
         storage.resize(size);
-        size_t* base_memory = (size_t*)thrust::raw_pointer_cast(storage.data());
+        uint32_t* base_memory = thrust::raw_pointer_cast(storage.data());
 
         size_t count = 0;
         // store offset
@@ -327,8 +333,14 @@ public:
         thrust::copy_n(offset_double_bdet.begin(), offset_double_bdet.size(), storage.begin() + count);
         count += offset_double_bdet.size();
 
-        // copy SMs
-        thrust::copy_n(exidx.storage.begin(), size - count, storage.begin() + count);
+        // copy SMs (exidx.storage is size_t; convert to uint32_t with overflow assertions)
+        size_t sm_count = size - count;
+        std::vector<uint32_t> sm_buf(sm_count);
+        for (size_t i = 0; i < sm_count; i++) {
+            assert(exidx.storage[i] <= UINT32_MAX);
+            sm_buf[i] = static_cast<uint32_t>(exidx.storage[i]);
+        }
+        thrust::copy_n(sm_buf.begin(), sm_count, storage.begin() + count);
         SelfFromAdetSM = base_memory + count;
         count += size_self_adet;
         SinglesFromAdetSM = base_memory + count;
@@ -342,7 +354,7 @@ public:
         DoublesFromBdetSM = base_memory + count;
 
         // convert CrAn from AoS to SoA
-        size_t size_cran = size_single_adet * 2 + size_double_adet * 4 + size_single_bdet * 2 + size_double_bdet * 4;
+        size_t size_cran = (size_t)size_single_adet * 2 + (size_t)size_double_adet * 4 + (size_t)size_single_bdet * 2 + (size_t)size_double_bdet * 4;
         std::vector<int> buf;
         count = 0;
 
@@ -350,61 +362,61 @@ public:
         int* base_cran = (int*)thrust::raw_pointer_cast(cran_storage.data());
 
         SinglesAdetCrAnSM = base_cran + count;
-        buf.resize(size_single_adet * 2);
+        buf.resize((size_t)size_single_adet * 2);
 #pragma omp parallel for
         for(size_t i=0; i < exidx.SinglesFromAdetLen.size(); i++) {
             for (int j=0; j <  exidx.SinglesFromAdetLen[i]; j++) {
                 size_t offset = offset_single_adet[i] + j;
                 buf[offset] = exidx.SinglesAdetCrAnSM[i][j * 2];
-                buf[size_single_adet + offset] = exidx.SinglesAdetCrAnSM[i][j * 2 + 1];
+                buf[(size_t)size_single_adet + offset] = exidx.SinglesAdetCrAnSM[i][j * 2 + 1];
             }
         }
-        thrust::copy_n(buf.begin(), size_single_adet * 2, cran_storage.begin() + count);
-        count += size_single_adet * 2;
+        thrust::copy_n(buf.begin(), (size_t)size_single_adet * 2, cran_storage.begin() + count);
+        count += (size_t)size_single_adet * 2;
 
 
         DoublesAdetCrAnSM = base_cran + count;
-        buf.resize(size_double_adet * 4);
+        buf.resize((size_t)size_double_adet * 4);
 #pragma omp parallel for
         for(size_t i=0; i < exidx.DoublesFromAdetLen.size(); i++) {
             for (int j=0; j <  exidx.DoublesFromAdetLen[i]; j++) {
                 size_t offset = offset_double_adet[i] + j;
                 buf[offset] = exidx.DoublesAdetCrAnSM[i][j * 4];
-                buf[size_double_adet + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 1];
-                buf[size_double_adet * 2 + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 2];
-                buf[size_double_adet * 3 + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 3];
+                buf[(size_t)size_double_adet + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 1];
+                buf[(size_t)size_double_adet * 2 + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 2];
+                buf[(size_t)size_double_adet * 3 + offset] = exidx.DoublesAdetCrAnSM[i][j * 4 + 3];
             }
         }
-        thrust::copy_n(buf.begin(), size_double_adet * 4, cran_storage.begin() + count);
-        count += size_double_adet * 4;
+        thrust::copy_n(buf.begin(), (size_t)size_double_adet * 4, cran_storage.begin() + count);
+        count += (size_t)size_double_adet * 4;
 
         SinglesBdetCrAnSM = base_cran + count;
-        buf.resize(size_single_bdet * 2);
+        buf.resize((size_t)size_single_bdet * 2);
 #pragma omp parallel for
         for(size_t i=0; i < exidx.SinglesFromBdetLen.size(); i++) {
             for (int j=0; j <  exidx.SinglesFromBdetLen[i]; j++) {
                 size_t offset = offset_single_bdet[i] + j;
                 buf[offset] = exidx.SinglesBdetCrAnSM[i][j * 2];
-                buf[size_single_bdet + offset] = exidx.SinglesBdetCrAnSM[i][j * 2 + 1];
+                buf[(size_t)size_single_bdet + offset] = exidx.SinglesBdetCrAnSM[i][j * 2 + 1];
             }
         }
-        thrust::copy_n(buf.begin(), size_single_bdet * 2, cran_storage.begin() + count);
-        count += size_single_bdet * 2;
+        thrust::copy_n(buf.begin(), (size_t)size_single_bdet * 2, cran_storage.begin() + count);
+        count += (size_t)size_single_bdet * 2;
 
         DoublesBdetCrAnSM = base_cran + count;
-        buf.resize(size_double_bdet * 4);
+        buf.resize((size_t)size_double_bdet * 4);
 #pragma omp parallel for
         for(size_t i=0; i < exidx.DoublesFromBdetLen.size(); i++) {
             for (int j=0; j <  exidx.DoublesFromBdetLen[i]; j++) {
                 size_t offset = offset_double_bdet[i] + j;
                 buf[offset] = exidx.DoublesBdetCrAnSM[i][j * 4];
-                buf[size_double_bdet + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 1];
-                buf[size_double_bdet * 2 + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 2];
-                buf[size_double_bdet * 3 + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 3];
+                buf[(size_t)size_double_bdet + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 1];
+                buf[(size_t)size_double_bdet * 2 + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 2];
+                buf[(size_t)size_double_bdet * 3 + offset] = exidx.DoublesBdetCrAnSM[i][j * 4 + 3];
             }
         }
-        thrust::copy_n(buf.begin(), size_double_bdet * 4, cran_storage.begin() + count);
-        count += size_double_bdet * 4;
+        thrust::copy_n(buf.begin(), (size_t)size_double_bdet * 4, cran_storage.begin() + count);
+        count += (size_t)size_double_bdet * 4;
     }
 
 

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -138,7 +138,8 @@ public:
     inline __device__ __host__ std::pair<bool, uint32_t> adet_lower_bound(uint32_t jast, uint32_t jbst)
     {
         uint32_t is = AdetToDetOffset[jast];
-        uint32_t ie = AdetToDetOffset[jast + 1];
+        const uint32_t i_upper = AdetToDetOffset[jast + 1];
+        uint32_t ie = i_upper;
         while (is != ie) {
             uint32_t i = (is + ie) / 2;
             if (AdetToBdetSM[i] < jbst)
@@ -146,13 +147,14 @@ public:
             else
                 ie = i;
         }
-        return {ie != AdetToDetOffset[jast + 1] && AdetToBdetSM[ie] == jbst, ie};
+        return {ie != i_upper && AdetToBdetSM[ie] == jbst, ie};
     }
 
     inline __device__ __host__ std::pair<bool, uint32_t> bdet_lower_bound(uint32_t jbst, uint32_t jast)
     {
         uint32_t is = BdetToDetOffset[jbst];
-        uint32_t ie = BdetToDetOffset[jbst + 1];
+        const uint32_t i_upper = BdetToDetOffset[jbst + 1];
+        uint32_t ie = i_upper;
         while (is != ie) {
             uint32_t i = (is + ie) / 2;
             if (BdetToAdetSM[i] < jast)
@@ -160,7 +162,7 @@ public:
             else
                 ie = i;
         }
-        return {ie != BdetToDetOffset[jbst + 1] && BdetToAdetSM[ie] == jast, ie};
+        return {ie != i_upper && BdetToAdetSM[ie] == jast, ie};
     }
 
 

--- a/include/sbd/chemistry/gdb/helper_thrust.h
+++ b/include/sbd/chemistry/gdb/helper_thrust.h
@@ -473,10 +473,36 @@ public:
         recv_size_map = 0;
     }
 
+    // Return the ket/map recv sizes recorded by the most recent ExchangeAsync call.
+    // Valid after ExchangeAsync returns and before Sync() clears them.
+    size_t get_recv_size()     const { return recv_size; }
+    size_t get_recv_size_map() const { return recv_size_map; }
+
+    // ExchangeAsync with caller-managed recv buffer capacity.
+    //
+    // send_ket_size    — actual number of ket elements in send (the caller
+    //                    tracks this separately because send.size() may equal
+    //                    global_max_ket_size after pre-allocation).
+    // send_map_size    — actual number of map elements in send_map_storage.
+    //
+    // recv / recv_map_storage — both device_vectors, pre-allocated by the
+    //                    caller to global_max_ket_size / global_max_map_size
+    //                    respectively and kept at that size throughout the
+    //                    task loop.  No resize is performed here; MPI_Irecv
+    //                    writes directly into the pre-allocated device memory.
+    //
+    // The caller is responsible for:
+    //   1. Before the first call: resize both recv buffers to the global max
+    //      (MPI_Allreduce MAX of local sizes), then cudaDeviceSynchronize()
+    //      so the fill kernels complete before MPI_Irecv fires.
+    //   2. After Sync() returns true: update the tracked ket/map sizes via
+    //      get_recv_size() / get_recv_size_map(), then swap active/recv buffers.
     void ExchangeAsync(const thrust::device_vector<ElemT> &send,
+                size_t send_ket_size,
                 thrust::device_vector<ElemT> &recv,
                 const DetIndexMapThrust& send_map,
                 const thrust::device_vector<uint32_t> &send_map_storage,
+                size_t send_map_size,
                 DetIndexMapThrust& recv_map,
                 thrust::device_vector<uint32_t> &recv_map_storage,
                 int slide,
@@ -495,8 +521,11 @@ public:
         std::vector<MPI_Status> sta_size(2);
         std::vector<size_t> send_offset(12);
         std::vector<size_t> recv_offset(12);
-        send_offset[0] = send.size();
-        send_offset[1] = send_map_storage.size();
+        // Use the caller-supplied logical sizes, not send.size() /
+        // send_map_storage.size(), which may equal global_max after
+        // pre-allocation rather than the actual ket/map element count.
+        send_offset[0] = send_ket_size;
+        send_offset[1] = send_map_size;
 
         // exchange idxmap offset
         {
@@ -513,47 +542,66 @@ public:
         send_offset[10] = (size_t)send_map.size_adet;
         send_offset[11] = (size_t)send_map.size_bdet;
 
-        MPI_Isend(send_offset.data(),12,SBD_MPI_SIZE_T,mpi_dest,id*4,comm,&req_size[0]);
-        MPI_Irecv(recv_offset.data(),12,SBD_MPI_SIZE_T,mpi_source,id*4,comm,&req_size[1]);
-        MPI_Waitall(2,req_size.data(),sta_size.data());
+        {
+            MPI_Isend(send_offset.data(),12,SBD_MPI_SIZE_T,mpi_dest,id*4,comm,&req_size[0]);
+        }
+        {
+            MPI_Irecv(recv_offset.data(),12,SBD_MPI_SIZE_T,mpi_source,id*4,comm,&req_size[1]);
+        }
+        {
+            MPI_Waitall(2,req_size.data(),sta_size.data());
+        }
 
         send_size = send_offset[0];
         recv_size = recv_offset[0];
         send_size_map = send_offset[1];
         recv_size_map = recv_offset[1];
 
-        // exchange async
+        // Post async send/recv without any resize or fill kernel.
+        // recv and recv_map_storage are pre-allocated to global_max by the caller.
         MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
         if( send_size != 0 ) {
-            MPI_Isend((ElemT*)thrust::raw_pointer_cast(send.data()),send_size,DataT,mpi_dest,id*4+2,comm,&req_send);
+            {
+                MPI_Isend((ElemT*)thrust::raw_pointer_cast(send.data()),send_size,DataT,mpi_dest,id*4+2,comm,&req_send);
+            }
         }
         if( recv_size != 0 ) {
-            recv.resize(recv_size);
-            MPI_Irecv((ElemT*)thrust::raw_pointer_cast(recv.data()),recv_size,DataT,mpi_source,id*4+2,comm,&req_recv);
-        } else {
-            recv = send;
+            // No resize: recv is pre-allocated to global_max_ket_size by the caller.
+            // MPI_Irecv writes recv_size elements directly into the device buffer.
+            {
+                MPI_Irecv((ElemT*)thrust::raw_pointer_cast(recv.data()),recv_size,DataT,mpi_source,id*4+2,comm,&req_recv);
+            }
         }
+        // recv_size == 0: nothing to receive; Sync() will return false for ket.
 
         if( send_size_map != 0 ) {
-            MPI_Isend((uint32_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,MPI_UINT32_T,mpi_dest,id*4+3,comm,&req_send_map);
+            {
+                MPI_Isend((uint32_t*)thrust::raw_pointer_cast(send_map_storage.data()),send_size_map,MPI_UINT32_T,mpi_dest,id*4+3,comm,&req_send_map);
+            }
         }
-        if( recv_size_map != 0 ) {
-            recv_map_storage.resize(recv_size_map);
-            MPI_Irecv((uint32_t*)thrust::raw_pointer_cast(recv_map_storage.data()),recv_size_map,MPI_UINT32_T,mpi_source,id*4+3,comm,&req_recv_map);
 
+        // recv_map_base: pointer used to set up recv_map field offsets below.
+        uint32_t* recv_map_base;
+        if( recv_size_map != 0 ) {
+            // No resize: recv_map_storage is pre-allocated to global_max_map_size.
+            {
+                MPI_Irecv((uint32_t*)thrust::raw_pointer_cast(recv_map_storage.data()),recv_size_map,MPI_UINT32_T,mpi_source,id*4+3,comm,&req_recv_map);
+            }
+            recv_map_base = thrust::raw_pointer_cast(recv_map_storage.data());
         } else {
-            recv_map_storage = send_map_storage;
+            // recv_size_map == 0: degenerate case; point recv_map at send's map.
+            // Sync() will not swap if recv_size is also 0.
             recv_offset = send_offset;
+            recv_map_base = const_cast<uint32_t*>(thrust::raw_pointer_cast(send_map_storage.data()));
         }
-        uint32_t* base = thrust::raw_pointer_cast(recv_map_storage.data());
-        recv_map.AdetToDetOffset = base + recv_offset[2];
-        recv_map.BdetToDetOffset = base + recv_offset[3];
-        recv_map.AdetIndex = base + recv_offset[4];
-        recv_map.BdetIndex = base + recv_offset[5];
-        recv_map.AdetToBdetSM = base + recv_offset[6];
-        recv_map.AdetToDetSM = base + recv_offset[7];
-        recv_map.BdetToAdetSM = base + recv_offset[8];
-        recv_map.BdetToDetSM = base + recv_offset[9];
+        recv_map.AdetToDetOffset = recv_map_base + recv_offset[2];
+        recv_map.BdetToDetOffset = recv_map_base + recv_offset[3];
+        recv_map.AdetIndex = recv_map_base + recv_offset[4];
+        recv_map.BdetIndex = recv_map_base + recv_offset[5];
+        recv_map.AdetToBdetSM = recv_map_base + recv_offset[6];
+        recv_map.AdetToDetSM = recv_map_base + recv_offset[7];
+        recv_map.BdetToAdetSM = recv_map_base + recv_offset[8];
+        recv_map.BdetToDetSM = recv_map_base + recv_offset[9];
         recv_map.size_adet = static_cast<uint32_t>(recv_offset[10]);
         recv_map.size_bdet = static_cast<uint32_t>(recv_offset[11]);
     }
@@ -564,23 +612,31 @@ public:
         if (send_size > 0) {
             MPI_Status st;
 
-            MPI_Wait(&req_send, &st);
+            {
+                MPI_Wait(&req_send, &st);
+            }
         }
         if (recv_size > 0) {
             MPI_Status st;
 
-            MPI_Wait(&req_recv, &st);
+            {
+                MPI_Wait(&req_recv, &st);
+            }
             recv = true;
         }
         if (send_size_map > 0) {
             MPI_Status st;
 
-            MPI_Wait(&req_send_map, &st);
+            {
+                MPI_Wait(&req_send_map, &st);
+            }
         }
         if (recv_size_map > 0) {
             MPI_Status st;
 
-            MPI_Wait(&req_recv_map, &st);
+            {
+                MPI_Wait(&req_recv_map, &st);
+            }
             recv = true;
         }
 

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -815,9 +815,27 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
 	for (size_t task = 0; task < exidx.size(); task++) {
-		// Launch all GPU kernels for this task asynchronously.
-		// The exchange below will overlap with these kernels.
+		// ExchangeAsync is posted BEFORE the GPU kernel launches.  active_buf
+		// holds MPI-received data from the previous Sync() with no outstanding
+		// GPU work (cudaDeviceSynchronize completed at end of prev task), so
+		// Cray MPICH's MPI_Isend finds a clean GPU stream and DMA starts
+		// immediately.  GPU kernels then run concurrently with NIC DMA — both
+		// read active_buf, neither writes it.
 		double _t_launch, _t_exch, _t_sync, _t_gpu;
+
+		if (task < exidx.size() - 1) {
+			int slide = exidx[task].slide - exidx[task + 1].slide;
+			{ auto _t0 = _ck::now();
+			  slider.ExchangeAsync(
+			      twk[active_buf], twk_ket_size[active_buf],
+			      twk[recv_buf],
+			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
+			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
+			      slide, this->b_comm(), (int)task);
+			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+		} else {
+			_t_exch = 0.0;
+		}
 
 		{ auto _t0 = _ck::now();
 
@@ -848,23 +866,10 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 
 		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
-		// While the GPU runs the kernels above, exchange the ket for the next
-		// task.  ExchangeAsync posts MPI_Irecv directly into the pre-allocated
-		// device buffer — no resize, no fill kernel, no cudaDeviceSynchronize
-		// inside the exchange.
+		// Sync() waits for offset + large data.  GPU kernels are running
+		// concurrently; cudaDeviceSynchronize below ensures they finish before
+		// the next task overwrites wb.
 		if (task < exidx.size() - 1) {
-			int slide = exidx[task].slide - exidx[task + 1].slide;
-			{ auto _t0 = _ck::now();
-			  slider.ExchangeAsync(
-			      twk[active_buf], twk_ket_size[active_buf],
-			      twk[recv_buf],
-			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
-			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
-			      slide, this->b_comm(), (int)task);
-			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-			// Sync() waits for the offset message (deferred from ExchangeAsync) and
-			// then waits for the large ket/map data.  get_recv_size() is valid after
-			// Sync() returns because recv_size is set inside Sync().
 			{ auto _t0 = _ck::now();
 			  if (slider.Sync()) {
 			    twk_ket_size[recv_buf] = slider.get_recv_size();
@@ -873,11 +878,9 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			  }
 			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 		} else {
-			_t_exch = 0.0;
 			_t_sync = 0.0;
 		}
 
-		// Wait for this task's kernels before the next task writes to wb.
 		{ auto _t0 = _ck::now();
 		  cudaDeviceSynchronize();
 		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -38,6 +38,8 @@ static_assert(SBD_MULT_BLOCK_SIZE == 32  ||
               SBD_MULT_BLOCK_SIZE == 128 ||
               SBD_MULT_BLOCK_SIZE == 256,
               "SBD_MULT_BLOCK_SIZE must be 32, 64, 128, or 256");
+static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_SUBWARP_SIZE == 0,
+              "SBD_MULT_BLOCK_SIZE must be a multiple of SBD_GDB_SUBWARP_SIZE.");
 
 // Custom blocksize-tunable launcher for the GDB Mult kernels. Replaces
 // thrust::for_each_n at the run()-level call sites. Smaller blocks free
@@ -477,9 +479,16 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t arg_i)
     {
-		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
-		size_t i    = arg_i / SUBWARP;                     // SUBWARP=1 → i = arg_i
-		int    lane = static_cast<int>(arg_i % SUBWARP);   // SUBWARP=1 → lane = 0
+		constexpr int SUBWARP   = SBD_GDB_SUBWARP_SIZE;
+		constexpr int BLOCK     = SBD_MULT_BLOCK_SIZE;
+		constexpr int GROUPS    = BLOCK / SUBWARP;        // SUBWARP groups per block
+		constexpr int BUF_PG    = 2 * SUBWARP;            // slots per group
+		constexpr int BUF_TOTAL = 2 * BLOCK;              // = GROUPS * BUF_PG
+
+		size_t i     = arg_i / SUBWARP;                   // SUBWARP=1 → i = arg_i
+		int    lane  = static_cast<int>(arg_i % SUBWARP); // 0..SUBWARP-1 within group
+		int    group = static_cast<int>(i % GROUPS);      // 0..GROUPS-1 within block
+		int    buf_base = group * BUF_PG;
 
 		size_t ibst = idxmap.AdetToBdetSM[i];
 		size_t idet = idxmap.AdetToDetSM[i];
@@ -492,38 +501,120 @@ public:
 		typename WarpReduceSum::TempStorage temp_sum;   // local; shuffle-only at p2 sizes
 		ElemT thread_sum = ElemT(0);
 
-		// alpha-beta two-particle excitations
-		// Inner k-loop is strided by SUBWARP starting at lane. We do NOT pass
-		// a running start_idx to adet_lower_bound: per-lane start_idx values
-		// make the binary search hit different elements per lane (warp-
-		// divergent), and the `continue` skips below would break any
-		// intra-loop reduction we'd want for sharing the bound. Each lane
-		// accumulates locally; cub::WarpReduce::Sum at the end of the
-		// outer-ja loop combines them. At SUBWARP=1 stride is 1, lane is 0,
-		// WarpReduce<T,1> is identity — body matches the original loop
-		// modulo dropping the start_idx amortization.
+		// SUBWARP-parallel (idxb, ja, k) accumulation buffer. Per-block
+		// shared, sliced by SUBWARP group. Each group's SUBWARP lanes ballot
+		// for valid candidates per probe round, append at distinct ranks
+		// (no atomicAdd), then dispatch TwoExcite once the group's slice
+		// holds ≥ SUBWARP entries.
+		__shared__ int64_t s_idxb [BUF_TOTAL];
+		__shared__ size_t  s_ja   [BUF_TOTAL];
+		__shared__ size_t  s_k    [BUF_TOTAL];
+		__shared__ int     s_count[GROUPS];
+		if (lane == 0) s_count[group] = 0;
+
+		// Per-SUBWARP ballot mask — covers this group's lanes within the
+		// containing CUDA warp. With multiple groups per warp (SUBWARP < 32),
+		// each group masks the warp-wide ballot to its own bit-range.
+		const int      lane_in_warp  = static_cast<int>(threadIdx.x) % 32;
+		const int      group_in_warp = lane_in_warp / SUBWARP;
+		const unsigned subwarp_lanes = (SUBWARP == 32) ? 0xFFFFFFFFu
+		                                               : ((1u << SUBWARP) - 1u);
+		const unsigned subwarp_mask  = subwarp_lanes << (group_in_warp * SUBWARP);
+		__syncwarp(subwarp_mask);
+
+		// Outer ja loop. Inner k loop runs k_iters times *uniformly* across
+		// all SUBWARP lanes of the group (k_lane = k_lo + it*SUBWARP + lane,
+		// guarded by `in_range = k_lane < k_hi`). This keeps __ballot_sync
+		// and __syncwarp(subwarp_mask) calls reachable by every lane on
+		// every iteration — fixing the divergent-loop-exit bug in v1.
 		// adet_lower_bound returns -1 on miss, otherwise i < AdetToDetOffset[jast+1];
 		// so (idxb - AdetToDetOffset[jast]) is in-range whenever idxb >= 0.
 		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
-			size_t jast = exidx.SinglesFromAdetSM[ja];
-			for (size_t k = exidx.SinglesFromBdetOffset[ibst] + lane;
-			            k < exidx.SinglesFromBdetOffset[ibst + 1];
-			            k += SUBWARP) {
-				size_t jbst = exidx.SinglesFromBdetSM[k];
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, /*start_idx=*/0);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
-					size_t jdet = tidxmap.AdetToDetSM[idxb];
+			size_t jast    = exidx.SinglesFromAdetSM[ja];
+			size_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
+			size_t k_hi    = exidx.SinglesFromBdetOffset[ibst + 1];
+			size_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
+
+			for (size_t it = 0; it < k_iters; it++) {
+				size_t  k        = k_lo + it * SUBWARP + lane;
+				bool    in_range = (k < k_hi);
+				int64_t idxb     = -1;
+				size_t  jbst     = 0;
+				bool    valid    = false;
+				if (in_range) {
+					jbst  = exidx.SinglesFromBdetSM[k];
+					idxb  = tidxmap.adet_lower_bound(jast, jbst, /*start_idx=*/0);
+					valid = (idxb >= 0 && jbst == tidxmap.AdetToBdetSM[idxb]);
+				}
+
+				// Per-group ballot (only this group's SUBWARP lanes
+				// participate; sibling groups in the same warp may be at
+				// different ja iterations). Per-lane rank within the group
+				// is __popc of group-local bits below this lane. Replaces
+				// atomicAdd for slot allocation.
+				unsigned warp_ballot    = __ballot_sync(subwarp_mask, valid);
+				unsigned subwarp_ballot = (warp_ballot & subwarp_mask) >> (group_in_warp * SUBWARP);
+				int      rank           = __popc(subwarp_ballot & ((1u << lane) - 1u));
+				int      added          = __popc(subwarp_ballot);
+
+				if (valid) {
+					int slot = buf_base + s_count[group] + rank;
+					s_idxb[slot] = idxb;
+					s_ja  [slot] = ja;
+					s_k   [slot] = k;
+				}
+				if (lane == 0) s_count[group] += added;
+				__syncwarp(subwarp_mask);
+
+				if (s_count[group] >= SUBWARP) {
+					// Dispatch SUBWARP TwoExcite() calls in parallel.
+					int     my_slot = buf_base + lane;
+					int64_t my_idxb = s_idxb[my_slot];
+					size_t  my_ja   = s_ja  [my_slot];
+					size_t  my_k    = s_k   [my_slot];
+					size_t  jdet    = tidxmap.AdetToDetSM[my_idxb];
 					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
-										exidx.SinglesAdetCrAnSM[ja],
-										exidx.SinglesBdetCrAnSM[k],
-										exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
-										exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
+					                    exidx.SinglesAdetCrAnSM[my_ja],
+					                    exidx.SinglesBdetCrAnSM[my_k],
+					                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],
+					                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
 					thread_sum += eij * this->twk[jdet];
+					__syncwarp(subwarp_mask);
+
+					// Compact this group's slice in parallel. Source range
+					// [buf_base+SUBWARP, buf_base+2*SUBWARP) was not touched
+					// by dispatch and is disjoint from the destination
+					// [buf_base, buf_base+SUBWARP) — direct lane-parallel copy
+					// is safe without an intermediate sync. Slots above the
+					// new s_count are garbage but invisible (next probe round
+					// overwrites starting at s_count). Only lane 0 mutates
+					// s_count (decrement-not-assign), so no read-write race
+					// with other lanes that have already pulled their copies.
+					s_idxb[buf_base + lane] = s_idxb[buf_base + SUBWARP + lane];
+					s_ja  [buf_base + lane] = s_ja  [buf_base + SUBWARP + lane];
+					s_k   [buf_base + lane] = s_k   [buf_base + SUBWARP + lane];
+					if (lane == 0) s_count[group] -= SUBWARP;
+					__syncwarp(subwarp_mask);
 				}
 			}
 		}
+
+		// Drain remaining (count < SUBWARP). All lanes evaluate the predicate
+		// uniformly; only those with `lane < s_count[group]` enter the body.
+		if (lane < s_count[group]) {
+			int     my_slot = buf_base + lane;
+			int64_t my_idxb = s_idxb[my_slot];
+			size_t  my_ja   = s_ja  [my_slot];
+			size_t  my_k    = s_k   [my_slot];
+			size_t  jdet    = tidxmap.AdetToDetSM[my_idxb];
+			ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+			                    exidx.SinglesAdetCrAnSM[my_ja],
+			                    exidx.SinglesBdetCrAnSM[my_k],
+			                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],
+			                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
+			thread_sum += eij * this->twk[jdet];
+		}
+		__syncwarp(subwarp_mask);
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
 		if (lane == 0) this->wb[idet] += total;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -8,6 +8,7 @@
 
 #include "sbd/framework/mpi_utility_thrust.h"
 #include <cassert>
+#include <chrono>
 
 // SUBWARP threading for MultAlphaBetaKernel (track gh-A).
 // SBD_GDB_SUBWARP_SIZE selects the threading granularity:
@@ -26,6 +27,22 @@ static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
               SBD_GDB_SUBWARP_SIZE == 16 ||
               SBD_GDB_SUBWARP_SIZE == 32,
               "SBD_GDB_SUBWARP_SIZE must be 1, 2, 4, 8, 16, or 32");
+
+// SBD_GDB_AB_SUBWARP_SIZE overrides SubwarpSize for MultAlphaBetaKernel only.
+// When unset, defaults to SBD_GDB_SUBWARP_SIZE (uniform subwarp granularity
+// across all five mult kernels). Set independently to sweep the AlphaBeta
+// subwarp size without changing the other four kernels.
+#ifndef SBD_GDB_AB_SUBWARP_SIZE
+  #define SBD_GDB_AB_SUBWARP_SIZE SBD_GDB_SUBWARP_SIZE
+#endif
+static_assert(SBD_GDB_AB_SUBWARP_SIZE == 1  ||
+              SBD_GDB_AB_SUBWARP_SIZE == 2  ||
+              SBD_GDB_AB_SUBWARP_SIZE == 4  ||
+              SBD_GDB_AB_SUBWARP_SIZE == 8  ||
+              SBD_GDB_AB_SUBWARP_SIZE == 16 ||
+              SBD_GDB_AB_SUBWARP_SIZE == 32,
+              "SBD_GDB_AB_SUBWARP_SIZE must be 1, 2, 4, 8, 16, or 32");
+
 #include <cub/warp/warp_reduce.cuh>
 
 namespace sbd
@@ -43,6 +60,8 @@ static_assert(SBD_MULT_BLOCK_SIZE == 32  ||
               "SBD_MULT_BLOCK_SIZE must be 32, 64, 128, or 256");
 static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_SUBWARP_SIZE == 0,
               "SBD_MULT_BLOCK_SIZE must be a multiple of SBD_GDB_SUBWARP_SIZE.");
+static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_AB_SUBWARP_SIZE == 0,
+              "SBD_MULT_BLOCK_SIZE must be a multiple of SBD_GDB_AB_SUBWARP_SIZE.");
 
 // SBD_MULT_MIN_BLOCKS_PER_SM tunes the second argument of
 // __launch_bounds__ on mult_for_each_n_kernel — the
@@ -494,7 +513,7 @@ template <typename ElemT>
 class MultAlphaBetaKernel : public MultKernelBase<ElemT>
 {
 public:
-    using MultKernelBase<ElemT>::SubwarpSize;
+    static constexpr int SubwarpSize = SBD_GDB_AB_SUBWARP_SIZE;
     using MultKernelBase<ElemT>::BlockSize;
 protected:
 	DetIndexMapThrust idxmap;
@@ -708,6 +727,15 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	}
 
 	MpiSlider<ElemT> slider;
+#ifdef SBD_MULT_TIME_KERNELS
+	double _t_sa = 0, _t_da = 0, _t_sb = 0, _t_db = 0, _t_ab = 0;
+	using _ck = std::chrono::steady_clock;
+	auto _timed = [](auto n, auto& kern, double& accum) {
+		auto t0 = _ck::now();
+		launch_mult_for_each_n(n, kern);
+		accum += std::chrono::duration<double, std::milli>(_ck::now() - t0).count();
+	};
+#endif
 	for (size_t task = 0; task < exidx.size(); task++) {
         if (task_sent == task) {
             if (task_sent != 0) {
@@ -730,28 +758,54 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		// single alpha excitations
 		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+#ifdef SBD_MULT_TIME_KERNELS
+		_timed(idxmap.size_adet, kernel_single_alpha, _t_sa);
+#else
 		launch_mult_for_each_n(idxmap.size_adet, kernel_single_alpha);
+#endif
 
 		// double alpha excitations
 		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+#ifdef SBD_MULT_TIME_KERNELS
+		_timed(idxmap.size_adet, kernel_double_alpha, _t_da);
+#else
 		launch_mult_for_each_n(idxmap.size_adet, kernel_double_alpha);
+#endif
 
 		// single beta excitations
 		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+#ifdef SBD_MULT_TIME_KERNELS
+		_timed(idxmap.size_bdet, kernel_single_beta, _t_sb);
+#else
 		launch_mult_for_each_n(idxmap.size_bdet, kernel_single_beta);
+#endif
 
 		// double beta excitations
 		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+#ifdef SBD_MULT_TIME_KERNELS
+		_timed(idxmap.size_bdet, kernel_double_beta, _t_db);
+#else
 		launch_mult_for_each_n(idxmap.size_bdet, kernel_double_beta);
+#endif
 
 		// alpha-beta excitations
 		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+#ifdef SBD_MULT_TIME_KERNELS
+		_timed(idxmap.size_adet, kernel_alpha_beta, _t_ab);
+#else
 		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta);
+#endif
 	} // end task for loop
+
+#ifdef SBD_MULT_TIME_KERNELS
+	if (mpi_rank_t == 0 && mpi_rank_b == 0 && mpi_rank_h == 0)
+		fprintf(stderr, "mult_kernel_ms: tasks=%zu sa=%.1f da=%.1f sb=%.1f db=%.1f ab=%.1f\n",
+		        exidx.size(), _t_sa, _t_da, _t_sb, _t_db, _t_ab);
+#endif
 
 	if (mpi_size_t > 1)
 		MpiAllreduce(wb, MPI_SUM, this->t_comm());

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -8,6 +8,23 @@
 
 #include "sbd/framework/mpi_utility_thrust.h"
 
+// SUBWARP threading for MultAlphaBetaKernel (track gh-A).
+// SBD_GDB_SUBWARP_SIZE selects the threading granularity:
+//   1            → stride=1, behaves like the original code path
+//                  (cub::WarpReduce<T,1> is identity; no cross-lane comm)
+//   8 / 16 / 32  → strided inner-k loop + cub::WarpReduce reduction
+// Single code path for all sizes — no #ifdef'd duplicate body. Each lane
+// keeps its own start_idx running optimisation across its strided subset.
+#ifndef SBD_GDB_SUBWARP_SIZE
+  #define SBD_GDB_SUBWARP_SIZE 1
+#endif
+static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
+              SBD_GDB_SUBWARP_SIZE == 8  ||
+              SBD_GDB_SUBWARP_SIZE == 16 ||
+              SBD_GDB_SUBWARP_SIZE == 32,
+              "SBD_GDB_SUBWARP_SIZE must be 1, 8, 16, or 32");
+#include <cub/warp/warp_reduce.cuh>
+
 namespace sbd
 {
 namespace gdb
@@ -377,8 +394,12 @@ public:
 		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
 
     // kernel entry point
-    __device__ __host__ void operator()(size_t i)
+    __device__ __host__ void operator()(size_t arg_i)
     {
+		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		size_t i    = arg_i / SUBWARP;                     // SUBWARP=1 → i = arg_i
+		int    lane = static_cast<int>(arg_i % SUBWARP);   // SUBWARP=1 → lane = 0
+
 		size_t ibst = idxmap.AdetToBdetSM[i];
 		size_t idet = idxmap.AdetToDetSM[i];
 		size_t ia = idxmap.AdetIndex[i];
@@ -386,12 +407,23 @@ public:
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
+		using WarpReduce = cub::WarpReduce<ElemT, SUBWARP>;
+		typename WarpReduce::TempStorage temp_storage;   // local; shuffle-only at p2 sizes
+		ElemT thread_sum = ElemT(0);
+
 		// alpha-beta two-particle excitations
+		// Inner k-loop is strided by SUBWARP starting at lane; each lane keeps
+		// its own start_idx running lower-bound across its strided subset
+		// (start_idx grows monotonically with k since SinglesFromBdetSM is sorted,
+		// so the per-lane start_idx is correct as a lower bound for that lane's
+		// next k). At SUBWARP=1 this is identical to the original sequential loop.
 		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			size_t jast = exidx.SinglesFromAdetSM[ja];
 			size_t start_idx = 0;
 			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
-			for (size_t k = exidx.SinglesFromBdetOffset[ibst]; k < exidx.SinglesFromBdetOffset[ibst + 1]; k++) {
+			for (size_t k = exidx.SinglesFromBdetOffset[ibst] + lane;
+			            k < exidx.SinglesFromBdetOffset[ibst + 1];
+			            k += SUBWARP) {
 				size_t jbst = exidx.SinglesFromBdetSM[k];
 				if (start_idx >= end_idx)
 					break;
@@ -409,11 +441,14 @@ public:
 												exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
 						// size_t odiff;
 						// ElemT eij = Hij(det[idet],tdet[jdet],bit_length,norb,I0,I1,I2,odiff);
-						this->wb[idet] += eij * this->twk[jdet];
+						thread_sum += eij * this->twk[jdet];
 					}
 				}
 			}
 		}
+
+		ElemT total = WarpReduce(temp_storage).Sum(thread_sum);
+		if (lane == 0) this->wb[idet] += total;
 	}
 };
 
@@ -529,7 +564,8 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
 
 		auto ci_ab = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_ab, idxmap.size_adet, kernel_alpha_beta);
+		thrust::for_each_n(thrust::device, ci_ab,
+		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_alpha_beta);
 	} // end task for loop
 
 	if (mpi_size_t > 1)

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -43,22 +43,31 @@ static_assert(SBD_MULT_BLOCK_SIZE == 32  ||
 static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_SUBWARP_SIZE == 0,
               "SBD_MULT_BLOCK_SIZE must be a multiple of SBD_GDB_SUBWARP_SIZE.");
 
+// SBD_MULT_MIN_BLOCKS_PER_SM tunes the second argument of
+// __launch_bounds__ on mult_for_each_n_kernel — the
+// minBlocksPerMultiprocessor hint the compiler uses to pick a register
+// budget per thread. Default 32 = H100 hardware maximum; lower values
+// trade occupancy for a larger per-thread register budget.
+//   threads/SM = SBD_MULT_BLOCK_SIZE × SBD_MULT_MIN_BLOCKS_PER_SM
+//   regs/thread budget ≈ 65536 / threads/SM
+// Examples (BS=64):
+//   mbpsm=32 → 2048 threads/SM (100% occupancy); 32 regs/thread
+//   mbpsm=24 → 1536 threads/SM (75% occupancy); 42 regs/thread
+//   mbpsm=20 → 1280 threads/SM (62.5% occupancy); 51 regs/thread
+//   mbpsm=16 → 1024 threads/SM (50% occupancy); 64 regs/thread
+#ifndef SBD_MULT_MIN_BLOCKS_PER_SM
+  #define SBD_MULT_MIN_BLOCKS_PER_SM 32
+#endif
+static_assert(SBD_MULT_MIN_BLOCKS_PER_SM >= 1 &&
+              SBD_MULT_MIN_BLOCKS_PER_SM <= 32,
+              "SBD_MULT_MIN_BLOCKS_PER_SM must be in [1, 32] (H100 hw max).");
+
 // Custom blocksize-tunable launcher for the GDB Mult kernels. Replaces
 // thrust::for_each_n at the run()-level call sites with a fixed-block
 // launch so the v2 SUBWARP-parallel kernel's shared-memory sizing
 // (`BUF_TOTAL = 2 * SBD_MULT_BLOCK_SIZE`) matches the actual block size.
-//
-// __launch_bounds__(BlockSize, 32): the second argument fixes
-// minBlocksPerMultiprocessor at 32 — H100's hardware maximum of
-// 32 thread blocks per SM. The compiler picks a register budget that
-// keeps 32 BlockSize-thread blocks resident per SM:
-//   BS=32 → 32 × 32 = 1024 threads/SM (50% occupancy); 65536/1024 = 64
-//           registers/thread budget.
-//   BS=64 → 32 × 64 = 2048 threads/SM (100% occupancy); 32 regs/thread.
-// Larger BlockSize (128, 256) cannot reach the 32-block/SM target and
-// are out of scope for this build configuration.
 template <int BlockSize, typename Functor>
-__global__ __launch_bounds__(BlockSize, 32)
+__global__ __launch_bounds__(BlockSize, SBD_MULT_MIN_BLOCKS_PER_SM)
 void mult_for_each_n_kernel(size_t n, Functor functor)
 {
     size_t i = static_cast<size_t>(blockIdx.x) * BlockSize + threadIdx.x;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -72,11 +72,11 @@ static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_AB_SUBWARP_SIZE == 0,
 //   regs/thread budget ≈ 65536 / threads/SM
 // Examples (BS=64):
 //   mbpsm=32 → 2048 threads/SM (100% occupancy); 32 regs/thread
-//   mbpsm=24 → 1536 threads/SM (75% occupancy); 42 regs/thread
-//   mbpsm=20 → 1280 threads/SM (62.5% occupancy); 51 regs/thread  ← default (track U)
+//   mbpsm=24 → 1536 threads/SM (75% occupancy); 42 regs/thread  ← default (track H)
+//   mbpsm=20 → 1280 threads/SM (62.5% occupancy); 51 regs/thread
 //   mbpsm=16 → 1024 threads/SM (50% occupancy); 64 regs/thread
 #ifndef SBD_MULT_MIN_BLOCKS_PER_SM
-  #define SBD_MULT_MIN_BLOCKS_PER_SM 20
+  #define SBD_MULT_MIN_BLOCKS_PER_SM 24
 #endif
 static_assert(SBD_MULT_MIN_BLOCKS_PER_SM >= 1 &&
               SBD_MULT_MIN_BLOCKS_PER_SM <= 32,

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -815,27 +815,10 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
 	for (size_t task = 0; task < exidx.size(); task++) {
-		// ExchangeAsync is posted BEFORE the GPU kernel launches.  active_buf
-		// holds MPI-received data from the previous Sync() with no outstanding
-		// GPU work (cudaDeviceSynchronize completed at end of prev task), so
-		// Cray MPICH's MPI_Isend finds a clean GPU stream and DMA starts
-		// immediately.  GPU kernels then run concurrently with NIC DMA — both
-		// read active_buf, neither writes it.
+		// No GPU/MPI overlap: kernels run to completion before ExchangeAsync
+		// is posted.  Isolates whether concurrent GPU activity interferes with
+		// NIC DMA throughput from GPU buffers.
 		double _t_launch, _t_exch, _t_sync, _t_gpu;
-
-		if (task < exidx.size() - 1) {
-			int slide = exidx[task].slide - exidx[task + 1].slide;
-			{ auto _t0 = _ck::now();
-			  slider.ExchangeAsync(
-			      twk[active_buf], twk_ket_size[active_buf],
-			      twk[recv_buf],
-			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
-			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
-			      slide, this->b_comm(), (int)task);
-			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-		} else {
-			_t_exch = 0.0;
-		}
 
 		{ auto _t0 = _ck::now();
 
@@ -866,10 +849,20 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 
 		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
-		// Sync() waits for offset + large data.  GPU kernels are running
-		// concurrently; cudaDeviceSynchronize below ensures they finish before
-		// the next task overwrites wb.
+		{ auto _t0 = _ck::now();
+		  cudaDeviceSynchronize();
+		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+
 		if (task < exidx.size() - 1) {
+			int slide = exidx[task].slide - exidx[task + 1].slide;
+			{ auto _t0 = _ck::now();
+			  slider.ExchangeAsync(
+			      twk[active_buf], twk_ket_size[active_buf],
+			      twk[recv_buf],
+			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
+			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
+			      slide, this->b_comm(), (int)task);
+			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 			{ auto _t0 = _ck::now();
 			  if (slider.Sync()) {
 			    twk_ket_size[recv_buf] = slider.get_recv_size();
@@ -878,12 +871,9 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			  }
 			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 		} else {
+			_t_exch = 0.0;
 			_t_sync = 0.0;
 		}
-
-		{ auto _t0 = _ck::now();
-		  cudaDeviceSynchronize();
-		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
 		fprintf(stderr, "mult_task_ms: rank_b=%d task=%zu"
 		        " launch=%.1f exch=%.1f sync=%.1f gpu_sync=%.1f\n",

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -473,9 +473,10 @@ public:
 		// outer-ja loop combines them. At SUBWARP=1 stride is 1, lane is 0,
 		// WarpReduce<T,1> is identity — body matches the original loop
 		// modulo dropping the start_idx amortization.
+		// adet_lower_bound returns -1 on miss, otherwise i < AdetToDetOffset[jast+1];
+		// so (idxb - AdetToDetOffset[jast]) is in-range whenever idxb >= 0.
 		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			size_t jast = exidx.SinglesFromAdetSM[ja];
-			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
 			for (size_t k = exidx.SinglesFromBdetOffset[ibst] + lane;
 			            k < exidx.SinglesFromBdetOffset[ibst + 1];
 			            k += SUBWARP) {
@@ -484,16 +485,13 @@ public:
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					size_t local_idx = idxb - tidxmap.AdetToDetOffset[jast];
-					if (local_idx < end_idx) {
-						size_t jdet = tidxmap.AdetToDetSM[idxb];
-						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
-											exidx.SinglesAdetCrAnSM[ja],
-											exidx.SinglesBdetCrAnSM[k],
-											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
-											exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
-						thread_sum += eij * this->twk[jdet];
-					}
+					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+										exidx.SinglesAdetCrAnSM[ja],
+										exidx.SinglesBdetCrAnSM[k],
+										exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
+										exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
+					thread_sum += eij * this->twk[jdet];
 				}
 			}
 		}

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -24,11 +24,6 @@ static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
               SBD_GDB_SUBWARP_SIZE == 32,
               "SBD_GDB_SUBWARP_SIZE must be 1, 8, 16, or 32");
 #include <cub/warp/warp_reduce.cuh>
-// Note: Jim's reference form was
-//   start_idx = cuda::device::warp::shuffle_idx(start_idx, SUBWARP-1, SUBWARP);
-// `cuda::device::warp::shuffle_idx` is a CCCL/libcu++ wrapper not present in
-// NVHPC SDK 25.5 (no <cuda/warp> header). The functionally-equivalent CUDA
-// built-in `__shfl_sync(0xffffffff, value, srcLane, width)` is used below.
 
 namespace sbd
 {
@@ -417,33 +412,28 @@ public:
 		ElemT thread_sum = ElemT(0);
 
 		// alpha-beta two-particle excitations
-		// Inner k-loop is strided by SUBWARP starting at lane. Each lane keeps
-		// its own running start_idx; at end of each iteration we broadcast the
-		// last lane's start_idx to all SUBWARP lanes (it has the tightest
-		// lower_bound this iteration since SinglesFromBdetSM is sorted and
-		// last-lane's k is the highest in the strided block). The condition
-		// `k + SUBWARP - lane < k_hi` ensures all SUBWARP lanes are at the
-		// shuffle call site (it's equivalent to `block_start + SUBWARP < k_hi`,
-		// which implies `block_start + (SUBWARP-1) < k_hi`, so lane SUBWARP-1
-		// of the current block is also in range). At SUBWARP=1 stride is 1,
-		// lane is 0, the shuffle width=1 srcLane=0 is identity, so the body
-		// collapses to the original sequential loop.
+		// Inner k-loop is strided by SUBWARP starting at lane. We do NOT pass
+		// a running start_idx to adet_lower_bound: per-lane start_idx values
+		// make the binary search hit different elements per lane (warp-
+		// divergent), and the `continue` skips below would break any
+		// intra-loop reduction we'd want for sharing the bound. Each lane
+		// accumulates locally; cub::WarpReduce::Sum at the end of the
+		// outer-ja loop combines them. At SUBWARP=1 stride is 1, lane is 0,
+		// WarpReduce<T,1> is identity — body matches the original loop
+		// modulo dropping the start_idx amortization.
 		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			size_t jast = exidx.SinglesFromAdetSM[ja];
-			size_t start_idx = 0;
 			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
 			for (size_t k = exidx.SinglesFromBdetOffset[ibst] + lane;
 			            k < exidx.SinglesFromBdetOffset[ibst + 1];
 			            k += SUBWARP) {
 				size_t jbst = exidx.SinglesFromBdetSM[k];
-				if (start_idx >= end_idx)
-					break;
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, /*start_idx=*/0);
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					start_idx = idxb - tidxmap.AdetToDetOffset[jast];
-					if (start_idx < end_idx) {
+					size_t local_idx = idxb - tidxmap.AdetToDetOffset[jast];
+					if (local_idx < end_idx) {
 						size_t jdet = tidxmap.AdetToDetSM[idxb];
 						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 											exidx.SinglesAdetCrAnSM[ja],
@@ -453,13 +443,6 @@ public:
 						thread_sum += eij * this->twk[jdet];
 					}
 				}
-				// Share last-lane's start_idx if the next strided block is
-				// still in range. This guard implies block_start + SUBWARP <
-				// k_hi → block_start + (SUBWARP-1) < k_hi too, so all SUBWARP
-				// lanes of the current block are still in this iteration and
-				// reach the shuffle (no warp divergence).
-				if (k + SUBWARP - lane < exidx.SinglesFromBdetOffset[ibst + 1])
-					start_idx = __shfl_sync(0xffffffff, start_idx, SUBWARP - 1, SUBWARP);
 			}
 		}
 

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -42,11 +42,19 @@ static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_SUBWARP_SIZE == 0,
               "SBD_MULT_BLOCK_SIZE must be a multiple of SBD_GDB_SUBWARP_SIZE.");
 
 // Custom blocksize-tunable launcher for the GDB Mult kernels. Replaces
-// thrust::for_each_n at the run()-level call sites. Smaller blocks free
-// SM block slots warp-by-warp; CUB's default (128-thread blocks under
-// __launch_bounds__(128, 16)) holds a slot until all 4 peer warps finish.
+// thrust::for_each_n at the run()-level call sites with a fixed-block
+// launch so the v2 SUBWARP-parallel kernel's shared-memory sizing
+// (`BUF_TOTAL = 2 * SBD_MULT_BLOCK_SIZE`) matches the actual block size.
+//
+// Note: the original d977b38 version added `__launch_bounds__(BlockSize,
+// 2048/BlockSize)` to constrain max-threads-per-SM to 2048 and let
+// smaller blocks free SM slots warp-by-warp. On the v2+B+drain kernel
+// (shared mem + ballot + TwoExcite), the annotation appears to force
+// register spilling — actual register pressure exceeds what fits in
+// 2048 threads/SM × 32 regs/thread × H100's 65536 regs/SM. Annotation
+// dropped to let the compiler pick its own register/occupancy tradeoff.
 template <int BlockSize, typename Functor>
-__global__ __launch_bounds__(BlockSize, 2048/BlockSize)
+__global__
 void mult_for_each_n_kernel(size_t n, Functor functor)
 {
     size_t i = static_cast<size_t>(blockIdx.x) * BlockSize + threadIdx.x;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -748,12 +748,53 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
         thrust::for_each_n(thrust::device, ci, twk[active_buf].size(), Wb_init_kernel(wb, hii, twk[active_buf]));
 	}
 
+	// Pre-allocate both double buffers to the global maximum ket/map size before
+	// the task loop.  This eliminates per-task thrust::device_vector::resize()
+	// calls inside ExchangeAsync, which previously launched a Thrust fill-to-zero
+	// kernel followed by cudaDeviceSynchronize() — serializing GPU/MPI overlap on
+	// every task where the recv buffer needed to grow.
+	//
+	// Because send.size() / send_map_storage.size() would then equal global_max
+	// rather than the actual ket/map element count, the caller-supplied logical
+	// sizes (twk_ket_size[] / twk_map_size[]) are passed explicitly to
+	// ExchangeAsync and updated after each successful Sync().
+	size_t twk_ket_size[2];
+	size_t twk_map_size[2];
+	{
+		size_t local_ket_size = twk[active_buf].size();
+		size_t global_max_ket_size;
+		MPI_Allreduce(&local_ket_size, &global_max_ket_size, 1, SBD_MPI_SIZE_T, MPI_MAX, this->b_comm());
+
+		size_t local_map_size = tidxmap_storage[active_buf].size();
+		size_t global_max_map_size;
+		MPI_Allreduce(&local_map_size, &global_max_map_size, 1, SBD_MPI_SIZE_T, MPI_MAX, this->b_comm());
+
+		// Logical sizes tracked independently of vector .size() (which = global_max).
+		twk_ket_size[active_buf] = local_ket_size;
+		twk_ket_size[recv_buf]   = global_max_ket_size;  // placeholder; set after first recv
+		twk_map_size[active_buf] = local_map_size;
+		twk_map_size[recv_buf]   = global_max_map_size;
+
+		// Resize both buffers to global max (fill runs twice total, not per-task).
+		// Active buffer: already has data in [0, local_ket_size); fill only extends
+		// the tail, which is never accessed by kernels (they use tidxmap sizes).
+		twk[active_buf].resize(global_max_ket_size);
+		twk[recv_buf].resize(global_max_ket_size);
+		tidxmap_storage[active_buf].resize(global_max_map_size);
+		tidxmap_storage[recv_buf].resize(global_max_map_size);
+		// Ensure the fill kernels complete before MPI_Irecv writes into these
+		// buffers via GPUDirect RDMA.
+		cudaDeviceSynchronize();
+	}
+
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
-	double _t_exch = 0, _t_sync = 0, _t_gpu = 0;
 	for (size_t task = 0; task < exidx.size(); task++) {
 		// Launch all GPU kernels for this task asynchronously.
 		// The exchange below will overlap with these kernels.
+		double _t_launch, _t_exch, _t_sync, _t_gpu;
+
+		{ auto _t0 = _ck::now();
 
 		// single alpha excitations
 		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
@@ -780,32 +821,46 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
 		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta);
 
+		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+
 		// While the GPU runs the kernels above, exchange the ket for the next
-		// task.  ExchangeAsync and Sync are called back-to-back: the internal
-		// size MPI_Waitall (rendezvous with neighbours) and the large data
-		// transfer both complete while this task's kernels are in flight.
+		// task.  ExchangeAsync posts MPI_Irecv directly into the pre-allocated
+		// device buffer — no resize, no fill kernel, no cudaDeviceSynchronize
+		// inside the exchange.
 		if (task < exidx.size() - 1) {
 			int slide = exidx[task].slide - exidx[task + 1].slide;
 			{ auto _t0 = _ck::now();
-			  slider.ExchangeAsync(twk[active_buf], twk[recv_buf],
-			                       tidxmap[active_buf], tidxmap_storage[active_buf],
-			                       tidxmap[recv_buf], tidxmap_storage[recv_buf],
-			                       slide, this->b_comm(), (int)task);
-			  _t_exch += std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+			  slider.ExchangeAsync(
+			      twk[active_buf], twk_ket_size[active_buf],
+			      twk[recv_buf],
+			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
+			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
+			      slide, this->b_comm(), (int)task);
+			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+			// Save recv sizes before Sync() clears them, then complete the transfer.
+			size_t actual_recv_ket = slider.get_recv_size();
+			size_t actual_recv_map = slider.get_recv_size_map();
 			{ auto _t0 = _ck::now();
 			  if (slider.Sync()) {
+			    twk_ket_size[recv_buf] = actual_recv_ket;
+			    twk_map_size[recv_buf] = actual_recv_map;
 			    int t = active_buf; active_buf = recv_buf; recv_buf = t;
 			  }
-			  _t_sync += std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+		} else {
+			_t_exch = 0.0;
+			_t_sync = 0.0;
 		}
 
 		// Wait for this task's kernels before the next task writes to wb.
 		{ auto _t0 = _ck::now();
 		  cudaDeviceSynchronize();
-		  _t_gpu += std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+
+		fprintf(stderr, "mult_task_ms: rank_b=%d task=%zu"
+		        " launch=%.1f exch=%.1f sync=%.1f gpu_sync=%.1f\n",
+		        mpi_rank_b, task, _t_launch, _t_exch, _t_sync, _t_gpu);
 	} // end task for loop
-	fprintf(stderr, "mult_overlap_ms: rank_b=%d exch=%.1f sync=%.1f gpu_sync=%.1f\n",
-	        mpi_rank_b, _t_exch, _t_sync, _t_gpu);
 
 	if (mpi_size_t > 1)
 		MpiAllreduce(wb, MPI_SUM, this->t_comm());

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -837,19 +837,56 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
         thrust::for_each_n(thrust::device, ci, twk_ket_size[active_buf], Wb_init_kernel(wb, hii, twk[active_buf]));
 	}
 
-	// Non-blocking stream keeps mult kernels off the default stream so
-	// Cray MPICH GPU-direct DMA (which syncs the default stream) does not
-	// stall waiting for kernel completion.
+	// Non-blocking compute stream for the five mult kernels.
 	cudaStream_t compute_stream;
 	cudaStreamCreateWithFlags(&compute_stream, cudaStreamNonBlocking);
+
+	// CPU-staging: separate copy stream moves received ket data from CPU
+	// pinned memory into GPU HBM asynchronously.  copy_done[b] is signalled
+	// when buffer b's GPU copy is complete; compute_stream waits on it before
+	// launching kernels that read buffer b.  This decouples the NIC DMA from
+	// GPU HBM: MPI_Isend/Irecv target CPU pinned memory, eliminating the
+	// HBM bandwidth contention that halves effective MPI throughput when GPU
+	// kernels are running.
+	cudaStream_t copy_stream;
+	cudaStreamCreateWithFlags(&copy_stream, cudaStreamNonBlocking);
+	// copy_done[b]: fired when h_twk[b]/h_map[b] have been copied to GPU.
+	// compute_done[b]: fired when the compute_stream kernels that READ twk[b] finish.
+	// These two event pairs encode the two hazards:
+	//   compute_stream must not read twk[b] until copy_done[b].
+	//   copy_stream must not write twk[b] until compute_done[b].
+	cudaEvent_t copy_done[2], compute_done[2];
+	cudaEventCreate(&copy_done[0]);    cudaEventCreate(&copy_done[1]);
+	cudaEventCreate(&compute_done[0]); cudaEventCreate(&compute_done[1]);
+
+	// CPU-pinned staging buffers (two per data type, one per double-buffer slot).
+	ElemT*    h_twk[2] = {nullptr, nullptr};
+	uint32_t* h_map[2] = {nullptr, nullptr};
+	// twk[*].size() and tidxmap_storage[*].size() equal global_max after the
+	// pre-allocation block above.
+	cudaMallocHost(&h_twk[0], twk[0].size() * sizeof(ElemT));
+	cudaMallocHost(&h_twk[1], twk[1].size() * sizeof(ElemT));
+	cudaMallocHost(&h_map[0], tidxmap_storage[0].size() * sizeof(uint32_t));
+	cudaMallocHost(&h_map[1], tidxmap_storage[1].size() * sizeof(uint32_t));
+
+	// One-time sync copy: mirror the initial active GPU ket into the CPU
+	// staging buffer so the first task can MPI_Isend from host memory.
+	// Synchronous cudaMemcpy completes before the task loop begins.
+	cudaMemcpy(h_twk[active_buf],
+	           thrust::raw_pointer_cast(twk[active_buf].data()),
+	           twk_ket_size[active_buf] * sizeof(ElemT),
+	           cudaMemcpyDeviceToHost);
+	cudaMemcpy(h_map[active_buf],
+	           thrust::raw_pointer_cast(tidxmap_storage[active_buf].data()),
+	           twk_map_size[active_buf] * sizeof(uint32_t),
+	           cudaMemcpyDeviceToHost);
+	// No event pre-recording needed: CUDA treats unrecorded events as complete.
 
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
 	for (size_t task = 0; task < exidx.size(); task++) {
-		// H19 ordering (kernels first, then ExchangeAsync) with kernels on
-		// compute_stream.  Cray MPICH syncs the default stream before DMA;
-		// since kernels run on compute_stream the default stream is always
-		// clean when ExchangeAsync posts MPI_Isend.
+		// compute_stream may not read twk[active] until the CPU→GPU copy is done.
+		cudaStreamWaitEvent(compute_stream, copy_done[active_buf]);
 		double _t_launch, _t_exch, _t_sync, _t_gpu;
 
 		{ auto _t0 = _ck::now();
@@ -881,14 +918,30 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 
 		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
+		// Record compute_done[active] into compute_stream — fires when this
+		// task's kernels finish reading twk[active].  The copy_stream for
+		// a future task will wait on this before writing into that buffer.
+		cudaEventRecord(compute_done[active_buf], compute_stream);
+
 		if (task < exidx.size() - 1) {
 			int slide = exidx[task].slide - exidx[task + 1].slide;
 			{ auto _t0 = _ck::now();
-			  slider.ExchangeAsync(
-			      twk[active_buf], twk_ket_size[active_buf],
-			      twk[recv_buf],
-			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
-			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
+			  // Ensure the cudaMemcpyAsync that READ h_twk[recv_buf] in a prior
+			  // task has completed before MPI_Irecv writes into that same buffer.
+			  // In practice copy_done[recv_buf] fires ~3ms after launch and
+			  // Sync() in the intervening task takes >> 3ms, so this is a no-op
+			  // in steady state — but the dependency must be explicit.
+			  cudaEventSynchronize(copy_done[recv_buf]);
+			  // CPU-staging: send from h_twk[active] (CPU DRAM) — no HBM touch.
+			  slider.ExchangeAsyncHost(
+			      h_twk[active_buf], twk_ket_size[active_buf],
+			      h_twk[recv_buf],   twk[recv_buf].size(),
+			      tidxmap[active_buf],
+			      thrust::raw_pointer_cast(tidxmap_storage[active_buf].data()),
+			      h_map[active_buf],  twk_map_size[active_buf],
+			      tidxmap[recv_buf],
+			      h_map[recv_buf],    tidxmap_storage[recv_buf].size(),
+			      thrust::raw_pointer_cast(tidxmap_storage[recv_buf].data()),
 			      slide, this->b_comm(), (int)task);
 			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 		} else {
@@ -900,6 +953,20 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			  if (slider.Sync()) {
 			    twk_ket_size[recv_buf] = slider.get_recv_size();
 			    twk_map_size[recv_buf] = slider.get_recv_size_map();
+			    // copy_stream must not write twk[recv] while a prior task's
+			    // kernels are still reading it.  Wait for those kernels' event.
+			    cudaStreamWaitEvent(copy_stream, compute_done[recv_buf]);
+			    cudaMemcpyAsync(
+			        thrust::raw_pointer_cast(twk[recv_buf].data()),
+			        h_twk[recv_buf],
+			        twk_ket_size[recv_buf] * sizeof(ElemT),
+			        cudaMemcpyHostToDevice, copy_stream);
+			    cudaMemcpyAsync(
+			        thrust::raw_pointer_cast(tidxmap_storage[recv_buf].data()),
+			        h_map[recv_buf],
+			        twk_map_size[recv_buf] * sizeof(uint32_t),
+			        cudaMemcpyHostToDevice, copy_stream);
+			    cudaEventRecord(copy_done[recv_buf], copy_stream);
 			    int t = active_buf; active_buf = recv_buf; recv_buf = t;
 			  }
 			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
@@ -908,7 +975,11 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		}
 
 		{ auto _t0 = _ck::now();
-		  cudaStreamSynchronize(compute_stream);
+		  // No cudaStreamSynchronize here: all ordering is via events.
+		  // cudaEventSynchronize on the last task's compute_done ensures we
+		  // don't exit run() before the final kernels have written their output.
+		  if (task == exidx.size() - 1)
+		      cudaEventSynchronize(compute_done[active_buf]);
 		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
 		fprintf(stderr, "mult_task_ms: rank_b=%d task=%zu"
@@ -916,6 +987,11 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		        mpi_rank_b, task, _t_launch, _t_exch, _t_sync, _t_gpu);
 	} // end task for loop
 
+	cudaFreeHost(h_twk[0]); cudaFreeHost(h_twk[1]);
+	cudaFreeHost(h_map[0]);  cudaFreeHost(h_map[1]);
+	cudaEventDestroy(copy_done[0]);    cudaEventDestroy(copy_done[1]);
+	cudaEventDestroy(compute_done[0]); cudaEventDestroy(compute_done[1]);
+	cudaStreamDestroy(copy_stream);
 	cudaStreamDestroy(compute_stream);
 
 	if (mpi_size_t > 1)

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -862,13 +862,13 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
 			      slide, this->b_comm(), (int)task);
 			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-			// Save recv sizes before Sync() clears them, then complete the transfer.
-			size_t actual_recv_ket = slider.get_recv_size();
-			size_t actual_recv_map = slider.get_recv_size_map();
+			// Sync() waits for the offset message (deferred from ExchangeAsync) and
+			// then waits for the large ket/map data.  get_recv_size() is valid after
+			// Sync() returns because recv_size is set inside Sync().
 			{ auto _t0 = _ck::now();
 			  if (slider.Sync()) {
-			    twk_ket_size[recv_buf] = actual_recv_ket;
-			    twk_map_size[recv_buf] = actual_recv_map;
+			    twk_ket_size[recv_buf] = slider.get_recv_size();
+			    twk_map_size[recv_buf] = slider.get_recv_size_map();
 			    int t = active_buf; active_buf = recv_buf; recv_buf = t;
 			  }
 			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -12,17 +12,19 @@
 // SBD_GDB_SUBWARP_SIZE selects the threading granularity:
 //   1            → stride=1, behaves like the original code path
 //                  (cub::WarpReduce<T,1> is identity; no cross-lane comm)
-//   8 / 16 / 32  → strided inner-k loop + cub::WarpReduce reduction +
-//                  per-iteration shuffle of last-lane start_idx
+//   2 / 4 / 8 / 16 / 32 → strided inner-k loop + cub::WarpReduce reduction
+//                  + per-iteration ballot-based candidate buffer.
 // Single code path for all sizes — no #ifdef'd duplicate body.
 #ifndef SBD_GDB_SUBWARP_SIZE
   #define SBD_GDB_SUBWARP_SIZE 1
 #endif
 static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
+              SBD_GDB_SUBWARP_SIZE == 2  ||
+              SBD_GDB_SUBWARP_SIZE == 4  ||
               SBD_GDB_SUBWARP_SIZE == 8  ||
               SBD_GDB_SUBWARP_SIZE == 16 ||
               SBD_GDB_SUBWARP_SIZE == 32,
-              "SBD_GDB_SUBWARP_SIZE must be 1, 8, 16, or 32");
+              "SBD_GDB_SUBWARP_SIZE must be 1, 2, 4, 8, 16, or 32");
 #include <cub/warp/warp_reduce.cuh>
 
 namespace sbd
@@ -46,15 +48,17 @@ static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_SUBWARP_SIZE == 0,
 // launch so the v2 SUBWARP-parallel kernel's shared-memory sizing
 // (`BUF_TOTAL = 2 * SBD_MULT_BLOCK_SIZE`) matches the actual block size.
 //
-// Note: the original d977b38 version added `__launch_bounds__(BlockSize,
-// 2048/BlockSize)` to constrain max-threads-per-SM to 2048 and let
-// smaller blocks free SM slots warp-by-warp. On the v2+B+drain kernel
-// (shared mem + ballot + TwoExcite), the annotation appears to force
-// register spilling — actual register pressure exceeds what fits in
-// 2048 threads/SM × 32 regs/thread × H100's 65536 regs/SM. Annotation
-// dropped to let the compiler pick its own register/occupancy tradeoff.
+// __launch_bounds__(BlockSize, 32): the second argument fixes
+// minBlocksPerMultiprocessor at 32 — H100's hardware maximum of
+// 32 thread blocks per SM. The compiler picks a register budget that
+// keeps 32 BlockSize-thread blocks resident per SM:
+//   BS=32 → 32 × 32 = 1024 threads/SM (50% occupancy); 65536/1024 = 64
+//           registers/thread budget.
+//   BS=64 → 32 × 64 = 2048 threads/SM (100% occupancy); 32 regs/thread.
+// Larger BlockSize (128, 256) cannot reach the 32-block/SM target and
+// are out of scope for this build configuration.
 template <int BlockSize, typename Functor>
-__global__
+__global__ __launch_bounds__(BlockSize, 32)
 void mult_for_each_n_kernel(size_t n, Functor functor)
 {
     size_t i = static_cast<size_t>(blockIdx.x) * BlockSize + threadIdx.x;
@@ -67,6 +71,10 @@ inline void launch_mult_for_each_n(size_t n, Functor functor)
     if (n == 0) return;
     const size_t grid = (n + BlockSize - 1) / BlockSize;
     mult_for_each_n_kernel<BlockSize><<<grid, BlockSize>>>(n, functor);
+    // E1 (advice-from-parent §5): force per-launch stream serialization to
+    // test the stream-ordering hypothesis. If this resolves the b_comm>=3
+    // Davidson hang, the legacy default stream is the contention surface.
+    cudaDeviceSynchronize();
 }
 
 template <typename ElemT>

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -97,14 +97,15 @@ void mult_for_each_n_kernel(size_t n, Functor functor)
 }
 
 template <typename Functor>
-inline void launch_mult_for_each_n(size_t n_subwarps, Functor functor)
+inline void launch_mult_for_each_n(size_t n_subwarps, Functor functor,
+                                    cudaStream_t stream = 0)
 {
     if (n_subwarps == 0) return;
     constexpr int BS = Functor::BlockSize;
     constexpr int SW = Functor::SubwarpSize;
     const size_t n_threads = n_subwarps * SW;
     const size_t grid = (n_threads + BS - 1) / BS;
-    mult_for_each_n_kernel<Functor><<<grid, BS>>>(n_threads, functor);
+    mult_for_each_n_kernel<Functor><<<grid, BS, 0, stream>>>(n_threads, functor);
 }
 
 template <typename ElemT>
@@ -812,46 +813,19 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
         thrust::for_each_n(thrust::device, ci, twk_ket_size[active_buf], Wb_init_kernel(wb, hii, twk[active_buf]));
 	}
 
+	// Non-blocking stream keeps mult kernels off the default stream so
+	// Cray MPICH GPU-direct DMA (which syncs the default stream) does not
+	// stall waiting for kernel completion.
+	cudaStream_t compute_stream;
+	cudaStreamCreateWithFlags(&compute_stream, cudaStreamNonBlocking);
+
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
 	for (size_t task = 0; task < exidx.size(); task++) {
-		// No GPU/MPI overlap: kernels run to completion before ExchangeAsync
-		// is posted.  Isolates whether concurrent GPU activity interferes with
-		// NIC DMA throughput from GPU buffers.
+		// H20 ordering (ExchangeAsync before kernel launches) with kernels
+		// on compute_stream.  NIC DMA runs on the default stream and sees
+		// no outstanding GPU work there.
 		double _t_launch, _t_exch, _t_sync, _t_gpu;
-
-		{ auto _t0 = _ck::now();
-
-		// single alpha excitations
-		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
-		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n(idxmap.size_adet, kernel_single_alpha);
-
-		// double alpha excitations
-		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
-		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n(idxmap.size_adet, kernel_double_alpha);
-
-		// single beta excitations
-		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
-		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n(idxmap.size_bdet, kernel_single_beta);
-
-		// double beta excitations
-		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
-		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n(idxmap.size_bdet, kernel_double_beta);
-
-		// alpha-beta excitations
-		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
-		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta);
-
-		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-
-		{ auto _t0 = _ck::now();
-		  cudaDeviceSynchronize();
-		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
 		if (task < exidx.size() - 1) {
 			int slide = exidx[task].slide - exidx[task + 1].slide;
@@ -863,6 +837,40 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
 			      slide, this->b_comm(), (int)task);
 			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+		} else {
+			_t_exch = 0.0;
+		}
+
+		{ auto _t0 = _ck::now();
+
+		// single alpha excitations
+		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+		launch_mult_for_each_n(idxmap.size_adet, kernel_single_alpha, compute_stream);
+
+		// double alpha excitations
+		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
+		launch_mult_for_each_n(idxmap.size_adet, kernel_double_alpha, compute_stream);
+
+		// single beta excitations
+		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+		launch_mult_for_each_n(idxmap.size_bdet, kernel_single_beta, compute_stream);
+
+		// double beta excitations
+		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+		launch_mult_for_each_n(idxmap.size_bdet, kernel_double_beta, compute_stream);
+
+		// alpha-beta excitations
+		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
+		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
+		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta, compute_stream);
+
+		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+
+		if (task < exidx.size() - 1) {
 			{ auto _t0 = _ck::now();
 			  if (slider.Sync()) {
 			    twk_ket_size[recv_buf] = slider.get_recv_size();
@@ -871,14 +879,19 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			  }
 			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 		} else {
-			_t_exch = 0.0;
 			_t_sync = 0.0;
 		}
+
+		{ auto _t0 = _ck::now();
+		  cudaStreamSynchronize(compute_stream);
+		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
 
 		fprintf(stderr, "mult_task_ms: rank_b=%d task=%zu"
 		        " launch=%.1f exch=%.1f sync=%.1f gpu_sync=%.1f\n",
 		        mpi_rank_b, task, _t_launch, _t_exch, _t_sync, _t_gpu);
 	} // end task for loop
+
+	cudaStreamDestroy(compute_stream);
 
 	if (mpi_size_t > 1)
 		MpiAllreduce(wb, MPI_SUM, this->t_comm());

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -200,8 +200,12 @@ public:
 		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
 
     // kernel entry point
-    __device__ __host__ void operator()(size_t i)
+    __device__ __host__ void operator()(size_t arg_i)
     {
+		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		size_t i    = arg_i / SUBWARP;
+		int    lane = static_cast<int>(arg_i % SUBWARP);
+
 		size_t ibst = idxmap.AdetToBdetSM[i];
 		size_t idet = idxmap.AdetToDetSM[i];
 		size_t ia = idxmap.AdetIndex[i];
@@ -209,10 +213,16 @@ public:
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
+		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
+		typename WarpReduceSum::TempStorage temp_sum;
+		ElemT thread_sum = ElemT(0);
+
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
 			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
-			// single alpha excitations
-			for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+			// single alpha excitations — strided across SUBWARP lanes
+			for (size_t ja = exidx.SinglesFromAdetOffset[ia] + lane;
+			            ja < exidx.SinglesFromAdetOffset[ia + 1];
+			            ja += SUBWARP) {
 				size_t jast = exidx.SinglesFromAdetSM[ja];
 				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
 				if (idxa >= 0) {
@@ -222,10 +232,13 @@ public:
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
 											exidx.SinglesAdetCrAnSM[ja],
 											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet]);
-					this->wb[idet] += eij * this->twk[jdet];
+					thread_sum += eij * this->twk[jdet];
 				}
 			}
 		} // if there is same beta string
+
+		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
+		if (lane == 0) this->wb[idet] += total;
 	}
 };
 
@@ -246,8 +259,12 @@ public:
 		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
 
     // kernel entry point
-    __device__ __host__ void operator()(size_t i)
+    __device__ __host__ void operator()(size_t arg_i)
     {
+		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		size_t i    = arg_i / SUBWARP;
+		int    lane = static_cast<int>(arg_i % SUBWARP);
+
 		size_t ibst = idxmap.AdetToBdetSM[i];
 		size_t idet = idxmap.AdetToDetSM[i];
 		size_t ia = idxmap.AdetIndex[i];
@@ -255,10 +272,16 @@ public:
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
+		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
+		typename WarpReduceSum::TempStorage temp_sum;
+		ElemT thread_sum = ElemT(0);
+
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
 			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
-			// double alpha excitations
-			for (size_t ja = exidx.DoublesFromAdetOffset[ia]; ja < exidx.DoublesFromAdetOffset[ia + 1]; ja++) {
+			// double alpha excitations — strided across SUBWARP lanes
+			for (size_t ja = exidx.DoublesFromAdetOffset[ia] + lane;
+			            ja < exidx.DoublesFromAdetOffset[ia + 1];
+			            ja += SUBWARP) {
 				size_t jast = exidx.DoublesFromAdetSM[ja];
 				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
 				if (idxa >= 0) {
@@ -271,10 +294,13 @@ public:
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 2],
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 3]);
 					// size_t od;
-					this->wb[idet] += eij * this->twk[jdet];
+					thread_sum += eij * this->twk[jdet];
 				}
 			}
 		} // if there is same beta string
+
+		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
+		if (lane == 0) this->wb[idet] += total;
 	}
 };
 
@@ -298,8 +324,12 @@ public:
 		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
 
     // kernel entry point
-    __device__ __host__ void operator()(size_t i)
+    __device__ __host__ void operator()(size_t arg_i)
     {
+		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		size_t i    = arg_i / SUBWARP;
+		int    lane = static_cast<int>(arg_i % SUBWARP);
+
 		size_t iast = idxmap.BdetToAdetSM[i];
 		size_t idet = idxmap.BdetToDetSM[i];
 		size_t ib = idxmap.BdetIndex[i];
@@ -307,10 +337,16 @@ public:
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
+		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
+		typename WarpReduceSum::TempStorage temp_sum;
+		ElemT thread_sum = ElemT(0);
+
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
 			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
-			// single alpha excitations
-			for (size_t jb = exidx.SinglesFromBdetOffset[ib]; jb < exidx.SinglesFromBdetOffset[ib + 1]; jb++) {
+			// single beta excitations — strided across SUBWARP lanes
+			for (size_t jb = exidx.SinglesFromBdetOffset[ib] + lane;
+			            jb < exidx.SinglesFromBdetOffset[ib + 1];
+			            jb += SUBWARP) {
 				size_t jbst = exidx.SinglesFromBdetSM[jb];
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
 				if (idxb >= 0) {
@@ -320,10 +356,13 @@ public:
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
 											exidx.SinglesBdetCrAnSM[jb],
 											exidx.SinglesBdetCrAnSM[jb + exidx.size_single_bdet]);
-					this->wb[idet] += eij * this->twk[jdet];
+					thread_sum += eij * this->twk[jdet];
 				}
 			}
 		} // if there is same beta string
+
+		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
+		if (lane == 0) this->wb[idet] += total;
 	}
 };
 
@@ -344,8 +383,12 @@ public:
 		: MultKernelBase<ElemT>(v_wb, v_t, data), idxmap(idxmap_in), tidxmap(tidxmap_in), exidx(exidx_in) {}
 
     // kernel entry point
-    __device__ __host__ void operator()(size_t i)
+    __device__ __host__ void operator()(size_t arg_i)
     {
+		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		size_t i    = arg_i / SUBWARP;
+		int    lane = static_cast<int>(arg_i % SUBWARP);
+
 		size_t iast = idxmap.BdetToAdetSM[i];
 		size_t idet = idxmap.BdetToDetSM[i];
 		size_t ib = idxmap.BdetIndex[i];
@@ -353,10 +396,16 @@ public:
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
+		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
+		typename WarpReduceSum::TempStorage temp_sum;
+		ElemT thread_sum = ElemT(0);
+
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
 			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
-			// double alpha excitations
-			for (size_t jb = exidx.DoublesFromBdetOffset[ib]; jb < exidx.DoublesFromBdetOffset[ib + 1]; jb++) {
+			// double beta excitations — strided across SUBWARP lanes
+			for (size_t jb = exidx.DoublesFromBdetOffset[ib] + lane;
+			            jb < exidx.DoublesFromBdetOffset[ib + 1];
+			            jb += SUBWARP) {
 				size_t jbst = exidx.DoublesFromBdetSM[jb];
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
 				if (idxb >= 0) {
@@ -369,10 +418,13 @@ public:
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 2],
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 3]);
 					// size_t od;
-					this->wb[idet] += eij * this->twk[jdet];
+					thread_sum += eij * this->twk[jdet];
 				}
 			}
 		} // if there is same beta string
+
+		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
+		if (lane == 0) this->wb[idet] += total;
 	}
 };
 
@@ -535,28 +587,32 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
 
 		auto ci_sa = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_sa, idxmap.size_adet, kernel_single_alpha);
+		thrust::for_each_n(thrust::device, ci_sa,
+		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_single_alpha);
 
 		// double alpha excitations
 		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
 
 		auto ci_da = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_da, idxmap.size_adet, kernel_double_alpha);
+		thrust::for_each_n(thrust::device, ci_da,
+		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_double_alpha);
 
 		// single beta excitations
 		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
 
 		auto ci_sb = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_sb, idxmap.size_bdet, kernel_single_beta);
+		thrust::for_each_n(thrust::device, ci_sb,
+		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_single_beta);
 
 		// double beta excitations
 		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
 
 		auto ci_db = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_db, idxmap.size_bdet, kernel_double_beta);
+		thrust::for_each_n(thrust::device, ci_db,
+		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_double_beta);
 
 		// alpha-beta excitations
 		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -743,16 +743,16 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		twk[active_buf] = wk;
 	}
 
-	if (mpi_rank_t == 0) {
-        auto ci = thrust::counting_iterator<size_t>(0);
-        thrust::for_each_n(thrust::device, ci, twk[active_buf].size(), Wb_init_kernel(wb, hii, twk[active_buf]));
-	}
-
 	// Pre-allocate both double buffers to the global maximum ket/map size before
 	// the task loop.  This eliminates per-task thrust::device_vector::resize()
 	// calls inside ExchangeAsync, which previously launched a Thrust fill-to-zero
 	// kernel followed by cudaDeviceSynchronize() — serializing GPU/MPI overlap on
 	// every task where the recv buffer needed to grow.
+	//
+	// ORDERING: pre-allocation MUST come before Wb_init_kernel.  Wb_init_kernel
+	// captures twk[active_buf].data() at construction time; if resize() ran after
+	// the kernel was launched it could reallocate the buffer and free the old device
+	// memory while the kernel is still running on it.
 	//
 	// Because send.size() / send_map_storage.size() would then equal global_max
 	// rather than the actual ket/map element count, the caller-supplied logical
@@ -775,16 +775,41 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		twk_map_size[active_buf] = local_map_size;
 		twk_map_size[recv_buf]   = global_max_map_size;
 
-		// Resize both buffers to global max (fill runs twice total, not per-task).
-		// Active buffer: already has data in [0, local_ket_size); fill only extends
-		// the tail, which is never accessed by kernels (they use tidxmap sizes).
+		// Resize both ket buffers to global max.
 		twk[active_buf].resize(global_max_ket_size);
 		twk[recv_buf].resize(global_max_ket_size);
-		tidxmap_storage[active_buf].resize(global_max_map_size);
+
+		// Resize active map storage.  If resize() triggers reallocation the data
+		// moves to a new device address, which would invalidate the raw pointers
+		// already stored in tidxmap[active_buf].  Detect and fix up.
+		{
+			uint32_t* old_base = thrust::raw_pointer_cast(tidxmap_storage[active_buf].data());
+			tidxmap_storage[active_buf].resize(global_max_map_size);
+			uint32_t* new_base = thrust::raw_pointer_cast(tidxmap_storage[active_buf].data());
+			if (new_base != old_base) {
+				ptrdiff_t delta = new_base - old_base;
+				tidxmap[active_buf].AdetToDetOffset += delta;
+				tidxmap[active_buf].BdetToDetOffset += delta;
+				tidxmap[active_buf].AdetIndex       += delta;
+				tidxmap[active_buf].BdetIndex       += delta;
+				tidxmap[active_buf].AdetToBdetSM    += delta;
+				tidxmap[active_buf].AdetToDetSM     += delta;
+				tidxmap[active_buf].BdetToAdetSM    += delta;
+				tidxmap[active_buf].BdetToDetSM     += delta;
+			}
+		}
 		tidxmap_storage[recv_buf].resize(global_max_map_size);
-		// Ensure the fill kernels complete before MPI_Irecv writes into these
+		// Ensure all fill kernels complete before MPI_Irecv writes into these
 		// buffers via GPUDirect RDMA.
 		cudaDeviceSynchronize();
+	}
+
+	// Wb_init_kernel AFTER pre-allocation so it captures the (potentially
+	// reallocated) twk[active_buf] pointer.  Use twk_ket_size[active_buf]
+	// — not twk[active_buf].size() which equals global_max after resize.
+	if (mpi_rank_t == 0) {
+        auto ci = thrust::counting_iterator<size_t>(0);
+        thrust::for_each_n(thrust::device, ci, twk_ket_size[active_buf], Wb_init_kernel(wb, hii, twk[active_buf]));
 	}
 
 	MpiSlider<ElemT> slider;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -66,17 +66,17 @@ static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_AB_SUBWARP_SIZE == 0,
 // SBD_MULT_MIN_BLOCKS_PER_SM tunes the second argument of
 // __launch_bounds__ on mult_for_each_n_kernel — the
 // minBlocksPerMultiprocessor hint the compiler uses to pick a register
-// budget per thread. Default 32 = H100 hardware maximum; lower values
-// trade occupancy for a larger per-thread register budget.
+// budget per thread. Lower values trade occupancy for a larger per-thread
+// register budget.
 //   threads/SM = SBD_MULT_BLOCK_SIZE × SBD_MULT_MIN_BLOCKS_PER_SM
 //   regs/thread budget ≈ 65536 / threads/SM
 // Examples (BS=64):
 //   mbpsm=32 → 2048 threads/SM (100% occupancy); 32 regs/thread
 //   mbpsm=24 → 1536 threads/SM (75% occupancy); 42 regs/thread
-//   mbpsm=20 → 1280 threads/SM (62.5% occupancy); 51 regs/thread
+//   mbpsm=20 → 1280 threads/SM (62.5% occupancy); 51 regs/thread  ← default (track U)
 //   mbpsm=16 → 1024 threads/SM (50% occupancy); 64 regs/thread
 #ifndef SBD_MULT_MIN_BLOCKS_PER_SM
-  #define SBD_MULT_MIN_BLOCKS_PER_SM 18
+  #define SBD_MULT_MIN_BLOCKS_PER_SM 20
 #endif
 static_assert(SBD_MULT_MIN_BLOCKS_PER_SM >= 1 &&
               SBD_MULT_MIN_BLOCKS_PER_SM <= 32,

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -324,7 +324,7 @@ public:
     __device__ __host__ void operator()(size_t arg_i)
     {
 		constexpr int SUBWARP = SubwarpSize;
-		size_t i    = arg_i / SUBWARP;
+		uint32_t i    = static_cast<uint32_t>(arg_i / SUBWARP);
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
 		uint32_t ibst = idxmap.AdetToBdetSM[i];
@@ -343,10 +343,8 @@ public:
 			              ja < exidx.SinglesFromAdetOffset[ia + 1];
 			              ja += SUBWARP) {
 				uint32_t jast = exidx.SinglesFromAdetSM[ja];
-				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
-				if (idxa >= 0) {
-					if (jast != tidxmap.BdetToAdetSM[idxa])
-						continue;
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
 											exidx.SinglesAdetCrAnSM[ja],
@@ -383,7 +381,7 @@ public:
     __device__ __host__ void operator()(size_t arg_i)
     {
 		constexpr int SUBWARP = SubwarpSize;
-		size_t i    = arg_i / SUBWARP;
+		uint32_t i    = static_cast<uint32_t>(arg_i / SUBWARP);
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
 		uint32_t ibst = idxmap.AdetToBdetSM[i];
@@ -402,10 +400,8 @@ public:
 			              ja < exidx.DoublesFromAdetOffset[ia + 1];
 			              ja += SUBWARP) {
 				uint32_t jast = exidx.DoublesFromAdetSM[ja];
-				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
-				if (idxa >= 0) {
-					if (jast != tidxmap.BdetToAdetSM[idxa])
-						continue;
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
 											exidx.DoublesAdetCrAnSM[ja],
@@ -447,7 +443,7 @@ public:
     __device__ __host__ void operator()(size_t arg_i)
     {
 		constexpr int SUBWARP = SubwarpSize;
-		size_t i    = arg_i / SUBWARP;
+		uint32_t i    = static_cast<uint32_t>(arg_i / SUBWARP);
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
 		uint32_t iast = idxmap.BdetToAdetSM[i];
@@ -466,10 +462,8 @@ public:
 			              jb < exidx.SinglesFromBdetOffset[ib + 1];
 			              jb += SUBWARP) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
 											exidx.SinglesBdetCrAnSM[jb],
@@ -506,7 +500,7 @@ public:
     __device__ __host__ void operator()(size_t arg_i)
     {
 		constexpr int SUBWARP = SubwarpSize;
-		size_t i    = arg_i / SUBWARP;
+		uint32_t i    = static_cast<uint32_t>(arg_i / SUBWARP);
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
 		uint32_t iast = idxmap.BdetToAdetSM[i];
@@ -525,10 +519,8 @@ public:
 			              jb < exidx.DoublesFromBdetOffset[ib + 1];
 			              jb += SUBWARP) {
 				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
 											exidx.DoublesBdetCrAnSM[jb],
@@ -574,7 +566,7 @@ public:
 		constexpr int BUF_PG    = 2 * SUBWARP;            // slots per group
 		constexpr int BUF_TOTAL = 2 * BLOCK;              // = GROUPS * BUF_PG
 
-		size_t i     = arg_i / SUBWARP;                   // SUBWARP=1 → i = arg_i
+		uint32_t i     = static_cast<uint32_t>(arg_i / SUBWARP); // SUBWARP=1 → i = arg_i
 		int    lane  = static_cast<int>(arg_i % SUBWARP); // 0..SUBWARP-1 within group
 		int    group = static_cast<int>(i % GROUPS);      // 0..GROUPS-1 within block
 		int    buf_base = group * BUF_PG;
@@ -596,26 +588,27 @@ public:
 		__shared__ uint32_t s_idxb [BUF_TOTAL];
 		__shared__ uint32_t s_ja   [BUF_TOTAL];
 		__shared__ uint32_t s_k    [BUF_TOTAL];
-		__shared__ int     s_count[GROUPS];
-		if (lane == 0) s_count[group] = 0;
+		// s_count lives in a register: every lane computes __popc(warp_ballot)
+		// independently, so all lanes' copies stay identical without any
+		// shared-memory round-trip or __syncwarp for the count itself.
+		int s_count = 0;
 
 		// Per-SUBWARP ballot mask — covers this group's lanes within the
 		// containing CUDA warp. With multiple groups per warp (SUBWARP < 32),
 		// each group masks the warp-wide ballot to its own bit-range.
-		const int      lane_in_warp  = static_cast<int>(threadIdx.x) % 32;
-		const int      group_in_warp = lane_in_warp / SUBWARP;
+		const unsigned lane_in_warp  = static_cast<unsigned>(threadIdx.x) % 32u;
+		const unsigned group_in_warp = lane_in_warp / static_cast<unsigned>(SUBWARP);
 		const unsigned subwarp_lanes = (SUBWARP == 32) ? 0xFFFFFFFFu
 		                                               : ((1u << SUBWARP) - 1u);
 		const unsigned subwarp_mask  = subwarp_lanes << (group_in_warp * SUBWARP);
-		__syncwarp(subwarp_mask);
 
 		// Outer ja loop. Inner k loop runs k_iters times *uniformly* across
 		// all SUBWARP lanes of the group (k_lane = k_lo + it*SUBWARP + lane,
 		// guarded by `in_range = k_lane < k_hi`). This keeps __ballot_sync
-		// and __syncwarp(subwarp_mask) calls reachable by every lane on
-		// every iteration — fixing the divergent-loop-exit bug in v1.
-		// adet_lower_bound returns -1 on miss, otherwise i < AdetToDetOffset[jast+1];
-		// so (idxb - AdetToDetOffset[jast]) is in-range whenever idxb >= 0.
+		// reachable by every lane on every iteration — fixing the
+		// divergent-loop-exit bug in v1.
+		// adet_lower_bound returns {found, ie}; ie < AdetToDetOffset[jast+1] whenever found.
+		// (idxb - AdetToDetOffset[jast]) is in-range whenever valid.
 		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			uint32_t jast    = exidx.SinglesFromAdetSM[ja];
 			uint32_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
@@ -623,51 +616,35 @@ public:
 			uint32_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
 
 			for (uint32_t it = 0; it < k_iters; it++) {
-				uint32_t k        = k_lo + it * SUBWARP + lane;
-				bool     in_range = (k < k_hi);
-				int64_t  idxb     = -1;
-				uint32_t jbst     = 0;
-				bool    valid    = false;
-				if (in_range) {
-					jbst  = exidx.SinglesFromBdetSM[k];
-					idxb  = tidxmap.adet_lower_bound(jast, jbst, /*start_idx=*/0);
-					valid = (idxb >= 0 && jbst == tidxmap.AdetToBdetSM[idxb]);
-				}
+				uint32_t k             = k_lo + it * SUBWARP + lane;
+				uint32_t jbst          = exidx.SinglesFromBdetSM[std::min(k, k_hi - 1)];
+				auto [found, idxb]     = tidxmap.adet_lower_bound(jast, jbst);
+				bool     valid         = k < k_hi && found;
 
-				// Per-group ballot (only this group's SUBWARP lanes
-				// participate; sibling groups in the same warp may be at
-				// different ja iterations). Per-lane rank within the group
-				// is __popc of group-local bits below this lane. Replaces
-				// atomicAdd for slot allocation.
-				unsigned warp_ballot    = __ballot_sync(subwarp_mask, valid);
-				unsigned subwarp_ballot = (warp_ballot & subwarp_mask) >> (group_in_warp * SUBWARP);
-				int      rank           = __popc(subwarp_ballot & ((1u << lane) - 1u));
-				int      added          = __popc(subwarp_ballot);
+				// Per-group ballot. __ballot_sync(subwarp_mask,...) zeroes
+				// bits outside the mask so warp_ballot is already confined
+				// to this group; no shift needed for rank or total.
+				unsigned warp_ballot = __ballot_sync(subwarp_mask, valid);
 
 				if (valid) {
-					int slot = buf_base + s_count[group] + rank;
-					s_idxb[slot] = static_cast<uint32_t>(idxb);
+					int rank = __popc(warp_ballot & ((1u << lane_in_warp) - 1u));
+					int slot = buf_base + s_count + rank;
+					s_idxb[slot] = idxb;
 					s_ja  [slot] = ja;
 					s_k   [slot] = k;
 				}
-				if (lane == 0) s_count[group] += added;
-				__syncwarp(subwarp_mask);
+				// All lanes compute __popc(warp_ballot) identically — no syncwarp.
+				s_count += __popc(warp_ballot);
 
-				// Per Jim's drain-fold suggestion: extend the dispatch trigger
-				// to also fire on the very last (it, ja) so the post-loop drain
-				// block can be eliminated. Loop the dispatch on is_last_inner so
-				// the case where post-append count > SUBWARP on the last (it, ja)
-				// is also drained — Jim's literal proposal would lose
-				// (count - SUBWARP) candidates in that case (one round of
-				// SUBWARP-wide dispatch + compact, then kernel exits with the
-				// shifted leftovers still unprocessed). The while form runs at
-				// most twice on the last iter and once otherwise.
-				bool is_last_inner = (it == k_iters - 1) &&
-				                     (ja == exidx.SinglesFromAdetOffset[ia + 1] - 1);
-				while (s_count[group] >= SUBWARP || (is_last_inner && s_count[group] > 0)) {
-					// Dispatch up to SUBWARP TwoExcite() calls in parallel. Lane
-					// guard: count may be < SUBWARP on the is_last_inner drain pass.
-					if (lane < s_count[group]) {
+				// Dispatch when a full SUBWARP batch has accumulated.
+				// s_count < 2*SUBWARP at this point (invariant: s_count was
+				// < SUBWARP before the ballot, at most SUBWARP added), so
+				// if is sufficient — at most one dispatch per k-iteration.
+				if (s_count >= SUBWARP) {
+					// Fence: ensure accumulate writes above are visible to all
+					// lanes before dispatch reads below.
+					__syncwarp(subwarp_mask);
+					if (lane < s_count) {
 						int      my_slot = buf_base + lane;
 						uint32_t my_idxb = s_idxb[my_slot];
 						uint32_t my_ja   = s_ja  [my_slot];
@@ -680,24 +657,37 @@ public:
 						                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
 						thread_sum += eij * this->twk[jdet];
 					}
-					__syncwarp(subwarp_mask);
-
-					// Compact this group's slice. Source [buf_base+SUBWARP,
-					// buf_base+2*SUBWARP) and destination [buf_base, buf_base+SUBWARP)
-					// are disjoint; direct lane-parallel copy is safe without an
-					// intermediate sync. Slots above the new s_count are garbage
-					// but invisible — either next probe round overwrites starting
-					// at s_count, or kernel exits (is_last_inner drain case). Only
-					// lane 0 mutates s_count (decrement-not-assign).
+					// No __syncwarp between dispatch and compact: each lane reads/writes
+					// only its own slot (dispatch reads buf_base+lane; compact reads
+					// buf_base+SUBWARP+lane and writes buf_base+lane — non-overlapping
+					// per-lane ranges, so no cross-lane hazard here). The next
+					// __ballot_sync (next k-iteration) or post-loop __syncwarp fences
+					// these compact writes before subsequent reads.
 					s_idxb[buf_base + lane] = s_idxb[buf_base + SUBWARP + lane];
 					s_ja  [buf_base + lane] = s_ja  [buf_base + SUBWARP + lane];
 					s_k   [buf_base + lane] = s_k   [buf_base + SUBWARP + lane];
-					if (lane == 0) s_count[group] -= SUBWARP;
-					__syncwarp(subwarp_mask);
+					s_count -= SUBWARP;
 				}
 			}
 		}
 
+		// Drain any remaining candidates left in the buffer after all ja/k loops.
+		if (s_count > 0) {
+			__syncwarp(subwarp_mask);
+			if (lane < s_count) {
+				int      my_slot = buf_base + lane;
+				uint32_t my_idxb = s_idxb[my_slot];
+				uint32_t my_ja   = s_ja  [my_slot];
+				uint32_t my_k    = s_k   [my_slot];
+				uint32_t jdet    = tidxmap.AdetToDetSM[my_idxb];
+				ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
+				                    exidx.SinglesAdetCrAnSM[my_ja],
+				                    exidx.SinglesBdetCrAnSM[my_k],
+				                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],
+				                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
+				thread_sum += eij * this->twk[jdet];
+			}
+		}
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
 		if (lane == 0) this->wb[idet] += total;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -18,7 +18,7 @@
 //                  + per-iteration ballot-based candidate buffer.
 // Single code path for all sizes — no #ifdef'd duplicate body.
 #ifndef SBD_GDB_SUBWARP_SIZE
-  #define SBD_GDB_SUBWARP_SIZE 1
+  #define SBD_GDB_SUBWARP_SIZE 8
 #endif
 static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
               SBD_GDB_SUBWARP_SIZE == 2  ||
@@ -33,7 +33,7 @@ static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
 // across all five mult kernels). Set independently to sweep the AlphaBeta
 // subwarp size without changing the other four kernels.
 #ifndef SBD_GDB_AB_SUBWARP_SIZE
-  #define SBD_GDB_AB_SUBWARP_SIZE SBD_GDB_SUBWARP_SIZE
+  #define SBD_GDB_AB_SUBWARP_SIZE 32
 #endif
 static_assert(SBD_GDB_AB_SUBWARP_SIZE == 1  ||
               SBD_GDB_AB_SUBWARP_SIZE == 2  ||
@@ -51,7 +51,7 @@ namespace gdb
 {
 
 #ifndef SBD_MULT_BLOCK_SIZE
-  #define SBD_MULT_BLOCK_SIZE 32
+  #define SBD_MULT_BLOCK_SIZE 64
 #endif
 static_assert(SBD_MULT_BLOCK_SIZE == 32  ||
               SBD_MULT_BLOCK_SIZE == 64  ||
@@ -76,7 +76,7 @@ static_assert(SBD_MULT_BLOCK_SIZE % SBD_GDB_AB_SUBWARP_SIZE == 0,
 //   mbpsm=20 → 1280 threads/SM (62.5% occupancy); 51 regs/thread
 //   mbpsm=16 → 1024 threads/SM (50% occupancy); 64 regs/thread
 #ifndef SBD_MULT_MIN_BLOCKS_PER_SM
-  #define SBD_MULT_MIN_BLOCKS_PER_SM 32
+  #define SBD_MULT_MIN_BLOCKS_PER_SM 18
 #endif
 static_assert(SBD_MULT_MIN_BLOCKS_PER_SM >= 1 &&
               SBD_MULT_MIN_BLOCKS_PER_SM <= 32,

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -12,9 +12,9 @@
 // SBD_GDB_SUBWARP_SIZE selects the threading granularity:
 //   1            → stride=1, behaves like the original code path
 //                  (cub::WarpReduce<T,1> is identity; no cross-lane comm)
-//   8 / 16 / 32  → strided inner-k loop + cub::WarpReduce reduction
-// Single code path for all sizes — no #ifdef'd duplicate body. Each lane
-// keeps its own start_idx running optimisation across its strided subset.
+//   8 / 16 / 32  → strided inner-k loop + cub::WarpReduce reduction +
+//                  per-iteration shuffle of last-lane start_idx
+// Single code path for all sizes — no #ifdef'd duplicate body.
 #ifndef SBD_GDB_SUBWARP_SIZE
   #define SBD_GDB_SUBWARP_SIZE 1
 #endif
@@ -24,6 +24,11 @@ static_assert(SBD_GDB_SUBWARP_SIZE == 1  ||
               SBD_GDB_SUBWARP_SIZE == 32,
               "SBD_GDB_SUBWARP_SIZE must be 1, 8, 16, or 32");
 #include <cub/warp/warp_reduce.cuh>
+// Note: Jim's reference form was
+//   start_idx = cuda::device::warp::shuffle_idx(start_idx, SUBWARP-1, SUBWARP);
+// `cuda::device::warp::shuffle_idx` is a CCCL/libcu++ wrapper not present in
+// NVHPC SDK 25.5 (no <cuda/warp> header). The functionally-equivalent CUDA
+// built-in `__shfl_sync(0xffffffff, value, srcLane, width)` is used below.
 
 namespace sbd
 {
@@ -412,53 +417,49 @@ public:
 		ElemT thread_sum = ElemT(0);
 
 		// alpha-beta two-particle excitations
-		// Inner k-loop is strided by SUBWARP. Explicit iteration count so ALL
-		// SUBWARP lanes reach the per-iteration shuffle-broadcast (lanes whose
-		// k is out of range just skip the body but still participate in the
-		// shuffle, required for warp-shuffle correctness on Volta+). After
-		// each non-final iteration we broadcast the LAST lane's start_idx to
-		// all SUBWARP lanes via __shfl_sync. Last lane's k is the highest in
-		// the iteration block, so its lower_bound has reached the furthest
-		// position. Lane L's next k > all lanes' current k (sorted
-		// SinglesFromBdetSM), so the last lane's start_idx is a valid (and
-		// usually tightest) lower bound for every lane's next adet_lower_bound.
-		// At SUBWARP=1: stride 1, lane 0, n_iters = k_hi - k_lo, no broadcast
-		// needed (last-iter check filters it out for the only iter), so the
-		// body collapses to the original sequential loop.
+		// Inner k-loop is strided by SUBWARP starting at lane. Each lane keeps
+		// its own running start_idx; at end of each iteration we broadcast the
+		// last lane's start_idx to all SUBWARP lanes (it has the tightest
+		// lower_bound this iteration since SinglesFromBdetSM is sorted and
+		// last-lane's k is the highest in the strided block). The condition
+		// `k + SUBWARP - lane < k_hi` ensures all SUBWARP lanes are at the
+		// shuffle call site (it's equivalent to `block_start + SUBWARP < k_hi`,
+		// which implies `block_start + (SUBWARP-1) < k_hi`, so lane SUBWARP-1
+		// of the current block is also in range). At SUBWARP=1 stride is 1,
+		// lane is 0, the shuffle width=1 srcLane=0 is identity, so the body
+		// collapses to the original sequential loop.
 		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			size_t jast = exidx.SinglesFromAdetSM[ja];
 			size_t start_idx = 0;
 			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
-
-			size_t k_lo = exidx.SinglesFromBdetOffset[ibst];
-			size_t k_hi = exidx.SinglesFromBdetOffset[ibst + 1];
-			size_t n_iters = (k_hi > k_lo) ? ((k_hi - k_lo + SUBWARP - 1) / SUBWARP) : 0;
-
-			for (size_t iter = 0; iter < n_iters; iter++) {
-				size_t k = k_lo + iter * SUBWARP + lane;
-				if (k < k_hi && start_idx < end_idx) {
-					size_t jbst = exidx.SinglesFromBdetSM[k];
-					int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
-					if (idxb >= 0 && jbst == tidxmap.AdetToBdetSM[idxb]) {
-						size_t local_idx = idxb - tidxmap.AdetToDetOffset[jast];
-						if (local_idx < end_idx) {
-							start_idx = local_idx;
-							size_t jdet = tidxmap.AdetToDetSM[idxb];
-							ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
-												exidx.SinglesAdetCrAnSM[ja],
-												exidx.SinglesBdetCrAnSM[k],
-												exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
-												exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
-							thread_sum += eij * this->twk[jdet];
-						}
+			for (size_t k = exidx.SinglesFromBdetOffset[ibst] + lane;
+			            k < exidx.SinglesFromBdetOffset[ibst + 1];
+			            k += SUBWARP) {
+				size_t jbst = exidx.SinglesFromBdetSM[k];
+				if (start_idx >= end_idx)
+					break;
+				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
+				if (idxb >= 0) {
+					if (jbst != tidxmap.AdetToBdetSM[idxb])
+						continue;
+					start_idx = idxb - tidxmap.AdetToDetOffset[jast];
+					if (start_idx < end_idx) {
+						size_t jdet = tidxmap.AdetToDetSM[idxb];
+						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+											exidx.SinglesAdetCrAnSM[ja],
+											exidx.SinglesBdetCrAnSM[k],
+											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
+											exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
+						thread_sum += eij * this->twk[jdet];
 					}
 				}
-				// Per-iteration sync: broadcast last lane's start_idx (= the
-				// tightest natural lower bound after this iter's strided block)
-				// to all SUBWARP lanes. Skip on the last iter.
-				if (iter + 1 < n_iters) {
+				// Share last-lane's start_idx if the next strided block is
+				// still in range. This guard implies block_start + SUBWARP <
+				// k_hi → block_start + (SUBWARP-1) < k_hi too, so all SUBWARP
+				// lanes of the current block are still in this iteration and
+				// reach the shuffle (no warp divergence).
+				if (k + SUBWARP - lane < exidx.SinglesFromBdetOffset[ibst + 1])
 					start_idx = __shfl_sync(0xffffffff, start_idx, SUBWARP - 1, SUBWARP);
-				}
 			}
 		}
 

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -117,6 +117,7 @@ protected:
 	thrust::device_vector<uint32_t> idxmap_storage;
 	DetIndexMapThrust idxmap;
     thrust::device_vector<size_t> dets_;
+    thrust::device_vector<size_t> detsums_;
     ElemT I0_;
     oneInt_Thrust<ElemT> I1_;
     thrust::device_vector<ElemT> I1_store;
@@ -147,6 +148,10 @@ public:
 	const thrust::device_vector<size_t>& dets(void) const
 	{
 		return dets_;
+	}
+	const thrust::device_vector<size_t>& detsums(void) const
+	{
+		return detsums_;
 	}
 
 	void Init(
@@ -225,6 +230,35 @@ void MultGDBThrust<ElemT>::Init(
         thrust::copy_n(dets_in[i].begin(), this->D_size_, dets_.begin() + i * this->D_size_);
     }
 
+    // compute detsums_: inclusive prefix parity of each determinant's bit string.
+    // detsums_[d*D_size+w] bit k = parity of bits [0, w*bit_length+k] of det d.
+    // Computed via a 6-step parallel prefix XOR scan per word, carrying parity
+    // between words. Used by parity_fast() / TwoExciteFast() for O(1) parity lookup.
+    {
+        const size_t n_dets = dets_in.size();
+        const size_t bl     = bit_length_in;
+        std::vector<size_t> detsums_host(this->D_size_ * n_dets);
+        for (size_t d = 0; d < n_dets; d++) {
+            size_t carry = 0; // parity of all bits in preceding words (0 or 1)
+            for (size_t w = 0; w < this->D_size_; w++) {
+                size_t q = dets_in[d][w];
+                // inclusive prefix XOR scan: q[k] = XOR of original bits [0..k]
+                q ^= (q << 1);
+                q ^= (q << 2);
+                q ^= (q << 4);
+                q ^= (q << 8);
+                q ^= (q << 16);
+                q ^= (q << 32);
+                // apply carry from previous words
+                if (carry) q = ~q;
+                detsums_host[d * this->D_size_ + w] = q;
+                carry = (q >> (bl - 1)) & 1; // parity of bits [0, (w+1)*bl-1]
+            }
+        }
+        detsums_.resize(this->D_size_ * n_dets);
+        thrust::copy_n(detsums_host.begin(), detsums_host.size(), detsums_.begin());
+    }
+
 	// copy indexmap
 	idxmap = DetIndexMapThrust(idxmap_storage, idxmap_in);
 }
@@ -239,6 +273,7 @@ protected:
     ElemT *wb;
     ElemT* twk;
     size_t* det;
+    size_t* detsum;
 public:
     MultKernelBase() {}
 
@@ -249,13 +284,15 @@ public:
     {
         wb = (ElemT*)thrust::raw_pointer_cast(v_wb.data());
         twk = (ElemT*)thrust::raw_pointer_cast(v_t.data());
-        det = (size_t*)thrust::raw_pointer_cast(data.dets().data());
+        det    = (size_t*)thrust::raw_pointer_cast(data.dets().data());
+        detsum = (size_t*)thrust::raw_pointer_cast(data.detsums().data());
     }
 
     MultKernelBase(const MultGDBThrust<ElemT>& data)
                  : DeterminantKernels<ElemT>(data.bit_length(), data.norbs(), data.I0(), data.I1(), data.I2())
     {
-        det = (size_t*)thrust::raw_pointer_cast(data.dets().data());
+        det    = (size_t*)thrust::raw_pointer_cast(data.dets().data());
+        detsum = (size_t*)thrust::raw_pointer_cast(data.detsums().data());
     }
 
     void set_mpi_size(size_t h_rank, size_t h_size)
@@ -370,7 +407,7 @@ public:
 					if (jast != tidxmap.BdetToAdetSM[idxa])
 						continue;
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
-					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+					ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
 											exidx.DoublesAdetCrAnSM[ja],
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet],
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 2],
@@ -493,7 +530,7 @@ public:
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
-					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+					ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
 											exidx.DoublesBdetCrAnSM[jb],
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet],
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 2],
@@ -636,7 +673,7 @@ public:
 						uint32_t my_ja   = s_ja  [my_slot];
 						uint32_t my_k    = s_k   [my_slot];
 						uint32_t jdet    = tidxmap.AdetToDetSM[my_idxb];
-						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+						ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
 						                    exidx.SinglesAdetCrAnSM[my_ja],
 						                    exidx.SinglesBdetCrAnSM[my_k],
 						                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -822,24 +822,11 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
 	for (size_t task = 0; task < exidx.size(); task++) {
-		// H20 ordering (ExchangeAsync before kernel launches) with kernels
-		// on compute_stream.  NIC DMA runs on the default stream and sees
-		// no outstanding GPU work there.
+		// H19 ordering (kernels first, then ExchangeAsync) with kernels on
+		// compute_stream.  Cray MPICH syncs the default stream before DMA;
+		// since kernels run on compute_stream the default stream is always
+		// clean when ExchangeAsync posts MPI_Isend.
 		double _t_launch, _t_exch, _t_sync, _t_gpu;
-
-		if (task < exidx.size() - 1) {
-			int slide = exidx[task].slide - exidx[task + 1].slide;
-			{ auto _t0 = _ck::now();
-			  slider.ExchangeAsync(
-			      twk[active_buf], twk_ket_size[active_buf],
-			      twk[recv_buf],
-			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
-			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
-			      slide, this->b_comm(), (int)task);
-			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-		} else {
-			_t_exch = 0.0;
-		}
 
 		{ auto _t0 = _ck::now();
 
@@ -869,6 +856,20 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta, compute_stream);
 
 		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+
+		if (task < exidx.size() - 1) {
+			int slide = exidx[task].slide - exidx[task + 1].slide;
+			{ auto _t0 = _ck::now();
+			  slider.ExchangeAsync(
+			      twk[active_buf], twk_ket_size[active_buf],
+			      twk[recv_buf],
+			      tidxmap[active_buf], tidxmap_storage[active_buf], twk_map_size[active_buf],
+			      tidxmap[recv_buf], tidxmap_storage[recv_buf],
+			      slide, this->b_comm(), (int)task);
+			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+		} else {
+			_t_exch = 0.0;
+		}
 
 		if (task < exidx.size() - 1) {
 			{ auto _t0 = _ck::now();

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -529,7 +529,7 @@ public:
 		// for valid candidates per probe round, append at distinct ranks
 		// (no atomicAdd), then dispatch TwoExcite once the group's slice
 		// holds ≥ SUBWARP entries.
-		__shared__ int64_t  s_idxb [BUF_TOTAL];
+		__shared__ uint32_t s_idxb [BUF_TOTAL];
 		__shared__ uint32_t s_ja   [BUF_TOTAL];
 		__shared__ uint32_t s_k    [BUF_TOTAL];
 		__shared__ int     s_count[GROUPS];
@@ -582,7 +582,7 @@ public:
 
 				if (valid) {
 					int slot = buf_base + s_count[group] + rank;
-					s_idxb[slot] = idxb;
+					s_idxb[slot] = static_cast<uint32_t>(idxb);
 					s_ja  [slot] = ja;
 					s_k   [slot] = k;
 				}
@@ -605,10 +605,10 @@ public:
 					// guard: count may be < SUBWARP on the is_last_inner drain pass.
 					if (lane < s_count[group]) {
 						int      my_slot = buf_base + lane;
-						int64_t  my_idxb = s_idxb[my_slot];
+						uint32_t my_idxb = s_idxb[my_slot];
 						uint32_t my_ja   = s_ja  [my_slot];
 						uint32_t my_k    = s_k   [my_slot];
-						uint32_t jdet   = tidxmap.AdetToDetSM[my_idxb];
+						uint32_t jdet    = tidxmap.AdetToDetSM[my_idxb];
 						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 						                    exidx.SinglesAdetCrAnSM[my_ja],
 						                    exidx.SinglesBdetCrAnSM[my_k],

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -30,6 +30,35 @@ namespace sbd
 namespace gdb
 {
 
+#ifndef SBD_MULT_BLOCK_SIZE
+  #define SBD_MULT_BLOCK_SIZE 32
+#endif
+static_assert(SBD_MULT_BLOCK_SIZE == 32  ||
+              SBD_MULT_BLOCK_SIZE == 64  ||
+              SBD_MULT_BLOCK_SIZE == 128 ||
+              SBD_MULT_BLOCK_SIZE == 256,
+              "SBD_MULT_BLOCK_SIZE must be 32, 64, 128, or 256");
+
+// Custom blocksize-tunable launcher for the GDB Mult kernels. Replaces
+// thrust::for_each_n at the run()-level call sites. Smaller blocks free
+// SM block slots warp-by-warp; CUB's default (128-thread blocks under
+// __launch_bounds__(128, 16)) holds a slot until all 4 peer warps finish.
+template <int BlockSize, typename Functor>
+__global__ __launch_bounds__(BlockSize, 2048/BlockSize)
+void mult_for_each_n_kernel(size_t n, Functor functor)
+{
+    size_t i = static_cast<size_t>(blockIdx.x) * BlockSize + threadIdx.x;
+    if (i < n) functor(i);
+}
+
+template <int BlockSize, typename Functor>
+inline void launch_mult_for_each_n(size_t n, Functor functor)
+{
+    if (n == 0) return;
+    const size_t grid = (n + BlockSize - 1) / BlockSize;
+    mult_for_each_n_kernel<BlockSize><<<grid, BlockSize>>>(n, functor);
+}
+
 template <typename ElemT>
 class MultGDBThrust : public sbd::MultBase<ElemT> {
 protected:
@@ -583,42 +612,32 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		// single alpha excitations
 		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-		auto ci_sa = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_sa,
-		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_single_alpha);
+		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
+		    SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_single_alpha);
 
 		// double alpha excitations
 		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-		auto ci_da = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_da,
-		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_double_alpha);
+		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
+		    SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_double_alpha);
 
 		// single beta excitations
 		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-		auto ci_sb = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_sb,
-		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_single_beta);
+		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
+		    SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_single_beta);
 
 		// double beta excitations
 		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-		auto ci_db = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_db,
-		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_double_beta);
+		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
+		    SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_double_beta);
 
 		// alpha-beta excitations
 		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-
-		auto ci_ab = thrust::counting_iterator<size_t>(0);
-		thrust::for_each_n(thrust::device, ci_ab,
-		                   SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_alpha_beta);
+		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
+		    SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_alpha_beta);
 	} // end task for loop
 
 	if (mpi_size_t > 1)

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -337,12 +337,14 @@ public:
 		const uint32_t self_hi = exidx.SelfFromBdetOffset[ibst + 1];
 		const uint32_t ja_lo   = exidx.SinglesFromAdetOffset[ia];
 		const uint32_t ja_hi   = exidx.SinglesFromAdetOffset[ia + 1];
-		if (self_lo != self_hi) {
+		if (self_lo != self_hi && ja_lo != ja_hi) {
 			uint32_t jbst = exidx.SelfFromBdetSM[self_lo];
+			const uint32_t bdet_lo = tidxmap.BdetToDetOffset[jbst];
+			const uint32_t bdet_hi = tidxmap.BdetToDetOffset[jbst + 1];
 			// single alpha excitations — strided across SUBWARP lanes
 			for (uint32_t ja = ja_lo + lane; ja < ja_hi; ja += SUBWARP) {
 				uint32_t jast = exidx.SinglesFromAdetSM[ja];
-				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(bdet_lo, bdet_hi, jast);
 				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
@@ -354,7 +356,7 @@ public:
 		} // if there is same beta string
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
-		if (lane == 0) this->wb[idet] += total;
+		if (lane == 0 && total != ElemT(0)) this->wb[idet] += total;
 	}
 };
 
@@ -396,12 +398,14 @@ public:
 		const uint32_t self_hi = exidx.SelfFromBdetOffset[ibst + 1];
 		const uint32_t ja_lo   = exidx.DoublesFromAdetOffset[ia];
 		const uint32_t ja_hi   = exidx.DoublesFromAdetOffset[ia + 1];
-		if (self_lo != self_hi) {
+		if (self_lo != self_hi && ja_lo != ja_hi) {
 			uint32_t jbst = exidx.SelfFromBdetSM[self_lo];
+			const uint32_t bdet_lo = tidxmap.BdetToDetOffset[jbst];
+			const uint32_t bdet_hi = tidxmap.BdetToDetOffset[jbst + 1];
 			// double alpha excitations — strided across SUBWARP lanes
 			for (uint32_t ja = ja_lo + lane; ja < ja_hi; ja += SUBWARP) {
 				uint32_t jast = exidx.DoublesFromAdetSM[ja];
-				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
+				auto [found_a, idxa] = tidxmap.bdet_lower_bound(bdet_lo, bdet_hi, jast);
 				if (found_a) {
 					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
@@ -415,7 +419,7 @@ public:
 		} // if there is same beta string
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
-		if (lane == 0) this->wb[idet] += total;
+		if (lane == 0 && total != ElemT(0)) this->wb[idet] += total;
 	}
 };
 
@@ -460,12 +464,14 @@ public:
 		const uint32_t self_hi = exidx.SelfFromAdetOffset[iast + 1];
 		const uint32_t jb_lo   = exidx.SinglesFromBdetOffset[ib];
 		const uint32_t jb_hi   = exidx.SinglesFromBdetOffset[ib + 1];
-		if (self_lo != self_hi) {
+		if (self_lo != self_hi && jb_lo != jb_hi) {
 			uint32_t jast = exidx.SelfFromAdetSM[self_lo];
+			const uint32_t adet_lo = tidxmap.AdetToDetOffset[jast];
+			const uint32_t adet_hi = tidxmap.AdetToDetOffset[jast + 1];
 			// single beta excitations — strided across SUBWARP lanes
 			for (uint32_t jb = jb_lo + lane; jb < jb_hi; jb += SUBWARP) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
-				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(adet_lo, adet_hi, jbst);
 				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
@@ -477,7 +483,7 @@ public:
 		} // if there is same beta string
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
-		if (lane == 0) this->wb[idet] += total;
+		if (lane == 0 && total != ElemT(0)) this->wb[idet] += total;
 	}
 };
 
@@ -519,12 +525,14 @@ public:
 		const uint32_t self_hi = exidx.SelfFromAdetOffset[iast + 1];
 		const uint32_t jb_lo   = exidx.DoublesFromBdetOffset[ib];
 		const uint32_t jb_hi   = exidx.DoublesFromBdetOffset[ib + 1];
-		if (self_lo != self_hi) {
+		if (self_lo != self_hi && jb_lo != jb_hi) {
 			uint32_t jast = exidx.SelfFromAdetSM[self_lo];
+			const uint32_t adet_lo = tidxmap.AdetToDetOffset[jast];
+			const uint32_t adet_hi = tidxmap.AdetToDetOffset[jast + 1];
 			// double beta excitations — strided across SUBWARP lanes
 			for (uint32_t jb = jb_lo + lane; jb < jb_hi; jb += SUBWARP) {
 				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
-				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
+				auto [found_b, idxb] = tidxmap.adet_lower_bound(adet_lo, adet_hi, jbst);
 				if (found_b) {
 					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					ElemT eij = this->TwoExciteFast(this->detsum + idet * this->D_size,
@@ -538,7 +546,7 @@ public:
 		} // if there is same beta string
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
-		if (lane == 0) this->wb[idet] += total;
+		if (lane == 0 && total != ElemT(0)) this->wb[idet] += total;
 	}
 };
 
@@ -613,6 +621,8 @@ public:
 		const uint32_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
 		const uint32_t k_hi    = exidx.SinglesFromBdetOffset[ibst + 1];
 		const uint32_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
+		const uint32_t ja_lo   = exidx.SinglesFromAdetOffset[ia];
+		const uint32_t ja_hi   = exidx.SinglesFromAdetOffset[ia + 1];
 
 		// Outer ja loop. Inner k loop runs k_iters times *uniformly* across
 		// all SUBWARP lanes of the group (k_lane = k_lo + it*SUBWARP + lane,
@@ -621,14 +631,15 @@ public:
 		// divergent-loop-exit bug in v1.
 		// adet_lower_bound returns {found, ie}; ie < AdetToDetOffset[jast+1] whenever found.
 		// (idxb - AdetToDetOffset[jast]) is in-range whenever valid.
-		const uint32_t ja_hi = exidx.SinglesFromAdetOffset[ia + 1];
-		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < ja_hi; ja++) {
+		if (k_lo != k_hi) for (uint32_t ja = ja_lo; ja < ja_hi; ja++) {
 			uint32_t jast    = exidx.SinglesFromAdetSM[ja];
+			const uint32_t adet_lo = tidxmap.AdetToDetOffset[jast];
+			const uint32_t adet_hi = tidxmap.AdetToDetOffset[jast + 1];
 
 			for (uint32_t it = 0; it < k_iters; it++) {
 				uint32_t k             = k_lo + it * SUBWARP + lane;
 				uint32_t jbst          = exidx.SinglesFromBdetSM[std::min(k, k_hi - 1)];
-				auto [found, idxb]     = tidxmap.adet_lower_bound(jast, jbst);
+				auto [found, idxb]     = tidxmap.adet_lower_bound(adet_lo, adet_hi, jbst);
 				bool     valid         = k < k_hi && found;
 
 				// Per-group ballot. __ballot_sync(subwarp_mask,...) zeroes
@@ -700,7 +711,7 @@ public:
 		}
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
-		if (lane == 0) this->wb[idet] += total;
+		if (lane == 0 && total != ElemT(0)) this->wb[idet] += total;
 	}
 };
 

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -7,6 +7,7 @@
 
 
 #include "sbd/framework/mpi_utility_thrust.h"
+#include <cassert>
 
 // SUBWARP threading for MultAlphaBetaKernel (track gh-A).
 // SBD_GDB_SUBWARP_SIZE selects the threading granularity:
@@ -66,20 +67,25 @@ static_assert(SBD_MULT_MIN_BLOCKS_PER_SM >= 1 &&
 // thrust::for_each_n at the run()-level call sites with a fixed-block
 // launch so the v2 SUBWARP-parallel kernel's shared-memory sizing
 // (`BUF_TOTAL = 2 * SBD_MULT_BLOCK_SIZE`) matches the actual block size.
-template <int BlockSize, typename Functor>
-__global__ __launch_bounds__(BlockSize, SBD_MULT_MIN_BLOCKS_PER_SM)
+// BlockSize and MinBlocksPerSM are read from the Functor class (static constexpr
+// members defined in MultKernelBase); n is the number of subwarps, not threads.
+template <typename Functor>
+__global__ __launch_bounds__(Functor::BlockSize, Functor::MinBlocksPerSM)
 void mult_for_each_n_kernel(size_t n, Functor functor)
 {
-    size_t i = static_cast<size_t>(blockIdx.x) * BlockSize + threadIdx.x;
+    size_t i = static_cast<size_t>(blockIdx.x) * Functor::BlockSize + threadIdx.x;
     if (i < n) functor(i);
 }
 
-template <int BlockSize, typename Functor>
-inline void launch_mult_for_each_n(size_t n, Functor functor)
+template <typename Functor>
+inline void launch_mult_for_each_n(size_t n_subwarps, Functor functor)
 {
-    if (n == 0) return;
-    const size_t grid = (n + BlockSize - 1) / BlockSize;
-    mult_for_each_n_kernel<BlockSize><<<grid, BlockSize>>>(n, functor);
+    if (n_subwarps == 0) return;
+    constexpr int BS = Functor::BlockSize;
+    constexpr int SW = Functor::SubwarpSize;
+    const size_t n_threads = n_subwarps * SW;
+    const size_t grid = (n_threads + BS - 1) / BS;
+    mult_for_each_n_kernel<Functor><<<grid, BS>>>(n_threads, functor);
     // E1 (advice-from-parent §5): force per-launch stream serialization to
     // test the stream-ordering hypothesis. If this resolves the b_comm>=3
     // Davidson hang, the legacy default stream is the contention surface.
@@ -206,11 +212,13 @@ void MultGDBThrust<ElemT>::Init(
 
 template <typename ElemT>
 class MultKernelBase : public DeterminantKernels<ElemT> {
+public:
+    static constexpr int BlockSize      = SBD_MULT_BLOCK_SIZE;
+    static constexpr int SubwarpSize    = SBD_GDB_SUBWARP_SIZE;
+    static constexpr int MinBlocksPerSM = SBD_MULT_MIN_BLOCKS_PER_SM;
 protected:
     ElemT *wb;
     ElemT* twk;
-    size_t mpi_rank_h;
-    size_t mpi_size_h;
     size_t* det;
 public:
     MultKernelBase() {}
@@ -233,8 +241,7 @@ public:
 
     void set_mpi_size(size_t h_rank, size_t h_size)
     {
-        mpi_rank_h = h_rank;
-        mpi_size_h = h_size;
+        assert(h_rank == 0 && h_size == 1);
     }
 };
 
@@ -242,6 +249,8 @@ public:
 template <typename ElemT>
 class MultSingleAlphaKernel : public MultKernelBase<ElemT>
 {
+public:
+    using MultKernelBase<ElemT>::SubwarpSize;
 protected:
 	DetIndexMapThrust idxmap;
 	DetIndexMapThrust tidxmap;
@@ -258,7 +267,7 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t arg_i)
     {
-		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		constexpr int SUBWARP = SubwarpSize;
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
@@ -266,8 +275,6 @@ public:
 		uint32_t idet = idxmap.AdetToDetSM[i];
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
 		typename WarpReduceSum::TempStorage temp_sum;
@@ -301,6 +308,8 @@ public:
 template <typename ElemT>
 class MultDoubleAlphaKernel : public MultKernelBase<ElemT>
 {
+public:
+    using MultKernelBase<ElemT>::SubwarpSize;
 protected:
 	DetIndexMapThrust idxmap;
 	DetIndexMapThrust tidxmap;
@@ -317,7 +326,7 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t arg_i)
     {
-		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		constexpr int SUBWARP = SubwarpSize;
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
@@ -325,8 +334,6 @@ public:
 		uint32_t idet = idxmap.AdetToDetSM[i];
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
 		typename WarpReduceSum::TempStorage temp_sum;
@@ -365,6 +372,8 @@ public:
 template <typename ElemT>
 class MultSingleBetaKernel : public MultKernelBase<ElemT>
 {
+public:
+    using MultKernelBase<ElemT>::SubwarpSize;
 protected:
 	DetIndexMapThrust idxmap;
 	DetIndexMapThrust tidxmap;
@@ -381,7 +390,7 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t arg_i)
     {
-		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		constexpr int SUBWARP = SubwarpSize;
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
@@ -389,8 +398,6 @@ public:
 		uint32_t idet = idxmap.BdetToDetSM[i];
 		uint32_t ib   = idxmap.BdetIndex[i];
 		uint32_t ibst = ib;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
 		typename WarpReduceSum::TempStorage temp_sum;
@@ -424,6 +431,8 @@ public:
 template <typename ElemT>
 class MultDoubleBetaKernel : public MultKernelBase<ElemT>
 {
+public:
+    using MultKernelBase<ElemT>::SubwarpSize;
 protected:
 	DetIndexMapThrust idxmap;
 	DetIndexMapThrust tidxmap;
@@ -440,7 +449,7 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t arg_i)
     {
-		constexpr int SUBWARP = SBD_GDB_SUBWARP_SIZE;
+		constexpr int SUBWARP = SubwarpSize;
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
@@ -448,8 +457,6 @@ public:
 		uint32_t idet = idxmap.BdetToDetSM[i];
 		uint32_t ib   = idxmap.BdetIndex[i];
 		uint32_t ibst = ib;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
 		typename WarpReduceSum::TempStorage temp_sum;
@@ -486,6 +493,9 @@ public:
 template <typename ElemT>
 class MultAlphaBetaKernel : public MultKernelBase<ElemT>
 {
+public:
+    using MultKernelBase<ElemT>::SubwarpSize;
+    using MultKernelBase<ElemT>::BlockSize;
 protected:
 	DetIndexMapThrust idxmap;
 	DetIndexMapThrust tidxmap;
@@ -502,8 +512,8 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t arg_i)
     {
-		constexpr int SUBWARP   = SBD_GDB_SUBWARP_SIZE;
-		constexpr int BLOCK     = SBD_MULT_BLOCK_SIZE;
+		constexpr int SUBWARP   = SubwarpSize;
+		constexpr int BLOCK     = BlockSize;
 		constexpr int GROUPS    = BLOCK / SUBWARP;        // SUBWARP groups per block
 		constexpr int BUF_PG    = 2 * SUBWARP;            // slots per group
 		constexpr int BUF_TOTAL = 2 * BLOCK;              // = GROUPS * BUF_PG
@@ -517,8 +527,6 @@ public:
 		uint32_t idet = idxmap.AdetToDetSM[i];
 		uint32_t ia   = idxmap.AdetIndex[i];
 		uint32_t iast = ia;
-		if (idet % this->mpi_size_h != this->mpi_rank_h)
-			return;
 
 		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
 		typename WarpReduceSum::TempStorage temp_sum;   // local; shuffle-only at p2 sizes
@@ -722,32 +730,27 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		// single alpha excitations
 		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
-		    SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_single_alpha);
+		launch_mult_for_each_n(idxmap.size_adet, kernel_single_alpha);
 
 		// double alpha excitations
 		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
-		    SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_double_alpha);
+		launch_mult_for_each_n(idxmap.size_adet, kernel_double_alpha);
 
 		// single beta excitations
 		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
-		    SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_single_beta);
+		launch_mult_for_each_n(idxmap.size_bdet, kernel_single_beta);
 
 		// double beta excitations
 		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
-		    SBD_GDB_SUBWARP_SIZE * idxmap.size_bdet, kernel_double_beta);
+		launch_mult_for_each_n(idxmap.size_bdet, kernel_double_beta);
 
 		// alpha-beta excitations
 		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-		launch_mult_for_each_n<SBD_MULT_BLOCK_SIZE>(
-		    SBD_GDB_SUBWARP_SIZE * idxmap.size_adet, kernel_alpha_beta);
+		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta);
 	} // end task for loop
 
 	if (mpi_size_t > 1)
@@ -808,10 +811,8 @@ public:
     // kernel entry point
     __device__ __host__ void operator()(size_t i)
     {
-		if (i % this->mpi_size_h == this->mpi_rank_h) {
-	        size_t* Det = this->det + i * this->D_size;
-            hii[i] = this->ZeroExcite(Det);
-		}
+        size_t* Det = this->det + i * this->D_size;
+        hii[i] = this->ZeroExcite(Det);
     }
 };
 

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -105,10 +105,6 @@ inline void launch_mult_for_each_n(size_t n_subwarps, Functor functor)
     const size_t n_threads = n_subwarps * SW;
     const size_t grid = (n_threads + BS - 1) / BS;
     mult_for_each_n_kernel<Functor><<<grid, BS>>>(n_threads, functor);
-    // E1 (advice-from-parent §5): force per-launch stream serialization to
-    // test the stream-ordering hypothesis. If this resolves the b_comm>=3
-    // Davidson hang, the legacy default stream is the contention surface.
-    cudaDeviceSynchronize();
 }
 
 template <typename ElemT>
@@ -738,7 +734,6 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	DetIndexMapThrust tidxmap[2];
 	int active_buf = 0;
     int recv_buf = 1;
-    size_t task_sent = 0;
 
 	if (exidx[0].slide != 0) {
 		sbd::gdb::MpiSlide(idxmap, idxmap_storage, tidxmap[active_buf], tidxmap_storage[active_buf], -exidx[0].slide, this->b_comm());
@@ -754,85 +749,63 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	}
 
 	MpiSlider<ElemT> slider;
-#ifdef SBD_MULT_TIME_KERNELS
-	double _t_sa = 0, _t_da = 0, _t_sb = 0, _t_db = 0, _t_ab = 0;
 	using _ck = std::chrono::steady_clock;
-	auto _timed = [](auto n, auto& kern, double& accum) {
-		auto t0 = _ck::now();
-		launch_mult_for_each_n(n, kern);
-		accum += std::chrono::duration<double, std::milli>(_ck::now() - t0).count();
-	};
-#endif
+	double _t_exch = 0, _t_sync = 0, _t_gpu = 0;
 	for (size_t task = 0; task < exidx.size(); task++) {
-        if (task_sent == task) {
-            if (task_sent != 0) {
-                if (slider.Sync()) {
-					int t = active_buf;
-					active_buf = recv_buf;
-					recv_buf = t;
-                }
-            }
-
-            // exchange asynchronously for later tasks
-            for (size_t extask = task_sent; extask < exidx.size() - 1; extask++) {
-				int slide = exidx[extask].slide - exidx[extask + 1].slide;
-				slider.ExchangeAsync(twk[active_buf], twk[recv_buf], tidxmap[active_buf], tidxmap_storage[active_buf], tidxmap[recv_buf], tidxmap_storage[recv_buf], slide, this->b_comm(), (int)extask);
-				task_sent = extask + 1;
-				break;
-            }
-        }
+		// Launch all GPU kernels for this task asynchronously.
+		// The exchange below will overlap with these kernels.
 
 		// single alpha excitations
 		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-#ifdef SBD_MULT_TIME_KERNELS
-		_timed(idxmap.size_adet, kernel_single_alpha, _t_sa);
-#else
 		launch_mult_for_each_n(idxmap.size_adet, kernel_single_alpha);
-#endif
 
 		// double alpha excitations
 		MultDoubleAlphaKernel kernel_double_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_alpha.set_mpi_size(mpi_rank_h, mpi_size_h);
-#ifdef SBD_MULT_TIME_KERNELS
-		_timed(idxmap.size_adet, kernel_double_alpha, _t_da);
-#else
 		launch_mult_for_each_n(idxmap.size_adet, kernel_double_alpha);
-#endif
 
 		// single beta excitations
 		MultSingleBetaKernel kernel_single_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_single_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-#ifdef SBD_MULT_TIME_KERNELS
-		_timed(idxmap.size_bdet, kernel_single_beta, _t_sb);
-#else
 		launch_mult_for_each_n(idxmap.size_bdet, kernel_single_beta);
-#endif
 
 		// double beta excitations
 		MultDoubleBetaKernel kernel_double_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_double_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-#ifdef SBD_MULT_TIME_KERNELS
-		_timed(idxmap.size_bdet, kernel_double_beta, _t_db);
-#else
 		launch_mult_for_each_n(idxmap.size_bdet, kernel_double_beta);
-#endif
 
 		// alpha-beta excitations
 		MultAlphaBetaKernel kernel_alpha_beta(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
-#ifdef SBD_MULT_TIME_KERNELS
-		_timed(idxmap.size_adet, kernel_alpha_beta, _t_ab);
-#else
 		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta);
-#endif
-	} // end task for loop
 
-#ifdef SBD_MULT_TIME_KERNELS
-	if (mpi_rank_t == 0 && mpi_rank_b == 0 && mpi_rank_h == 0)
-		fprintf(stderr, "mult_kernel_ms: tasks=%zu sa=%.1f da=%.1f sb=%.1f db=%.1f ab=%.1f\n",
-		        exidx.size(), _t_sa, _t_da, _t_sb, _t_db, _t_ab);
-#endif
+		// While the GPU runs the kernels above, exchange the ket for the next
+		// task.  ExchangeAsync and Sync are called back-to-back: the internal
+		// size MPI_Waitall (rendezvous with neighbours) and the large data
+		// transfer both complete while this task's kernels are in flight.
+		if (task < exidx.size() - 1) {
+			int slide = exidx[task].slide - exidx[task + 1].slide;
+			{ auto _t0 = _ck::now();
+			  slider.ExchangeAsync(twk[active_buf], twk[recv_buf],
+			                       tidxmap[active_buf], tidxmap_storage[active_buf],
+			                       tidxmap[recv_buf], tidxmap_storage[recv_buf],
+			                       slide, this->b_comm(), (int)task);
+			  _t_exch += std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+			{ auto _t0 = _ck::now();
+			  if (slider.Sync()) {
+			    int t = active_buf; active_buf = recv_buf; recv_buf = t;
+			  }
+			  _t_sync += std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+		}
+
+		// Wait for this task's kernels before the next task writes to wb.
+		{ auto _t0 = _ck::now();
+		  cudaDeviceSynchronize();
+		  _t_gpu += std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+	} // end task for loop
+	fprintf(stderr, "mult_overlap_ms: rank_b=%d exch=%.1f sync=%.1f gpu_sync=%.1f\n",
+	        mpi_rank_b, _t_exch, _t_sync, _t_gpu);
 
 	if (mpi_size_t > 1)
 		MpiAllreduce(wb, MPI_SUM, this->t_comm());

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -89,7 +89,7 @@ inline void launch_mult_for_each_n(size_t n, Functor functor)
 template <typename ElemT>
 class MultGDBThrust : public sbd::MultBase<ElemT> {
 protected:
-	thrust::device_vector<size_t> idxmap_storage;
+	thrust::device_vector<uint32_t> idxmap_storage;
 	DetIndexMapThrust idxmap;
     thrust::device_vector<size_t> dets_;
     ElemT I0_;
@@ -262,10 +262,10 @@ public:
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
-		size_t ibst = idxmap.AdetToBdetSM[i];
-		size_t idet = idxmap.AdetToDetSM[i];
-		size_t ia = idxmap.AdetIndex[i];
-		size_t iast = ia;
+		uint32_t ibst = idxmap.AdetToBdetSM[i];
+		uint32_t idet = idxmap.AdetToDetSM[i];
+		uint32_t ia   = idxmap.AdetIndex[i];
+		uint32_t iast = ia;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -284,7 +284,7 @@ public:
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
 						continue;
-					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
 											exidx.SinglesAdetCrAnSM[ja],
 											exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet]);
@@ -321,10 +321,10 @@ public:
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
-		size_t ibst = idxmap.AdetToBdetSM[i];
-		size_t idet = idxmap.AdetToDetSM[i];
-		size_t ia = idxmap.AdetIndex[i];
-		size_t iast = ia;
+		uint32_t ibst = idxmap.AdetToBdetSM[i];
+		uint32_t idet = idxmap.AdetToDetSM[i];
+		uint32_t ia   = idxmap.AdetIndex[i];
+		uint32_t iast = ia;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -343,13 +343,12 @@ public:
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
 						continue;
-					size_t jdet = tidxmap.BdetToDetSM[idxa];
+					uint32_t jdet = tidxmap.BdetToDetSM[idxa];
 					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 											exidx.DoublesAdetCrAnSM[ja],
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet],
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 2],
 											exidx.DoublesAdetCrAnSM[ja + exidx.size_double_adet * 3]);
-					// size_t od;
 					thread_sum += eij * this->twk[jdet];
 				}
 			}
@@ -386,10 +385,10 @@ public:
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
-		size_t iast = idxmap.BdetToAdetSM[i];
-		size_t idet = idxmap.BdetToDetSM[i];
-		size_t ib = idxmap.BdetIndex[i];
-		size_t ibst = ib;
+		uint32_t iast = idxmap.BdetToAdetSM[i];
+		uint32_t idet = idxmap.BdetToDetSM[i];
+		uint32_t ib   = idxmap.BdetIndex[i];
+		uint32_t ibst = ib;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -408,7 +407,7 @@ public:
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					ElemT eij = this->OneExcite(this->det + idet * this->D_size,
 											exidx.SinglesBdetCrAnSM[jb],
 											exidx.SinglesBdetCrAnSM[jb + exidx.size_single_bdet]);
@@ -445,10 +444,10 @@ public:
 		size_t i    = arg_i / SUBWARP;
 		int    lane = static_cast<int>(arg_i % SUBWARP);
 
-		size_t iast = idxmap.BdetToAdetSM[i];
-		size_t idet = idxmap.BdetToDetSM[i];
-		size_t ib = idxmap.BdetIndex[i];
-		size_t ibst = ib;
+		uint32_t iast = idxmap.BdetToAdetSM[i];
+		uint32_t idet = idxmap.BdetToDetSM[i];
+		uint32_t ib   = idxmap.BdetIndex[i];
+		uint32_t ibst = ib;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -467,13 +466,12 @@ public:
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
 						continue;
-					size_t jdet = tidxmap.AdetToDetSM[idxb];
+					uint32_t jdet = tidxmap.AdetToDetSM[idxb];
 					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 											exidx.DoublesBdetCrAnSM[jb],
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet],
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 2],
 											exidx.DoublesBdetCrAnSM[jb + exidx.size_double_bdet * 3]);
-					// size_t od;
 					thread_sum += eij * this->twk[jdet];
 				}
 			}
@@ -515,10 +513,10 @@ public:
 		int    group = static_cast<int>(i % GROUPS);      // 0..GROUPS-1 within block
 		int    buf_base = group * BUF_PG;
 
-		size_t ibst = idxmap.AdetToBdetSM[i];
-		size_t idet = idxmap.AdetToDetSM[i];
-		size_t ia = idxmap.AdetIndex[i];
-		size_t iast = ia;
+		uint32_t ibst = idxmap.AdetToBdetSM[i];
+		uint32_t idet = idxmap.AdetToDetSM[i];
+		uint32_t ia   = idxmap.AdetIndex[i];
+		uint32_t iast = ia;
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
@@ -610,7 +608,7 @@ public:
 						int64_t my_idxb = s_idxb[my_slot];
 						size_t  my_ja   = s_ja  [my_slot];
 						size_t  my_k    = s_k   [my_slot];
-						size_t  jdet    = tidxmap.AdetToDetSM[my_idxb];
+						uint32_t jdet   = tidxmap.AdetToDetSM[my_idxb];
 						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 						                    exidx.SinglesAdetCrAnSM[my_ja],
 						                    exidx.SinglesBdetCrAnSM[my_k],
@@ -682,7 +680,7 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 
 	// double buffering for MPI slide
 	thrust::device_vector<ElemT> twk[2];
-	thrust::device_vector<size_t> tidxmap_storage[2];
+	thrust::device_vector<uint32_t> tidxmap_storage[2];
 	DetIndexMapThrust tidxmap[2];
 	int active_buf = 0;
     int recv_buf = 1;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -8,7 +8,6 @@
 
 #include "sbd/framework/mpi_utility_thrust.h"
 #include <cassert>
-#include <chrono>
 
 // SUBWARP threading for MultAlphaBetaKernel (track gh-A).
 // SBD_GDB_SUBWARP_SIZE selects the threading granularity:
@@ -888,13 +887,9 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	cudaEventRecord(copy_done[recv_buf],  copy_stream);  // for MPI
 
 	MpiSlider<ElemT> slider;
-	using _ck = std::chrono::steady_clock;
 	for (size_t task = 0; task < exidx.size(); task++) {
 		// compute_stream may not read twk[active] until the CPU→GPU copy is done.
 		cudaStreamWaitEvent(compute_stream, copy_done[active_buf]);
-		double _t_launch, _t_exch, _t_sync, _t_gpu;
-
-		{ auto _t0 = _ck::now();
 
 		// single alpha excitations
 		MultSingleAlphaKernel kernel_single_alpha(wb, twk[active_buf], *this, idxmap, tidxmap[active_buf], exidx[task]);
@@ -921,8 +916,6 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 		kernel_alpha_beta.set_mpi_size(mpi_rank_h, mpi_size_h);
 		launch_mult_for_each_n(idxmap.size_adet, kernel_alpha_beta, compute_stream);
 
-		_t_launch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-
 		// Record compute_done[active] into compute_stream — fires when this
 		// task's kernels finish reading twk[active].  The copy_stream for
 		// a future task will wait on this before writing into that buffer.
@@ -930,35 +923,21 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 
 		if (task < exidx.size() - 1) {
 			int slide = exidx[task].slide - exidx[task + 1].slide;
-			{ auto _t0 = _ck::now();
-			  // Ensure the cudaMemcpyAsync that READ h_twk[recv_buf] in a prior
-			  // task has completed before MPI_Irecv writes into that same buffer.
-			  if (cudaEventQuery(copy_done[recv_buf]) == cudaErrorNotReady) {
-			    auto _tw0 = _ck::now();
-			    cudaEventSynchronize(copy_done[recv_buf]);
-			    double _tw = std::chrono::duration<double,std::milli>(_ck::now()-_tw0).count();
-			    fprintf(stderr, "event_wait_ms: rank_b=%d task=%zu event=copy_done wait=%.1f\n",
-			            mpi_rank_b, task, _tw);
-			  }
-			  // CPU-staging: send from h_twk[active] (CPU DRAM) — no HBM touch.
-			  slider.ExchangeAsyncHost(
-			      h_twk[active_buf], twk_ket_size[active_buf],
-			      h_twk[recv_buf],   twk[recv_buf].size(),
-			      tidxmap[active_buf],
-			      thrust::raw_pointer_cast(tidxmap_storage[active_buf].data()),
-			      h_map[active_buf],  twk_map_size[active_buf],
-			      tidxmap[recv_buf],
-			      h_map[recv_buf],    tidxmap_storage[recv_buf].size(),
-			      thrust::raw_pointer_cast(tidxmap_storage[recv_buf].data()),
-			      slide, this->b_comm(), (int)task);
-			  _t_exch = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-		} else {
-			_t_exch = 0.0;
-		}
-
-		if (task < exidx.size() - 1) {
-			{ auto _t0 = _ck::now();
-			  if (slider.Sync()) {
+			// Ensure the cudaMemcpyAsync that READ h_twk[recv_buf] in a prior
+			// task has completed before MPI_Irecv writes into that same buffer.
+			cudaEventSynchronize(copy_done[recv_buf]);
+			// CPU-staging: send from h_twk[active] (CPU DRAM) — no HBM touch.
+			slider.ExchangeAsyncHost(
+			    h_twk[active_buf], twk_ket_size[active_buf],
+			    h_twk[recv_buf],   twk[recv_buf].size(),
+			    tidxmap[active_buf],
+			    thrust::raw_pointer_cast(tidxmap_storage[active_buf].data()),
+			    h_map[active_buf],  twk_map_size[active_buf],
+			    tidxmap[recv_buf],
+			    h_map[recv_buf],    tidxmap_storage[recv_buf].size(),
+			    thrust::raw_pointer_cast(tidxmap_storage[recv_buf].data()),
+			    slide, this->b_comm(), (int)task);
+			if (slider.Sync()) {
 			    twk_ket_size[recv_buf] = slider.get_recv_size();
 			    twk_map_size[recv_buf] = slider.get_recv_size_map();
 			    // copy_stream must not write twk[recv] while a prior task's
@@ -976,23 +955,13 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			        cudaMemcpyHostToDevice, copy_stream);
 			    cudaEventRecord(copy_done[recv_buf], copy_stream);
 			    int t = active_buf; active_buf = recv_buf; recv_buf = t;
-			  }
-			  _t_sync = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
+			}
 		} else {
-			_t_sync = 0.0;
+			// No cudaStreamSynchronize here: all ordering is via events.
+			// cudaEventSynchronize on the last task's compute_done ensures we
+			// don't exit run() before the final kernels have written their output.
+			cudaEventSynchronize(compute_done[active_buf]);
 		}
-
-		{ auto _t0 = _ck::now();
-		  // No cudaStreamSynchronize here: all ordering is via events.
-		  // cudaEventSynchronize on the last task's compute_done ensures we
-		  // don't exit run() before the final kernels have written their output.
-		  if (task == exidx.size() - 1)
-		      cudaEventSynchronize(compute_done[active_buf]);
-		  _t_gpu = std::chrono::duration<double,std::milli>(_ck::now()-_t0).count(); }
-
-		fprintf(stderr, "mult_task_ms: rank_b=%d task=%zu"
-		        " launch=%.1f exch=%.1f sync=%.1f gpu_sync=%.1f\n",
-		        mpi_rank_b, task, _t_launch, _t_exch, _t_sync, _t_gpu);
 	} // end task for loop
 
 	cudaFreeHost(h_twk[0]); cudaFreeHost(h_twk[1]);

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -407,47 +407,62 @@ public:
 		if (idet % this->mpi_size_h != this->mpi_rank_h)
 			return;
 
-		using WarpReduce = cub::WarpReduce<ElemT, SUBWARP>;
-		typename WarpReduce::TempStorage temp_storage;   // local; shuffle-only at p2 sizes
+		using WarpReduceSum = cub::WarpReduce<ElemT, SUBWARP>;
+		typename WarpReduceSum::TempStorage temp_sum;   // local; shuffle-only at p2 sizes
 		ElemT thread_sum = ElemT(0);
 
 		// alpha-beta two-particle excitations
-		// Inner k-loop is strided by SUBWARP starting at lane; each lane keeps
-		// its own start_idx running lower-bound across its strided subset
-		// (start_idx grows monotonically with k since SinglesFromBdetSM is sorted,
-		// so the per-lane start_idx is correct as a lower bound for that lane's
-		// next k). At SUBWARP=1 this is identical to the original sequential loop.
+		// Inner k-loop is strided by SUBWARP. Explicit iteration count so ALL
+		// SUBWARP lanes reach the per-iteration shuffle-broadcast (lanes whose
+		// k is out of range just skip the body but still participate in the
+		// shuffle, required for warp-shuffle correctness on Volta+). After
+		// each non-final iteration we broadcast the LAST lane's start_idx to
+		// all SUBWARP lanes via __shfl_sync. Last lane's k is the highest in
+		// the iteration block, so its lower_bound has reached the furthest
+		// position. Lane L's next k > all lanes' current k (sorted
+		// SinglesFromBdetSM), so the last lane's start_idx is a valid (and
+		// usually tightest) lower bound for every lane's next adet_lower_bound.
+		// At SUBWARP=1: stride 1, lane 0, n_iters = k_hi - k_lo, no broadcast
+		// needed (last-iter check filters it out for the only iter), so the
+		// body collapses to the original sequential loop.
 		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
 			size_t jast = exidx.SinglesFromAdetSM[ja];
 			size_t start_idx = 0;
 			size_t end_idx = tidxmap.AdetToDetOffset[jast + 1] - tidxmap.AdetToDetOffset[jast];
-			for (size_t k = exidx.SinglesFromBdetOffset[ibst] + lane;
-			            k < exidx.SinglesFromBdetOffset[ibst + 1];
-			            k += SUBWARP) {
-				size_t jbst = exidx.SinglesFromBdetSM[k];
-				if (start_idx >= end_idx)
-					break;
-				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
-				if (idxb >= 0) {
-					if (jbst != tidxmap.AdetToBdetSM[idxb])
-						continue;
-					start_idx = idxb - tidxmap.AdetToDetOffset[jast];
-					if (start_idx < end_idx) {
-						size_t jdet = tidxmap.AdetToDetSM[idxb];
-						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+
+			size_t k_lo = exidx.SinglesFromBdetOffset[ibst];
+			size_t k_hi = exidx.SinglesFromBdetOffset[ibst + 1];
+			size_t n_iters = (k_hi > k_lo) ? ((k_hi - k_lo + SUBWARP - 1) / SUBWARP) : 0;
+
+			for (size_t iter = 0; iter < n_iters; iter++) {
+				size_t k = k_lo + iter * SUBWARP + lane;
+				if (k < k_hi && start_idx < end_idx) {
+					size_t jbst = exidx.SinglesFromBdetSM[k];
+					int64_t idxb = tidxmap.adet_lower_bound(jast, jbst, start_idx);
+					if (idxb >= 0 && jbst == tidxmap.AdetToBdetSM[idxb]) {
+						size_t local_idx = idxb - tidxmap.AdetToDetOffset[jast];
+						if (local_idx < end_idx) {
+							start_idx = local_idx;
+							size_t jdet = tidxmap.AdetToDetSM[idxb];
+							ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 												exidx.SinglesAdetCrAnSM[ja],
 												exidx.SinglesBdetCrAnSM[k],
 												exidx.SinglesAdetCrAnSM[ja + exidx.size_single_adet],
 												exidx.SinglesBdetCrAnSM[k + exidx.size_single_bdet]);
-						// size_t odiff;
-						// ElemT eij = Hij(det[idet],tdet[jdet],bit_length,norb,I0,I1,I2,odiff);
-						thread_sum += eij * this->twk[jdet];
+							thread_sum += eij * this->twk[jdet];
+						}
 					}
+				}
+				// Per-iteration sync: broadcast last lane's start_idx (= the
+				// tightest natural lower bound after this iter's strided block)
+				// to all SUBWARP lanes. Skip on the last iter.
+				if (iter + 1 < n_iters) {
+					start_idx = __shfl_sync(0xffffffff, start_idx, SUBWARP - 1, SUBWARP);
 				}
 			}
 		}
 
-		ElemT total = WarpReduce(temp_storage).Sum(thread_sum);
+		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
 		if (lane == 0) this->wb[idet] += total;
 	}
 };

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -100,7 +100,7 @@ protected:
     thrust::device_vector<ElemT> I2_dm;
     thrust::device_vector<ElemT> I2_em;
 
-	std::vector<thrust::device_vector<size_t>> exidx_storage;
+	std::vector<thrust::device_vector<uint32_t>> exidx_storage;
     std::vector<thrust::device_vector<int>> CrAn_storage;
 	std::vector<ExcitationLookupThrust> exidx;
 public:
@@ -274,12 +274,12 @@ public:
 		ElemT thread_sum = ElemT(0);
 
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
 			// single alpha excitations — strided across SUBWARP lanes
-			for (size_t ja = exidx.SinglesFromAdetOffset[ia] + lane;
-			            ja < exidx.SinglesFromAdetOffset[ia + 1];
-			            ja += SUBWARP) {
-				size_t jast = exidx.SinglesFromAdetSM[ja];
+			for (uint32_t ja = exidx.SinglesFromAdetOffset[ia] + lane;
+			              ja < exidx.SinglesFromAdetOffset[ia + 1];
+			              ja += SUBWARP) {
+				uint32_t jast = exidx.SinglesFromAdetSM[ja];
 				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
@@ -333,12 +333,12 @@ public:
 		ElemT thread_sum = ElemT(0);
 
 		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			size_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
 			// double alpha excitations — strided across SUBWARP lanes
-			for (size_t ja = exidx.DoublesFromAdetOffset[ia] + lane;
-			            ja < exidx.DoublesFromAdetOffset[ia + 1];
-			            ja += SUBWARP) {
-				size_t jast = exidx.DoublesFromAdetSM[ja];
+			for (uint32_t ja = exidx.DoublesFromAdetOffset[ia] + lane;
+			              ja < exidx.DoublesFromAdetOffset[ia + 1];
+			              ja += SUBWARP) {
+				uint32_t jast = exidx.DoublesFromAdetSM[ja];
 				int64_t idxa = tidxmap.bdet_lower_bound(jbst, jast);
 				if (idxa >= 0) {
 					if (jast != tidxmap.BdetToAdetSM[idxa])
@@ -397,12 +397,12 @@ public:
 		ElemT thread_sum = ElemT(0);
 
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
 			// single beta excitations — strided across SUBWARP lanes
-			for (size_t jb = exidx.SinglesFromBdetOffset[ib] + lane;
-			            jb < exidx.SinglesFromBdetOffset[ib + 1];
-			            jb += SUBWARP) {
-				size_t jbst = exidx.SinglesFromBdetSM[jb];
+			for (uint32_t jb = exidx.SinglesFromBdetOffset[ib] + lane;
+			              jb < exidx.SinglesFromBdetOffset[ib + 1];
+			              jb += SUBWARP) {
+				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
@@ -456,12 +456,12 @@ public:
 		ElemT thread_sum = ElemT(0);
 
 		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			size_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
 			// double beta excitations — strided across SUBWARP lanes
-			for (size_t jb = exidx.DoublesFromBdetOffset[ib] + lane;
-			            jb < exidx.DoublesFromBdetOffset[ib + 1];
-			            jb += SUBWARP) {
-				size_t jbst = exidx.DoublesFromBdetSM[jb];
+			for (uint32_t jb = exidx.DoublesFromBdetOffset[ib] + lane;
+			              jb < exidx.DoublesFromBdetOffset[ib + 1];
+			              jb += SUBWARP) {
+				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
 				int64_t idxb = tidxmap.adet_lower_bound(jast, jbst);
 				if (idxb >= 0) {
 					if (jbst != tidxmap.AdetToBdetSM[idxb])
@@ -529,9 +529,9 @@ public:
 		// for valid candidates per probe round, append at distinct ranks
 		// (no atomicAdd), then dispatch TwoExcite once the group's slice
 		// holds ≥ SUBWARP entries.
-		__shared__ int64_t s_idxb [BUF_TOTAL];
-		__shared__ size_t  s_ja   [BUF_TOTAL];
-		__shared__ size_t  s_k    [BUF_TOTAL];
+		__shared__ int64_t  s_idxb [BUF_TOTAL];
+		__shared__ uint32_t s_ja   [BUF_TOTAL];
+		__shared__ uint32_t s_k    [BUF_TOTAL];
 		__shared__ int     s_count[GROUPS];
 		if (lane == 0) s_count[group] = 0;
 
@@ -552,17 +552,17 @@ public:
 		// every iteration — fixing the divergent-loop-exit bug in v1.
 		// adet_lower_bound returns -1 on miss, otherwise i < AdetToDetOffset[jast+1];
 		// so (idxb - AdetToDetOffset[jast]) is in-range whenever idxb >= 0.
-		for (size_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
-			size_t jast    = exidx.SinglesFromAdetSM[ja];
-			size_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
-			size_t k_hi    = exidx.SinglesFromBdetOffset[ibst + 1];
-			size_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
+		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+			uint32_t jast    = exidx.SinglesFromAdetSM[ja];
+			uint32_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
+			uint32_t k_hi    = exidx.SinglesFromBdetOffset[ibst + 1];
+			uint32_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
 
-			for (size_t it = 0; it < k_iters; it++) {
-				size_t  k        = k_lo + it * SUBWARP + lane;
-				bool    in_range = (k < k_hi);
-				int64_t idxb     = -1;
-				size_t  jbst     = 0;
+			for (uint32_t it = 0; it < k_iters; it++) {
+				uint32_t k        = k_lo + it * SUBWARP + lane;
+				bool     in_range = (k < k_hi);
+				int64_t  idxb     = -1;
+				uint32_t jbst     = 0;
 				bool    valid    = false;
 				if (in_range) {
 					jbst  = exidx.SinglesFromBdetSM[k];
@@ -604,10 +604,10 @@ public:
 					// Dispatch up to SUBWARP TwoExcite() calls in parallel. Lane
 					// guard: count may be < SUBWARP on the is_last_inner drain pass.
 					if (lane < s_count[group]) {
-						int     my_slot = buf_base + lane;
-						int64_t my_idxb = s_idxb[my_slot];
-						size_t  my_ja   = s_ja  [my_slot];
-						size_t  my_k    = s_k   [my_slot];
+						int      my_slot = buf_base + lane;
+						int64_t  my_idxb = s_idxb[my_slot];
+						uint32_t my_ja   = s_ja  [my_slot];
+						uint32_t my_k    = s_k   [my_slot];
 						uint32_t jdet   = tidxmap.AdetToDetSM[my_idxb];
 						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
 						                    exidx.SinglesAdetCrAnSM[my_ja],

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -333,12 +333,14 @@ public:
 		typename WarpReduceSum::TempStorage temp_sum;
 		ElemT thread_sum = ElemT(0);
 
-		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+		const uint32_t self_lo = exidx.SelfFromBdetOffset[ibst];
+		const uint32_t self_hi = exidx.SelfFromBdetOffset[ibst + 1];
+		const uint32_t ja_lo   = exidx.SinglesFromAdetOffset[ia];
+		const uint32_t ja_hi   = exidx.SinglesFromAdetOffset[ia + 1];
+		if (self_lo != self_hi) {
+			uint32_t jbst = exidx.SelfFromBdetSM[self_lo];
 			// single alpha excitations — strided across SUBWARP lanes
-			for (uint32_t ja = exidx.SinglesFromAdetOffset[ia] + lane;
-			              ja < exidx.SinglesFromAdetOffset[ia + 1];
-			              ja += SUBWARP) {
+			for (uint32_t ja = ja_lo + lane; ja < ja_hi; ja += SUBWARP) {
 				uint32_t jast = exidx.SinglesFromAdetSM[ja];
 				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
 				if (found_a) {
@@ -390,12 +392,14 @@ public:
 		typename WarpReduceSum::TempStorage temp_sum;
 		ElemT thread_sum = ElemT(0);
 
-		if (exidx.SelfFromBdetOffset[ibst] != exidx.SelfFromBdetOffset[ibst + 1]) {
-			uint32_t jbst = exidx.SelfFromBdetSM[exidx.SelfFromBdetOffset[ibst]];
+		const uint32_t self_lo = exidx.SelfFromBdetOffset[ibst];
+		const uint32_t self_hi = exidx.SelfFromBdetOffset[ibst + 1];
+		const uint32_t ja_lo   = exidx.DoublesFromAdetOffset[ia];
+		const uint32_t ja_hi   = exidx.DoublesFromAdetOffset[ia + 1];
+		if (self_lo != self_hi) {
+			uint32_t jbst = exidx.SelfFromBdetSM[self_lo];
 			// double alpha excitations — strided across SUBWARP lanes
-			for (uint32_t ja = exidx.DoublesFromAdetOffset[ia] + lane;
-			              ja < exidx.DoublesFromAdetOffset[ia + 1];
-			              ja += SUBWARP) {
+			for (uint32_t ja = ja_lo + lane; ja < ja_hi; ja += SUBWARP) {
 				uint32_t jast = exidx.DoublesFromAdetSM[ja];
 				auto [found_a, idxa] = tidxmap.bdet_lower_bound(jbst, jast);
 				if (found_a) {
@@ -452,12 +456,14 @@ public:
 		typename WarpReduceSum::TempStorage temp_sum;
 		ElemT thread_sum = ElemT(0);
 
-		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+		const uint32_t self_lo = exidx.SelfFromAdetOffset[iast];
+		const uint32_t self_hi = exidx.SelfFromAdetOffset[iast + 1];
+		const uint32_t jb_lo   = exidx.SinglesFromBdetOffset[ib];
+		const uint32_t jb_hi   = exidx.SinglesFromBdetOffset[ib + 1];
+		if (self_lo != self_hi) {
+			uint32_t jast = exidx.SelfFromAdetSM[self_lo];
 			// single beta excitations — strided across SUBWARP lanes
-			for (uint32_t jb = exidx.SinglesFromBdetOffset[ib] + lane;
-			              jb < exidx.SinglesFromBdetOffset[ib + 1];
-			              jb += SUBWARP) {
+			for (uint32_t jb = jb_lo + lane; jb < jb_hi; jb += SUBWARP) {
 				uint32_t jbst = exidx.SinglesFromBdetSM[jb];
 				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
 				if (found_b) {
@@ -509,12 +515,14 @@ public:
 		typename WarpReduceSum::TempStorage temp_sum;
 		ElemT thread_sum = ElemT(0);
 
-		if (exidx.SelfFromAdetOffset[iast] != exidx.SelfFromAdetOffset[iast + 1]) {
-			uint32_t jast = exidx.SelfFromAdetSM[exidx.SelfFromAdetOffset[iast]];
+		const uint32_t self_lo = exidx.SelfFromAdetOffset[iast];
+		const uint32_t self_hi = exidx.SelfFromAdetOffset[iast + 1];
+		const uint32_t jb_lo   = exidx.DoublesFromBdetOffset[ib];
+		const uint32_t jb_hi   = exidx.DoublesFromBdetOffset[ib + 1];
+		if (self_lo != self_hi) {
+			uint32_t jast = exidx.SelfFromAdetSM[self_lo];
 			// double beta excitations — strided across SUBWARP lanes
-			for (uint32_t jb = exidx.DoublesFromBdetOffset[ib] + lane;
-			              jb < exidx.DoublesFromBdetOffset[ib + 1];
-			              jb += SUBWARP) {
+			for (uint32_t jb = jb_lo + lane; jb < jb_hi; jb += SUBWARP) {
 				uint32_t jbst = exidx.DoublesFromBdetSM[jb];
 				auto [found_b, idxb] = tidxmap.adet_lower_bound(jast, jbst);
 				if (found_b) {
@@ -599,6 +607,13 @@ public:
 		                                               : ((1u << SUBWARP) - 1u);
 		const unsigned subwarp_mask  = subwarp_lanes << (group_in_warp * SUBWARP);
 
+		// k_lo/k_hi/k_iters depend only on ibst (constant for this thread);
+		// hoist outside the ja loop so the compiler sees they are loop-invariant
+		// even though SinglesFromBdetOffset is a raw device pointer.
+		const uint32_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
+		const uint32_t k_hi    = exidx.SinglesFromBdetOffset[ibst + 1];
+		const uint32_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
+
 		// Outer ja loop. Inner k loop runs k_iters times *uniformly* across
 		// all SUBWARP lanes of the group (k_lane = k_lo + it*SUBWARP + lane,
 		// guarded by `in_range = k_lane < k_hi`). This keeps __ballot_sync
@@ -606,11 +621,9 @@ public:
 		// divergent-loop-exit bug in v1.
 		// adet_lower_bound returns {found, ie}; ie < AdetToDetOffset[jast+1] whenever found.
 		// (idxb - AdetToDetOffset[jast]) is in-range whenever valid.
-		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < exidx.SinglesFromAdetOffset[ia + 1]; ja++) {
+		const uint32_t ja_hi = exidx.SinglesFromAdetOffset[ia + 1];
+		for (uint32_t ja = exidx.SinglesFromAdetOffset[ia]; ja < ja_hi; ja++) {
 			uint32_t jast    = exidx.SinglesFromAdetSM[ja];
-			uint32_t k_lo    = exidx.SinglesFromBdetOffset[ibst];
-			uint32_t k_hi    = exidx.SinglesFromBdetOffset[ibst + 1];
-			uint32_t k_iters = (k_hi - k_lo + SUBWARP - 1) / SUBWARP;
 
 			for (uint32_t it = 0; it < k_iters; it++) {
 				uint32_t k             = k_lo + it * SUBWARP + lane;

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -856,8 +856,11 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	//   compute_stream must not read twk[b] until copy_done[b].
 	//   copy_stream must not write twk[b] until compute_done[b].
 	cudaEvent_t copy_done[2], compute_done[2];
-	cudaEventCreate(&copy_done[0]);    cudaEventCreate(&copy_done[1]);
-	cudaEventCreate(&compute_done[0]); cudaEventCreate(&compute_done[1]);
+	cudaEventCreateWithFlags(&copy_done[0],    cudaEventDisableTiming);
+	cudaEventCreateWithFlags(&copy_done[1],    cudaEventDisableTiming);
+	cudaEventCreateWithFlags(&compute_done[0], cudaEventDisableTiming);
+	cudaEventCreateWithFlags(&compute_done[1], cudaEventDisableTiming);
+	// No event pre-recording needed: CUDA treats unrecorded events as complete.
 
 	// CPU-pinned staging buffers (two per data type, one per double-buffer slot).
 	ElemT*    h_twk[2] = {nullptr, nullptr};
@@ -869,18 +872,20 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 	cudaMallocHost(&h_map[0], tidxmap_storage[0].size() * sizeof(uint32_t));
 	cudaMallocHost(&h_map[1], tidxmap_storage[1].size() * sizeof(uint32_t));
 
-	// One-time sync copy: mirror the initial active GPU ket into the CPU
-	// staging buffer so the first task can MPI_Isend from host memory.
-	// Synchronous cudaMemcpy completes before the task loop begins.
-	cudaMemcpy(h_twk[active_buf],
-	           thrust::raw_pointer_cast(twk[active_buf].data()),
-	           twk_ket_size[active_buf] * sizeof(ElemT),
-	           cudaMemcpyDeviceToHost);
-	cudaMemcpy(h_map[active_buf],
-	           thrust::raw_pointer_cast(tidxmap_storage[active_buf].data()),
-	           twk_map_size[active_buf] * sizeof(uint32_t),
-	           cudaMemcpyDeviceToHost);
-	// No event pre-recording needed: CUDA treats unrecorded events as complete.
+	// Async D→H: mirror the initial active GPU ket into the CPU staging buffer
+	// so the first MPI_Isend can go from host memory.  Both copies go on
+	// copy_stream; copy_done[active_buf] gates compute_stream's kernel launch
+	// and copy_done[recv_buf] gates the task-0 ExchangeAsyncHost call.
+	cudaMemcpyAsync(h_twk[active_buf],
+	                thrust::raw_pointer_cast(twk[active_buf].data()),
+	                twk_ket_size[active_buf] * sizeof(ElemT),
+	                cudaMemcpyDeviceToHost, copy_stream);
+	cudaMemcpyAsync(h_map[active_buf],
+	                thrust::raw_pointer_cast(tidxmap_storage[active_buf].data()),
+	                twk_map_size[active_buf] * sizeof(uint32_t),
+	                cudaMemcpyDeviceToHost, copy_stream);
+	cudaEventRecord(copy_done[active_buf], copy_stream);  // for compute_stream
+	cudaEventRecord(copy_done[recv_buf],  copy_stream);  // for MPI
 
 	MpiSlider<ElemT> slider;
 	using _ck = std::chrono::steady_clock;
@@ -928,10 +933,13 @@ void MultGDBThrust<ElemT>::run(	const thrust::device_vector<ElemT> &hii,
 			{ auto _t0 = _ck::now();
 			  // Ensure the cudaMemcpyAsync that READ h_twk[recv_buf] in a prior
 			  // task has completed before MPI_Irecv writes into that same buffer.
-			  // In practice copy_done[recv_buf] fires ~3ms after launch and
-			  // Sync() in the intervening task takes >> 3ms, so this is a no-op
-			  // in steady state — but the dependency must be explicit.
-			  cudaEventSynchronize(copy_done[recv_buf]);
+			  if (cudaEventQuery(copy_done[recv_buf]) == cudaErrorNotReady) {
+			    auto _tw0 = _ck::now();
+			    cudaEventSynchronize(copy_done[recv_buf]);
+			    double _tw = std::chrono::duration<double,std::milli>(_ck::now()-_tw0).count();
+			    fprintf(stderr, "event_wait_ms: rank_b=%d task=%zu event=copy_done wait=%.1f\n",
+			            mpi_rank_b, task, _tw);
+			  }
 			  // CPU-staging: send from h_twk[active] (CPU DRAM) — no HBM touch.
 			  slider.ExchangeAsyncHost(
 			      h_twk[active_buf], twk_ket_size[active_buf],

--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -566,30 +566,42 @@ public:
 				if (lane == 0) s_count[group] += added;
 				__syncwarp(subwarp_mask);
 
-				if (s_count[group] >= SUBWARP) {
-					// Dispatch SUBWARP TwoExcite() calls in parallel.
-					int     my_slot = buf_base + lane;
-					int64_t my_idxb = s_idxb[my_slot];
-					size_t  my_ja   = s_ja  [my_slot];
-					size_t  my_k    = s_k   [my_slot];
-					size_t  jdet    = tidxmap.AdetToDetSM[my_idxb];
-					ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
-					                    exidx.SinglesAdetCrAnSM[my_ja],
-					                    exidx.SinglesBdetCrAnSM[my_k],
-					                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],
-					                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
-					thread_sum += eij * this->twk[jdet];
+				// Per Jim's drain-fold suggestion: extend the dispatch trigger
+				// to also fire on the very last (it, ja) so the post-loop drain
+				// block can be eliminated. Loop the dispatch on is_last_inner so
+				// the case where post-append count > SUBWARP on the last (it, ja)
+				// is also drained — Jim's literal proposal would lose
+				// (count - SUBWARP) candidates in that case (one round of
+				// SUBWARP-wide dispatch + compact, then kernel exits with the
+				// shifted leftovers still unprocessed). The while form runs at
+				// most twice on the last iter and once otherwise.
+				bool is_last_inner = (it == k_iters - 1) &&
+				                     (ja == exidx.SinglesFromAdetOffset[ia + 1] - 1);
+				while (s_count[group] >= SUBWARP || (is_last_inner && s_count[group] > 0)) {
+					// Dispatch up to SUBWARP TwoExcite() calls in parallel. Lane
+					// guard: count may be < SUBWARP on the is_last_inner drain pass.
+					if (lane < s_count[group]) {
+						int     my_slot = buf_base + lane;
+						int64_t my_idxb = s_idxb[my_slot];
+						size_t  my_ja   = s_ja  [my_slot];
+						size_t  my_k    = s_k   [my_slot];
+						size_t  jdet    = tidxmap.AdetToDetSM[my_idxb];
+						ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
+						                    exidx.SinglesAdetCrAnSM[my_ja],
+						                    exidx.SinglesBdetCrAnSM[my_k],
+						                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],
+						                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
+						thread_sum += eij * this->twk[jdet];
+					}
 					__syncwarp(subwarp_mask);
 
-					// Compact this group's slice in parallel. Source range
-					// [buf_base+SUBWARP, buf_base+2*SUBWARP) was not touched
-					// by dispatch and is disjoint from the destination
-					// [buf_base, buf_base+SUBWARP) — direct lane-parallel copy
-					// is safe without an intermediate sync. Slots above the
-					// new s_count are garbage but invisible (next probe round
-					// overwrites starting at s_count). Only lane 0 mutates
-					// s_count (decrement-not-assign), so no read-write race
-					// with other lanes that have already pulled their copies.
+					// Compact this group's slice. Source [buf_base+SUBWARP,
+					// buf_base+2*SUBWARP) and destination [buf_base, buf_base+SUBWARP)
+					// are disjoint; direct lane-parallel copy is safe without an
+					// intermediate sync. Slots above the new s_count are garbage
+					// but invisible — either next probe round overwrites starting
+					// at s_count, or kernel exits (is_last_inner drain case). Only
+					// lane 0 mutates s_count (decrement-not-assign).
 					s_idxb[buf_base + lane] = s_idxb[buf_base + SUBWARP + lane];
 					s_ja  [buf_base + lane] = s_ja  [buf_base + SUBWARP + lane];
 					s_k   [buf_base + lane] = s_k   [buf_base + SUBWARP + lane];
@@ -599,22 +611,6 @@ public:
 			}
 		}
 
-		// Drain remaining (count < SUBWARP). All lanes evaluate the predicate
-		// uniformly; only those with `lane < s_count[group]` enter the body.
-		if (lane < s_count[group]) {
-			int     my_slot = buf_base + lane;
-			int64_t my_idxb = s_idxb[my_slot];
-			size_t  my_ja   = s_ja  [my_slot];
-			size_t  my_k    = s_k   [my_slot];
-			size_t  jdet    = tidxmap.AdetToDetSM[my_idxb];
-			ElemT eij = this->TwoExcite(this->det + idet * this->D_size,
-			                    exidx.SinglesAdetCrAnSM[my_ja],
-			                    exidx.SinglesBdetCrAnSM[my_k],
-			                    exidx.SinglesAdetCrAnSM[my_ja + exidx.size_single_adet],
-			                    exidx.SinglesBdetCrAnSM[my_k + exidx.size_single_bdet]);
-			thread_sum += eij * this->twk[jdet];
-		}
-		__syncwarp(subwarp_mask);
 
 		ElemT total = WarpReduceSum(temp_sum).Sum(thread_sum);
 		if (lane == 0) this->wb[idet] += total;

--- a/include/sbd/framework/mpi_utility.h
+++ b/include/sbd/framework/mpi_utility.h
@@ -403,12 +403,10 @@ namespace sbd {
 
     scratch_send.resize(total_send_size);
     scratch_recv.resize(total_recv_size);
-    if( size_recv[0] != 0 ) {
-      B.resize(size_recv[0],std::vector<size_t>(size_recv[1]));
-    } else {
-      B.resize(0);
-    }
 
+    // Pack A into scratch_send before touching B.
+    // Ordering guarantee: A content is fully captured before B.resize() below,
+    // so it is safe to call with A and B aliasing the same vector (in-place slide).
     for(size_t n=0; n < size_send[0]; n++) {
       for(size_t k=0; k < size_send[1]; k++) {
         scratch_send[n*size_send[1]+k] = A[n][k];
@@ -420,6 +418,16 @@ namespace sbd {
     }
     if( total_recv_size != 0 ) {
       MPI_Irecv(scratch_recv.data(),total_recv_size,SBD_MPI_SIZE_T,mpi_source,1,comm,&req_data[1]);
+    }
+
+    // B.resize placed here — after pack (A safe) and Isend/Irecv (in flight),
+    // so construction of new vector rows overlaps with the MPI transfer.
+    // When A==B (in-place slide), B already has the right capacity if the
+    // communicator is balanced, making resize() a no-op.
+    if( size_recv[0] != 0 ) {
+      B.resize(size_recv[0],std::vector<size_t>(size_recv[1]));
+    } else {
+      B.resize(0);
     }
 
     if( total_send_size != 0 && total_recv_size != 0 ) {

--- a/include/sbd/framework/mpi_utility.h
+++ b/include/sbd/framework/mpi_utility.h
@@ -367,20 +367,22 @@ namespace sbd {
 
   
 
-  template <>
-  void MpiSlide(const std::vector<std::vector<size_t>> & A,
-		std::vector<std::vector<size_t>> & B,
-		int slide,
-		MPI_Comm comm) {
+  // MpiSlide for vector<vector<size_t>> with caller-supplied flat scratch buffers.
+  // When the same scratch vectors are reused across calls, resize() is a no-op
+  // on subsequent calls of equal size, avoiding repeated zero-initialization.
+  void MpiSlideWithScratch(const std::vector<std::vector<size_t>> & A,
+                            std::vector<std::vector<size_t>> & B,
+                            int slide,
+                            MPI_Comm comm,
+                            std::vector<size_t>& scratch_send,
+                            std::vector<size_t>& scratch_recv) {
     int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
     int mpi_size; MPI_Comm_size(comm,&mpi_size);
     int mpi_dest   = (mpi_size+mpi_rank+slide) % mpi_size;
     int mpi_source = (mpi_size+mpi_rank-slide) % mpi_size;
-    
+
     std::vector<MPI_Request> req_size(2);
     std::vector<MPI_Status> sta_size(2);
-
-    // We first check the size
     std::vector<size_t> size_send(2);
     std::vector<size_t> size_recv(2);
     size_send[0] = A.size();
@@ -399,8 +401,8 @@ namespace sbd {
     std::vector<MPI_Request> req_data(2);
     std::vector<MPI_Status> sta_data(2);
 
-    std::vector<size_t> data_send(total_send_size);
-    std::vector<size_t> data_recv(total_recv_size);
+    scratch_send.resize(total_send_size);
+    scratch_recv.resize(total_recv_size);
     if( size_recv[0] != 0 ) {
       B.resize(size_recv[0],std::vector<size_t>(size_recv[1]));
     } else {
@@ -409,17 +411,17 @@ namespace sbd {
 
     for(size_t n=0; n < size_send[0]; n++) {
       for(size_t k=0; k < size_send[1]; k++) {
-	data_send[n*size_send[1]+k] = A[n][k];
+        scratch_send[n*size_send[1]+k] = A[n][k];
       }
     }
 
     if( total_send_size != 0 ) {
-      MPI_Isend(data_send.data(),total_send_size,SBD_MPI_SIZE_T,mpi_dest,1,comm,&req_data[0]);
+      MPI_Isend(scratch_send.data(),total_send_size,SBD_MPI_SIZE_T,mpi_dest,1,comm,&req_data[0]);
     }
     if( total_recv_size != 0 ) {
-      MPI_Irecv(data_recv.data(),total_recv_size,SBD_MPI_SIZE_T,mpi_source,1,comm,&req_data[1]);
+      MPI_Irecv(scratch_recv.data(),total_recv_size,SBD_MPI_SIZE_T,mpi_source,1,comm,&req_data[1]);
     }
-    
+
     if( total_send_size != 0 && total_recv_size != 0 ) {
       MPI_Waitall(2,req_data.data(),sta_data.data());
     } else if ( total_send_size != 0 && total_recv_size == 0 ) {
@@ -430,10 +432,18 @@ namespace sbd {
 
     for(size_t n=0; n < size_recv[0]; n++) {
       for(size_t k=0; k < size_recv[1]; k++) {
-	B[n][k] = data_recv[n*size_recv[1]+k];
+        B[n][k] = scratch_recv[n*size_recv[1]+k];
       }
     }
-    
+  }
+
+  template <>
+  void MpiSlide(const std::vector<std::vector<size_t>> & A,
+		std::vector<std::vector<size_t>> & B,
+		int slide,
+		MPI_Comm comm) {
+    std::vector<size_t> scratch_send, scratch_recv;
+    MpiSlideWithScratch(A, B, slide, comm, scratch_send, scratch_recv);
   }
 
 

--- a/include/sbd/framework/type_def.h
+++ b/include/sbd/framework/type_def.h
@@ -39,6 +39,7 @@ namespace sbd {
   template<> inline MPI_Datatype GetMpiType<double>::MpiT = MPI_DOUBLE;
   template<> inline MPI_Datatype GetMpiType<std::complex<float>>::MpiT = MPI_CXX_FLOAT_COMPLEX;
   template<> inline MPI_Datatype GetMpiType<std::complex<double>>::MpiT = MPI_CXX_DOUBLE_COMPLEX;
+  template<> inline MPI_Datatype GetMpiType<uint32_t>::MpiT = MPI_UINT32_T;
 
 #if SIZE_MAX == UCHAR_MAX
   #define SBD_MPI_SIZE_T MPI_UNSIGNED_CHAR


### PR DESCRIPTION
Sub-warp parallelization of mult kernels to increase parallelism 8-32x and improve global memory load coalescing.
Change index array types from size_t to uint32_t to reduce load volume and register usage.
Replace parity computation with two loads from pre-computed parity prefix-sum array.
Add launch bounds to force even fewer registers and increase mult kernel occupancy to 75%.
Use host-pinned memory for MPI slide buffers to avoid contention from kernel loads.
Use CUDA streams, asynchronous copies, and events to ensure MPI-CUDA overlap.