### PR TITLE
caop: add reproducible --seed option to Davidson initial vector

### DIFF
--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -18,7 +18,8 @@ namespace sbd {
 		      MPI_Comm h_comm,
 		      MPI_Comm b_comm,
 		      MPI_Comm t_comm,
-		      int init) {
+		      int init,
+		      size_t seed) {
     int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
     int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
     int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
@@ -28,7 +29,7 @@ namespace sbd {
     if( init == 0 ) {
       if( mpi_rank_t == 0 ) {
 	w.resize(basis.size());
-	Randomize(w,b_comm,h_comm);
+	Randomize(w,b_comm,h_comm,seed);
       }
       MpiBcast(w,0,t_comm);
     }
@@ -48,7 +49,8 @@ namespace sbd {
 		int max_iteration,
 		int num_block,
 		int num_initvec,
-		RealT eps) {
+		RealT eps,
+		size_t seed) {
 
     // RealT eps_reg = 1.0e-12;
     size_t w_size = W.size();
@@ -88,7 +90,7 @@ namespace sbd {
 	if( mpi_rank_t == 0 ) {
 	  if( mpi_rank_h == 0 ) {
 	    V[iv].resize(w_size);
-	    Randomize(V[iv],b_comm);
+	    Randomize(V[iv],b_comm,seed+iv);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    Normalize(V[iv],vnrm,b_comm);
@@ -106,7 +108,7 @@ namespace sbd {
 	  C[iv][is] = V[iv][is];
 	}
       }
-      
+
       for(int ib=0; ib < nb; ib++) {
 	Zero(HC[ib]);
 	mult(hii,C[ib],HC[ib],
@@ -248,7 +250,8 @@ namespace sbd {
 		int max_iteration,
 		int num_block,
 		int num_initvec,
-		RealT eps) {
+		RealT eps,
+		size_t seed) {
 
     // RealT eps_reg = 1.0e-12;
     size_t w_size = W.size();
@@ -288,7 +291,7 @@ namespace sbd {
 	if( mpi_rank_t == 0 ) {
 	  if( mpi_rank_h == 0 ) {
 	    V[iv].resize(w_size);
-	    Randomize(V[iv],b_comm);
+	    Randomize(V[iv],b_comm,seed+iv);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    Normalize(V[iv],vnrm,b_comm);

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -21,6 +21,7 @@ namespace sbd {
       int max_iv = 1;
       double eps = 1.0e-4;
       int init = 0;
+      size_t seed = 0;
 
       size_t system_size = 64;
       size_t bit_length = 32;
@@ -67,6 +68,9 @@ namespace sbd {
 	}
 	if( std::string(argv[i]) == "--init" ) {
 	  sbd_data.init = std::atoi(argv[++i]);
+	}
+	if( std::string(argv[i]) == "--seed" ) {
+	  sbd_data.seed = std::stoull(argv[++i]);
 	}
 	if( std::string(argv[i]) == "--do_sort_basis" ) {
 	  if( std::atoi(argv[++i]) != 0 ) {
@@ -130,6 +134,21 @@ namespace sbd {
       int max_nb = sbd_data.max_nb;
       int max_iv = sbd_data.max_iv;
       int init   = sbd_data.init;
+      size_t seed = sbd_data.seed;
+      bool seed_was_random = (seed == 0);
+      if (seed == 0) {
+        if (mpi_rank == 0) {
+          seed = static_cast<size_t>(
+            std::chrono::high_resolution_clock::now().time_since_epoch().count());
+        }
+        unsigned long long bcast_seed = (unsigned long long)seed;
+        MPI_Bcast(&bcast_seed, 1, MPI_UNSIGNED_LONG_LONG, 0, comm);
+        seed = (size_t)bcast_seed;
+      }
+      if (mpi_rank == 0) {
+        std::cout << "# seed: " << seed
+                  << (seed_was_random ? " (random)" : " (user-specified)") << std::endl;
+      }
       double eps = sbd_data.eps;
       size_t system_size = sbd_data.system_size;
       size_t bit_length = sbd_data.bit_length;
@@ -158,7 +177,7 @@ namespace sbd {
       auto time_start_init = std::chrono::high_resolution_clock::now();
       std::vector<ElemT> W;
       if ( loadname.empty() ) {
-	InitVectorCAOP(W,basis,h_comm,b_comm,t_comm,init);
+	InitVectorCAOP(W,basis,h_comm,b_comm,t_comm,init,seed);
       } else {
 	LoadWavefunction(loadname,basis,h_comm,b_comm,t_comm,W);
       }
@@ -180,7 +199,7 @@ namespace sbd {
 	if( method == 0 ) {
 	  Davidson(hii,W,basis,bit_length,slide,H,sign,
 		   h_comm,b_comm,t_comm,
-		   max_it,max_nb,max_iv,eps);
+		   max_it,max_nb,max_iv,eps,seed);
 	} else if ( method == 2 ) {
 	  Lanczos(hii,W,basis,bit_length,slide,H,sign,
 		  h_comm,b_comm,t_comm,
@@ -244,7 +263,7 @@ namespace sbd {
 	if( method == 1 ) {
 	  Davidson(hii,ib,ik,hij,W,slide,
 		   h_comm,b_comm,t_comm,
-		   max_it,max_nb,max_iv,eps);
+		   max_it,max_nb,max_iv,eps,seed);
 	} else if ( method == 3 ) {
 	  Lanczos(hii,ib,ik,hij,W,slide,
 		  h_comm,b_comm,t_comm,

--- a/include/sbd/framework/dm_vector.h
+++ b/include/sbd/framework/dm_vector.h
@@ -97,29 +97,58 @@ namespace sbd {
     x = std::complex<double>(dist(gen),dist(gen));
   }
 
+// Hash (seed, global_element_index) -> uniform double in (-1,1).
+// Bijective mix based on splitmix64 finalizer; fast enough for per-element use.
+  static inline unsigned long long sbd_elem_hash(size_t seed, size_t idx) {
+    unsigned long long x = (unsigned long long)seed * 6364136223846793005ULL
+                         + (unsigned long long)idx  * 2862933555777941757ULL;
+    x ^= x >> 30; x *= 0xbf58476d1ce4e5b9ULL;
+    x ^= x >> 27; x *= 0x94d049bb133111ebULL;
+    return x ^ (x >> 31);
+  }
+
+  static inline double sbd_hash_to_uniform(unsigned long long h) {
+    return (double)(h >> 11) * (2.0 / 9007199254740992.0) - 1.0;
+  }
+
+  template <typename ElemT>
+  void apply_dist_seeded(ElemT & x, size_t seed, size_t idx) {
+    x = ElemT(sbd_hash_to_uniform(sbd_elem_hash(seed, idx)));
+  }
+
+  template<>
+  void apply_dist_seeded(std::complex<double> & x, size_t seed, size_t idx) {
+    x = std::complex<double>(sbd_hash_to_uniform(sbd_elem_hash(seed, 2*idx)),
+                             sbd_hash_to_uniform(sbd_elem_hash(seed, 2*idx + 1)));
+  }
+
   template <typename ElemT>
   void Randomize(std::vector<ElemT> & X,
 		 MPI_Comm b_comm,
-		 MPI_Comm h_comm) {
+		 MPI_Comm h_comm,
+		 size_t seed) {
     using RealT = typename GetRealType<ElemT>::RealT;
     int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
     int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
     int nth = omp_get_max_threads();
     RealT array[SBD_MAX_THREADS];
     RealT sum=0.0;
+    unsigned long long global_offset = 0;
+    if (mpi_size_b > 1) {
+      unsigned long long local_size = (unsigned long long)X.size();
+      MPI_Exscan(&local_size, &global_offset, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, b_comm);
+    }
+// Deterministic by global element index: reproducible for any (nranks, nthreads).
 // use Kahan summation for each thread and add the private sums in deterministic order
     #pragma omp parallel
     {
-      unsigned int seed = static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
-      std::mt19937 gen(seed);
-      std::uniform_real_distribution<RealT> dist(-1,1);
       int tid = omp_get_thread_num();
       RealT mysum = 0.0;
       RealT eps   = 0.0;
       RealT val, tmp;
       #pragma omp for schedule(static)
       for(size_t is=0; is < X.size(); is++) {
-	apply_dist(X[is],gen);
+        apply_dist_seeded(X[is], seed, (size_t)global_offset + is);
         val = GetReal( Conjugate(X[is]) * X[is] ) - eps;
         tmp = mysum + val;
         eps = (tmp - mysum) - val;
@@ -150,25 +179,29 @@ namespace sbd {
 
   template <typename ElemT>
   void Randomize(std::vector<ElemT> & X,
-		 MPI_Comm b_comm) {
+		 MPI_Comm b_comm,
+		 size_t seed) {
     using RealT = typename GetRealType<ElemT>::RealT;
     int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
     int nth = omp_get_max_threads();
     RealT array[SBD_MAX_THREADS];
     RealT sum=0.0;
+    unsigned long long global_offset = 0;
+    if (mpi_size_b > 1) {
+      unsigned long long local_size = (unsigned long long)X.size();
+      MPI_Exscan(&local_size, &global_offset, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, b_comm);
+    }
+// Deterministic by global element index: reproducible for any (nranks, nthreads).
 // use Kahan summation for each thread and add the private sums in deterministic order
     #pragma omp parallel
     {
-      unsigned int seed = static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
-      std::mt19937 gen(seed);
-      std::uniform_real_distribution<RealT> dist(-1,1);
       int tid = omp_get_thread_num();
       RealT mysum = 0.0;
       RealT eps   = 0.0;
       RealT val, tmp;
       #pragma omp for schedule(static)
       for(size_t is=0; is < X.size(); is++) {
-	apply_dist(X[is],gen);
+        apply_dist_seeded(X[is], seed, (size_t)global_offset + is);
         val = GetReal( Conjugate(X[is]) * X[is] ) - eps;
         tmp = mysum + val;
         eps = (tmp - mysum) - val;


### PR DESCRIPTION
Randomize() now uses a per-element hash (splitmix64-style bijection of seed and global element index) instead of per-thread RNG seeding. MPI_Exscan gives each b_comm rank its global offset so element i always receives hash(seed, i) regardless of rank count or thread count.

sbdiag: if --seed is not supplied, a clock-based seed is generated on rank 0 and broadcast to all ranks, then printed as "# seed: N (random)" or "# seed: N (user-specified)".

davidson: multi-initvec restart uses seed+iv to give each additional vector a distinct, reproducible starting direction.