### PR TITLE
gdb: equal-bra_a determinant redistribution

### DIFF
--- a/apps/chemistry_gdb_selected_basis_diagonalization/main.cc
+++ b/apps/chemistry_gdb_selected_basis_diagonalization/main.cc
@@ -153,6 +153,8 @@ int main(int argc, char * argv[]) {
 	sbd::reordering(det,bit_length,2*L,b_comm);
       } else if ( sbd_data.do_redist_det ) {
 	sbd::redistribution(det,bit_length,2*L,b_comm);
+      } else if ( sbd_data.do_redist_alpha_eq ) {
+	sbd::redistribution_equal_bra_a(det,bit_length,2*L,b_comm);
       }
     }
     sbd::MpiBcast(det,0,t_comm);

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -30,6 +30,52 @@ namespace sbd {
   
 
 
+  // Sort a[lo..hi) in less_from_back order by recursing one element at a time.
+  // Each comparison level touches exactly one size_t (no inner loop, no .size()
+  // call); for clen==1 this is a single std::sort with a bare size_t comparison.
+  void sort_from_back(std::vector<std::vector<size_t>>& a,
+                      size_t lo, size_t hi, int elem) {
+    if (hi - lo <= 1 || elem < 0) return;
+    std::sort(a.begin() + lo, a.begin() + hi,
+              [elem](const std::vector<size_t>& x,
+                     const std::vector<size_t>& y) {
+                return x[elem] < y[elem];
+              });
+    if (elem == 0) return;
+    size_t run_lo = lo;
+    for (size_t i = lo + 1; i <= hi; i++) {
+      if (i == hi || a[i][elem] != a[run_lo][elem]) {
+        if (i - run_lo > 1)
+          sort_from_back(a, run_lo, i, elem - 1);
+        run_lo = i;
+      }
+    }
+  }
+
+  // Sort idx[lo..hi) so that (a[idx[i]][elem] & Mask) is in ascending order,
+  // recursing on equal-valued runs through decreasing elements.
+  // Mask is a template parameter so the compiler specialises each instantiation:
+  // Mask=~0 eliminates the AND entirely; Mask=0x5555... is baked into code.
+  template<size_t Mask = ~size_t(0)>
+  void idx_sort_from_back(std::vector<size_t>& idx,
+                          const std::vector<std::vector<size_t>>& a,
+                          size_t lo, size_t hi, int elem) {
+    if (hi - lo <= 1 || elem < 0) return;
+    std::sort(idx.begin() + lo, idx.begin() + hi,
+              [&a, elem](size_t x, size_t y) {
+                return (a[x][elem] & Mask) < (a[y][elem] & Mask);
+              });
+    if (elem == 0) return;
+    size_t run_lo = lo;
+    for (size_t i = lo + 1; i <= hi; i++) {
+      if (i == hi || (a[idx[i]][elem] & Mask) != (a[idx[run_lo]][elem] & Mask)) {
+        if (i - run_lo > 1)
+          idx_sort_from_back<Mask>(idx, a, run_lo, i, elem - 1);
+        run_lo = i;
+      }
+    }
+  }
+
   // Equal-bra_a redistribution: partition dets so each rank owns a disjoint
   // contiguous range of alpha strings, giving equal bra_a across ranks.
   // Alpha occupation is at even bit positions (0,2,4,...) of the det bitstring,
@@ -42,53 +88,36 @@ namespace sbd {
     int mpi_rank; MPI_Comm_rank(comm, &mpi_rank);
 
     const int clen = static_cast<int>((total_bit_length + bit_length - 1) / bit_length);
+    // Alpha bits sit at even positions (0,2,4,...) of each interleaved word.
+    // Masking with ALPHA_MASK zeroes beta bits in place; the remaining even-position
+    // bits compare correctly with < because bit position order is preserved.
+    constexpr size_t ALPHA_MASK = 0x5555555555555555ULL;
 
-    // De-interleave one word: pack even-indexed bits into lower half.
-    auto deinterleave = [](size_t w) -> size_t {
-      size_t x = w & 0x5555555555555555ULL;
-      x = (x | (x >>  1)) & 0x3333333333333333ULL;
-      x = (x | (x >>  2)) & 0x0f0f0f0f0f0f0f0fULL;
-      x = (x | (x >>  4)) & 0x00ff00ff00ff00ffULL;
-      x = (x | (x >>  8)) & 0x0000ffff0000ffffULL;
-      x = (x | (x >> 16)) & 0x00000000ffffffffULL;
-      return x;
-    };
-
-    // Extract alpha key (clen packed words) from a det.
-    // Word k of the alpha key contains alpha orbitals [32k .. 32k+31].
-    auto get_alpha = [&](const std::vector<size_t>& det) -> std::vector<size_t> {
-      std::vector<size_t> a(clen);
-      for (int k = 0; k < clen; k++) a[k] = deinterleave(det[k]);
-      return a;
-    };
-
-    // Pre-compute alpha keys once to avoid redundant work in sort and lookup.
-    std::vector<std::vector<size_t>> akeys(config.size());
-    for (size_t j = 0; j < config.size(); j++) akeys[j] = get_alpha(config[j]);
-
-    // Step 1: sort local dets by (alpha_key, full_det) — alpha-primary.
+    // Step 1: sort local dets alpha-primary by masking beta bits out of each word.
+    // Det order within each alpha group is irrelevant; Step 7 re-sorts beta-primary.
     std::vector<size_t> idx(config.size());
     std::iota(idx.begin(), idx.end(), size_t(0));
-    std::sort(idx.begin(), idx.end(), [&](size_t a, size_t b) {
-      if (akeys[a] != akeys[b]) return less_from_back(akeys[a], akeys[b]);
-      return less_from_back(config[a], config[b]);
-    });
+    idx_sort_from_back<ALPHA_MASK>(idx, config, 0, idx.size(), clen - 1);
     {
-      std::vector<std::vector<size_t>> tmp_c(config.size()), tmp_a(config.size());
-      for (size_t i = 0; i < config.size(); i++) {
-        tmp_c[i] = std::move(config[idx[i]]);
-        tmp_a[i] = std::move(akeys[idx[i]]);
-      }
-      config = std::move(tmp_c);
-      akeys  = std::move(tmp_a);
+      std::vector<std::vector<size_t>> tmp(config.size());
+      for (size_t i = 0; i < config.size(); i++) tmp[i] = std::move(config[idx[i]]);
+      config = std::move(tmp);
     }
 
-    // Step 2: collect local unique alpha keys (already in sorted order).
+    // Step 2: collect local unique alpha keys from sorted config (mask on the fly).
     std::vector<std::vector<size_t>> local_alphas;
     {
       std::vector<size_t> prev(clen, ~size_t(0));
-      for (const auto& ak : akeys)
-        if (ak != prev) { local_alphas.push_back(ak); prev = ak; }
+      for (size_t j = 0; j < config.size(); j++) {
+        bool diff = false;
+        for (int k = 0; k < clen && !diff; k++)
+          diff = ((config[j][k] & ALPHA_MASK) != prev[k]);
+        if (diff) {
+          for (int k = 0; k < clen; k++)
+            prev[k] = config[j][k] & ALPHA_MASK;
+          local_alphas.emplace_back(prev);
+        }
+      }
     }
 
     // Step 3: allgather unique alpha keys → global sorted unique list.
@@ -123,13 +152,21 @@ namespace sbd {
     for (int r = 0; r < mpi_size; r++)
       alpha_start[r+1] = alpha_start[r] + chunk + (static_cast<size_t>(r) < rem ? 1 : 0);
 
-    // Step 5: for each local det compute destination rank using pre-computed akeys.
+    // Step 5: for each local det compute destination rank.
+    // all_alphas entries are already masked; apply ALPHA_MASK to config[j] inline.
     std::vector<int> dest_per_det(config.size());
     std::vector<int> sendcounts(mpi_size, 0);
     for (size_t j = 0; j < config.size(); j++) {
       size_t pos = static_cast<size_t>(
-        std::lower_bound(all_alphas.begin(), all_alphas.end(), akeys[j],
-          [](const auto& a, const auto& b) { return less_from_back(a, b); })
+        std::lower_bound(all_alphas.begin(), all_alphas.end(), config[j],
+          [clen](const std::vector<size_t>& alpha, const std::vector<size_t>& det) {
+            constexpr size_t ALPHA_MASK = 0x5555555555555555ULL;
+            for (int k = clen - 1; k >= 0; k--) {
+              if (alpha[k] < (det[k] & ALPHA_MASK)) return true;
+              if (alpha[k] > (det[k] & ALPHA_MASK)) return false;
+            }
+            return false;
+          })
         - all_alphas.begin());
       int dest = static_cast<int>(
         std::upper_bound(alpha_start.begin(), alpha_start.end(), pos)
@@ -161,12 +198,12 @@ namespace sbd {
     MPI_Alltoallv(sendbuf.data(), sendcounts_w.data(), sdispls.data(), SBD_MPI_SIZE_T,
                   recvbuf.data(), recvcounts_w.data(), rdispls.data(), SBD_MPI_SIZE_T, comm);
 
-    // Step 7: unpack and restore kernel sort order (sort_bitarray = beta-primary).
+    // Step 7: unpack and restore kernel sort order (beta-primary = less_from_back).
     size_t n_recv = static_cast<size_t>(total_recv_w) / static_cast<size_t>(clen);
     config.resize(n_recv, std::vector<size_t>(clen));
     for (size_t i = 0; i < n_recv; i++)
       for (int k = 0; k < clen; k++) config[i][k] = recvbuf[i * clen + k];
-    sort_bitarray(config);
+    sort_from_back(config, 0, config.size(), clen - 1);
   }
 
   void reordering(std::vector<std::vector<size_t>> & config,

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -28,6 +28,147 @@ namespace sbd {
     
   }
   
+
+
+  // Equal-bra_a redistribution: partition dets so each rank owns a disjoint
+  // contiguous range of alpha strings, giving equal bra_a across ranks.
+  // Alpha occupation is at even bit positions (0,2,4,...) of the det bitstring,
+  // interleaved with beta at odd positions.  Works for any clen.
+  void redistribution_equal_bra_a(std::vector<std::vector<size_t>> & config,
+                                   size_t bit_length,
+                                   size_t total_bit_length,
+                                   MPI_Comm comm) {
+    int mpi_size; MPI_Comm_size(comm, &mpi_size);
+    int mpi_rank; MPI_Comm_rank(comm, &mpi_rank);
+
+    const int clen = static_cast<int>((total_bit_length + bit_length - 1) / bit_length);
+
+    // De-interleave one word: pack even-indexed bits into lower half.
+    auto deinterleave = [](size_t w) -> size_t {
+      size_t x = w & 0x5555555555555555ULL;
+      x = (x | (x >>  1)) & 0x3333333333333333ULL;
+      x = (x | (x >>  2)) & 0x0f0f0f0f0f0f0f0fULL;
+      x = (x | (x >>  4)) & 0x00ff00ff00ff00ffULL;
+      x = (x | (x >>  8)) & 0x0000ffff0000ffffULL;
+      x = (x | (x >> 16)) & 0x00000000ffffffffULL;
+      return x;
+    };
+
+    // Extract alpha key (clen packed words) from a det.
+    // Word k of the alpha key contains alpha orbitals [32k .. 32k+31].
+    auto get_alpha = [&](const std::vector<size_t>& det) -> std::vector<size_t> {
+      std::vector<size_t> a(clen);
+      for (int k = 0; k < clen; k++) a[k] = deinterleave(det[k]);
+      return a;
+    };
+
+    // Pre-compute alpha keys once to avoid redundant work in sort and lookup.
+    std::vector<std::vector<size_t>> akeys(config.size());
+    for (size_t j = 0; j < config.size(); j++) akeys[j] = get_alpha(config[j]);
+
+    // Step 1: sort local dets by (alpha_key, full_det) — alpha-primary.
+    std::vector<size_t> idx(config.size());
+    std::iota(idx.begin(), idx.end(), size_t(0));
+    std::sort(idx.begin(), idx.end(), [&](size_t a, size_t b) {
+      if (akeys[a] != akeys[b]) return less_from_back(akeys[a], akeys[b]);
+      return less_from_back(config[a], config[b]);
+    });
+    {
+      std::vector<std::vector<size_t>> tmp_c(config.size()), tmp_a(config.size());
+      for (size_t i = 0; i < config.size(); i++) {
+        tmp_c[i] = std::move(config[idx[i]]);
+        tmp_a[i] = std::move(akeys[idx[i]]);
+      }
+      config = std::move(tmp_c);
+      akeys  = std::move(tmp_a);
+    }
+
+    // Step 2: collect local unique alpha keys (already in sorted order).
+    std::vector<std::vector<size_t>> local_alphas;
+    {
+      std::vector<size_t> prev(clen, ~size_t(0));
+      for (const auto& ak : akeys)
+        if (ak != prev) { local_alphas.push_back(ak); prev = ak; }
+    }
+
+    // Step 3: allgather unique alpha keys → global sorted unique list.
+    // Each alpha key is clen words; exchange as flat size_t arrays.
+    int local_n = static_cast<int>(local_alphas.size());
+    std::vector<int> all_counts(mpi_size);
+    MPI_Allgather(&local_n, 1, MPI_INT, all_counts.data(), 1, MPI_INT, comm);
+    int total_n = 0;
+    std::vector<int> ag_displs_w(mpi_size, 0), ag_counts_w(mpi_size);
+    for (int r = 0; r < mpi_size; r++) {
+      ag_displs_w[r] = total_n * clen;
+      ag_counts_w[r] = all_counts[r] * clen;
+      total_n += all_counts[r];
+    }
+    std::vector<size_t> flat_local(local_n * clen), flat_all(total_n * clen);
+    for (int i = 0; i < local_n; i++)
+      for (int k = 0; k < clen; k++) flat_local[i * clen + k] = local_alphas[i][k];
+    MPI_Allgatherv(flat_local.data(), local_n * clen, SBD_MPI_SIZE_T,
+                   flat_all.data(), ag_counts_w.data(), ag_displs_w.data(), SBD_MPI_SIZE_T, comm);
+    std::vector<std::vector<size_t>> all_alphas(total_n, std::vector<size_t>(clen));
+    for (int i = 0; i < total_n; i++)
+      for (int k = 0; k < clen; k++) all_alphas[i][k] = flat_all[i * clen + k];
+    std::sort(all_alphas.begin(), all_alphas.end(),
+      [](const auto& a, const auto& b) { return less_from_back(a, b); });
+    all_alphas.erase(std::unique(all_alphas.begin(), all_alphas.end()), all_alphas.end());
+    size_t global_bra_a = all_alphas.size();
+
+    // Step 4: assign alpha strings to ranks with equal bra_a.
+    size_t chunk = global_bra_a / static_cast<size_t>(mpi_size);
+    size_t rem   = global_bra_a % static_cast<size_t>(mpi_size);
+    std::vector<size_t> alpha_start(mpi_size + 1, 0);
+    for (int r = 0; r < mpi_size; r++)
+      alpha_start[r+1] = alpha_start[r] + chunk + (static_cast<size_t>(r) < rem ? 1 : 0);
+
+    // Step 5: for each local det compute destination rank using pre-computed akeys.
+    std::vector<int> dest_per_det(config.size());
+    std::vector<int> sendcounts(mpi_size, 0);
+    for (size_t j = 0; j < config.size(); j++) {
+      size_t pos = static_cast<size_t>(
+        std::lower_bound(all_alphas.begin(), all_alphas.end(), akeys[j],
+          [](const auto& a, const auto& b) { return less_from_back(a, b); })
+        - all_alphas.begin());
+      int dest = static_cast<int>(
+        std::upper_bound(alpha_start.begin(), alpha_start.end(), pos)
+        - alpha_start.begin()) - 1;
+      if (dest < 0) dest = 0;
+      if (dest >= mpi_size) dest = mpi_size - 1;
+      dest_per_det[j] = dest;
+      sendcounts[dest]++;
+    }
+
+    // Step 6: MPI_Alltoallv (clen words per det).
+    std::vector<int> sendcounts_w(mpi_size), sdispls(mpi_size, 0);
+    for (int r = 0; r < mpi_size; r++) sendcounts_w[r] = sendcounts[r] * clen;
+    for (int r = 1; r < mpi_size; r++) sdispls[r] = sdispls[r-1] + sendcounts_w[r-1];
+    std::vector<int> recvcounts_w(mpi_size), rdispls(mpi_size, 0);
+    MPI_Alltoall(sendcounts_w.data(), 1, MPI_INT, recvcounts_w.data(), 1, MPI_INT, comm);
+    for (int r = 1; r < mpi_size; r++) rdispls[r] = rdispls[r-1] + recvcounts_w[r-1];
+    int total_recv_w = rdispls[mpi_size-1] + recvcounts_w[mpi_size-1];
+
+    std::vector<size_t> sendbuf(config.size() * clen);
+    {
+      std::vector<int> fill(sdispls);
+      for (size_t j = 0; j < config.size(); j++) {
+        int d = dest_per_det[j];
+        for (int k = 0; k < clen; k++) sendbuf[fill[d]++] = config[j][k];
+      }
+    }
+    std::vector<size_t> recvbuf(total_recv_w);
+    MPI_Alltoallv(sendbuf.data(), sendcounts_w.data(), sdispls.data(), SBD_MPI_SIZE_T,
+                  recvbuf.data(), recvcounts_w.data(), rdispls.data(), SBD_MPI_SIZE_T, comm);
+
+    // Step 7: unpack and restore kernel sort order (sort_bitarray = beta-primary).
+    size_t n_recv = static_cast<size_t>(total_recv_w) / static_cast<size_t>(clen);
+    config.resize(n_recv, std::vector<size_t>(clen));
+    for (size_t i = 0; i < n_recv; i++)
+      for (int k = 0; k < clen; k++) config[i][k] = recvbuf[i * clen + k];
+    sort_bitarray(config);
+  }
+
   void reordering(std::vector<std::vector<size_t>> & config,
 		  size_t bit_length,
 		  size_t total_bit_length,

--- a/include/sbd/chemistry/gdb/sbdiag.h
+++ b/include/sbd/chemistry/gdb/sbdiag.h
@@ -27,6 +27,7 @@ namespace sbd {
       size_t bit_length = 20;
       bool do_sort_det = false;
       bool do_redist_det = false;
+      bool do_redist_alpha_eq = true;
     };
 
     SBD generate_sbd_data(int argc, char * argv[]) {
@@ -75,6 +76,9 @@ namespace sbd {
 	    sbd_data.do_redist_det = true;
 	  }
 	}
+	if( std::string(argv[i]) == "--do_redist_alpha_eq" ) {
+	  sbd_data.do_redist_alpha_eq = ( std::atoi(argv[++i]) != 0 );
+	}
       }
       return sbd_data;
     }
@@ -96,6 +100,7 @@ namespace sbd {
       std::cout << "# bit length: " << sbd_data.bit_length << std::endl;
       std::cout << "# do basis sort: " << sbd_data.do_sort_det << std::endl;
       std::cout << "# do redistribution of basis: " << sbd_data.do_redist_det << std::endl;
+      std::cout << "# do equal-bra_a redistribution: " << sbd_data.do_redist_alpha_eq << std::endl;
       if( sbd_data.do_rdm != 0.0 ) {
 	std::cout << "# do rdm: " << sbd_data.do_rdm << std::endl;
       }
@@ -609,6 +614,8 @@ namespace sbd {
 	    reordering(det,bit_length,2*L,b_comm);
 	  } else if ( sbd_data.do_redist_det ) {
 	    redistribution(det,bit_length,2*L,b_comm);
+	  } else if ( sbd_data.do_redist_alpha_eq ) {
+	    redistribution_equal_bra_a(det,bit_length,2*L,b_comm);
 	  }
 	}
 	MpiBcast(det,0,t_comm);


### PR DESCRIPTION
Reduces Davidson runtime by 40% on 4 ranks but increases helper construction
runtime by 50% for a net loss on H2O 1em5. Has not been optimized or accelerated.

On by default but can be disabled (--do_redist_alpha_eq 0). Could be defaulted off.

basis.h — new redistribution_equal_bra_a function:
  Alpha-primary partition giving each rank a disjoint equal-sized range of
  unique alpha strings. De-interleaves even bits to extract alpha keys;
  Allgather for global unique list; MPI_Alltoallv to route each det to its
  target rank; sort_bitarray restores kernel order. clen-aware for any
  bit_length / total_bit_length.

  All ranks must call the function and contribute zero-count sends even when
  starting with no dets (b_comm_size > num_files); avoids deadlock on 2+ nodes
  where some ranks receive an empty initial config.

  H2O 1em5 result: bra_a 2985/4175/4826/5514 → 1378-1379;
  Davidson 71.933s → 42.281s (−41%).

sbdiag.h / main.cc — --do_redist_alpha_eq flag; equal-bra_a redistribution
  enabled by default. --do_redist_alpha_eq 0 disables it.