### PR TITLE
gdb: stage dets into contiguous CPU buffer for single GPU upload

### DIFF
--- a/include/sbd/chemistry/gdb/mult_thrust.h
+++ b/include/sbd/chemistry/gdb/mult_thrust.h
@@ -121,10 +121,15 @@ void MultGDBThrust<ElemT>::Init(
         exidx.push_back(ExcitationLookupThrust(exidx_storage[task], CrAn_storage[task], exidx_in[task]));
     }
 
-    // copyin dets
-    dets_.resize(this->D_size_ * dets_in.size());
-    for (int i = 0; i < dets_in.size(); i++) {
-        thrust::copy_n(dets_in[i].begin(), this->D_size_, dets_.begin() + i * this->D_size_);
+    // copyin dets — stage into contiguous CPU buffer, then one GPU upload
+    const int D_size = this->D_size_;
+    const int n_dets = (int)dets_in.size();
+    dets_.resize(D_size * n_dets);
+    {
+        std::vector<size_t> flat(D_size * n_dets);
+        for (int i = 0; i < n_dets; i++)
+            std::copy_n(dets_in[i].data(), D_size, flat.data() + i * D_size);
+        thrust::copy_n(flat.begin(), flat.size(), dets_.begin());
     }
 
 	// copy indexmap


### PR DESCRIPTION
Replace N per-det thrust::copy_n calls (one per determinant) with a single std::copy_n loop into a contiguous host vector followed by one thrust::copy_n to the device.  Eliminates per-call GPU overhead and improves CPU cache behaviour when source vectors are heap-scattered (e.g. after MPI redistribution).

Measured on DeltaAI GH200, H2O 1em5, 4 ranks:
  before: ~67 s in MultGDBThrust::Init (7.6 M single-element copies)
  after:  ~80 ms (one 61 MB staged copy)