### PR TITLE
Fix UB in change_bitlength when bit_length_b >= word size causing corrupt packed determinants

### DIFF
--- a/include/sbd/framework/bit_manipulation.h
+++ b/include/sbd/framework/bit_manipulation.h
@@ -953,7 +953,7 @@ namespace sbd {
 	a_max_order += bit_length_a;
       }
       b[i] = v_a & maxbit_b;
-      v_a = v_a >> bit_length_b;
+      v_a = (bit_length_b >= 64) ? 0 : (v_a >> bit_length_b);
       min_order += bit_length_b;
       b_max_order += bit_length_b;
     }
@@ -997,7 +997,7 @@ namespace sbd {
 	  a_max_order += bit_length_a;
 	}
 	b[k][i] = (v_a & maxbit_b);
-	v_a = (v_a >> bit_length_b);
+	v_a = (bit_length_b >= 64) ? 0 : (v_a >> bit_length_b);
 	min_order += bit_length_b;
 	b_max_order += bit_length_b;
       }


### PR DESCRIPTION
## Bug: `change_bitlength` undefined behavior when `bit_length_b >= 64` corrupts packed determinants

### Root cause

`change_bitlength` in `bit_manipulation.h` repacks a bit array from `bit_length_a`-wide words into `bit_length_b`-wide words. After writing each output word it discards the consumed bits with:

```cpp
v_a = (v_a >> bit_length_b);
```

When `bit_length_b >= 64` this is undefined behavior in C++ (right-shifting a 64-bit value by an amount greater than or equal to its width). On x86-64 the hardware `SHR` instruction interprets the shift count modulo 64, so `>> 64` becomes `>> 0` — a no-op. `v_a` is never cleared, and the next output word accumulates all bits from the previous word on top of the correct remainder bits, corrupting every packed determinant that spans more than one word.

### When does it trigger?

The bug fires whenever the packed representation requires more than one 64-bit word, i.e. `total_bit_length > bit_length_b` with `bit_length_b = 64`. Concretely:

| Mode | `total_bit_length` | condition for bug |
|------|-------------------|-------------------|
| TPB  | `norb`            | `norb > 64`       |
| GDB  | `2×norb`          | `norb > 32`       |

### Fix

```cpp
// Both the single-vector and multi-vector overloads of change_bitlength:
v_a = (bit_length_b >= 64) ? 0 : (v_a >> bit_length_b);
```

When `bit_length_b >= 64` all 64 bits of `v_a` have been consumed into the current output word, so the correct residual is exactly 0. The ternary avoids the UB shift entirely.

> **Note:** the multi-vector overload already had a partial fix for the related `maxbit_b` computation (the `1 << 64` UB was handled separately), but the corresponding fix for the shift was missing