### PR TITLE
fix: initialize MultBase::a_comm_ to MPI_COMM_SELF

### DIFF
--- a/include/sbd/chemistry/basic/mult.h
+++ b/include/sbd/chemistry/basic/mult.h
@@ -34,10 +34,11 @@ protected:
     ncclComm_t a_nccl_comm_;
 #endif
 public:
-    MultBase() {}
+    MultBase() : a_comm_(MPI_COMM_SELF) {}
 
     MultBase(uint32_t bit_length, size_t norbs, MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm)
-        : bit_length_(bit_length), norbs_(norbs), h_comm_(h_comm), b_comm_(b_comm), t_comm_(t_comm)
+        : bit_length_(bit_length), norbs_(norbs), h_comm_(h_comm), b_comm_(b_comm), t_comm_(t_comm),
+          a_comm_(MPI_COMM_SELF)
     {
         D_size_ = (2 * norbs + bit_length - 1) / bit_length;
         D_half_size_ = (norbs + bit_length - 1) / bit_length;


### PR DESCRIPTION
davidson_thrust.h calls MPI_Comm_rank(mult.a_comm()) unconditionally, but MultBase left a_comm_ uninitialized. GDB has no alpha communicator and never sets a_comm_ via Init(), so the field contained garbage, causing MPI_ERR_COMM at the start of Davidson.

Initialize to MPI_COMM_SELF in both constructors. This gives mpi_size_a=1, which correctly suppresses the alpha allreduce (MPI and NCCL paths) for any MultBase subclass that has no alpha communicator.

Fixes GDB error introduced when a_comm_ was added in #43.