### PR TITLE
add CMake build system with multi-platform presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,109 @@
+cmake_minimum_required(VERSION 3.20)
+project(SBD LANGUAGES CXX VERSION 0.1)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# ── GPU backend ───────────────────────────────────────────────────────────────
+set(SBD_GPU_BACKEND "none" CACHE STRING "GPU backend: none | thrust | omp5")
+set_property(CACHE SBD_GPU_BACKEND PROPERTY STRINGS none thrust omp5)
+
+# Architecture token: cc90 (GH200/H100), sm_80 (A100), gfx90a (MI250X), …
+set(SBD_GPU_ARCH "cc90" CACHE STRING "GPU architecture for the chosen backend")
+
+# ── Feature flags ─────────────────────────────────────────────────────────────
+option(SBD_THRUST_SAFE_MPI_ALLREDUCE   "Safe Thrust MPI allreduce"                         OFF)
+option(SBD_TRADMODE                    "Traditional (non-Thrust) CPU mode for tpb"         OFF)
+option(SBD_USE_NVTX                    "NVTX profiling annotations"                        OFF)
+option(SBD_USE_NCCL                    "Link against NCCL"                                 OFF)
+option(SBD_USE_CUBLAS                  "Link against cuBLAS"                               OFF)
+option(SBD_USE_RANK_DISTRIBUTION       "Enable rank distribution"                          OFF)
+option(SBD_USE_BLOCK_RANK_DISTRIBUTION "Enable block rank distribution"                    OFF)
+option(SBD_REORDER_INDEX_ARRAY         "Enable index array reordering"                     OFF)
+option(SBD_USE_32BIT_PARITY            "Use 32-bit parity"                                 OFF)
+option(SBD_USE_THRUST_NOSYNC           "Thrust nosync mode"                                OFF)
+option(SBD_SBDIAG_DEBUG                "SBD diagnostic debug output"                       OFF)
+option(SBD_COMPLEX                     "Use complex<double> element type (-D_COMPLEX)"     OFF)
+
+# ── Compiler diagnostics ─────────────────────────────────────────────────────
+# nvc++ emits noisy warnings for unused variables/functions in template-heavy
+# headers. Suppress globally.
+# Note: CMAKE_CXX_COMPILER_ID is "NVHPC" (not "NVIDIA") for nvc++ in CMake
+# 3.20+, but it is not populated during the main configure pass under Cray PE
+# cross-compile mode (compiler check is skipped). PE_ENV=NVIDIA is the
+# reliable signal; CMAKE_CXX_COMPILER matches nvc++ for standalone builds.
+if(CMAKE_CXX_COMPILER MATCHES "nvc[+][+]" OR "$ENV{PE_ENV}" STREQUAL "NVIDIA")
+  add_compile_options(
+    "--diag_suppress=declared_but_not_referenced,set_but_not_used,cuda_compile"
+  )
+endif()
+
+# ── MPI / OpenMP / BLAS / LAPACK ─────────────────────────────────────────────
+# With CMAKE_SYSTEM_NAME=CrayLinuxEnvironment, CMake configures search paths
+# and compiler wrappers from the active PrgEnv-* module automatically.
+find_package(MPI REQUIRED CXX)
+find_package(OpenMP REQUIRED CXX)
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+
+# ── SBD header-only interface target ─────────────────────────────────────────
+add_library(sbd_headers INTERFACE)
+target_include_directories(sbd_headers INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+)
+
+# ── Diag-app helper ───────────────────────────────────────────────────────────
+# Wire up libraries, feature defines, and GPU backend for a diag executable.
+function(sbd_configure_diag target)
+  target_link_libraries(${target} PRIVATE
+    sbd_headers
+    MPI::MPI_CXX
+    OpenMP::OpenMP_CXX
+    BLAS::BLAS
+    LAPACK::LAPACK
+  )
+
+  target_compile_definitions(${target} PRIVATE
+    $<$<BOOL:${SBD_COMPLEX}>:_COMPLEX>
+    $<$<BOOL:${SBD_TRADMODE}>:SBD_TRADMODE>
+    $<$<BOOL:${SBD_USE_RANK_DISTRIBUTION}>:SBD_USE_RANK_DISTRIBUTION>
+    $<$<BOOL:${SBD_USE_BLOCK_RANK_DISTRIBUTION}>:SBD_USE_BLOCK_RANK_DISTRIBUTION>
+    $<$<BOOL:${SBD_REORDER_INDEX_ARRAY}>:SBD_REORDER_INDEX_ARRAY>
+    $<$<BOOL:${SBD_USE_32BIT_PARITY}>:SBD_USE_32BIT_PARITY>
+    $<$<BOOL:${SBD_SBDIAG_DEBUG}>:SBD_SBDIAG_DEBUG>
+  )
+
+  if(SBD_GPU_BACKEND STREQUAL "thrust")
+    target_compile_definitions(${target} PRIVATE
+      SBD_THRUST
+      $<$<BOOL:${SBD_THRUST_SAFE_MPI_ALLREDUCE}>:SBD_THRUST_SAFE_MPI_ALLREDUCE>
+      $<$<BOOL:${SBD_USE_NVTX}>:SBD_USE_NVTX>
+      $<$<BOOL:${SBD_USE_NCCL}>:SBD_USE_NCCL>
+      $<$<BOOL:${SBD_USE_CUBLAS}>:SBD_USE_CUBLAS>
+      $<$<BOOL:${SBD_USE_THRUST_NOSYNC}>:SBD_USE_THRUST_NOSYNC>
+    )
+    target_compile_options(${target} PRIVATE
+      -cuda
+      "-gpu=${SBD_GPU_ARCH},mem:unified,interceptdeallocations"
+    )
+    target_link_options(${target} PRIVATE
+      -cuda
+      "-gpu=${SBD_GPU_ARCH},mem:unified,interceptdeallocations"
+    )
+  elseif(SBD_GPU_BACKEND STREQUAL "omp5")
+    target_compile_definitions(${target} PRIVATE SBD_TRADMODE USE_OMP_OFFLOAD)
+    target_compile_options(${target} PRIVATE -mp=gpu "-gpu=${SBD_GPU_ARCH}")
+    target_link_options(${target}   PRIVATE -mp=gpu "-gpu=${SBD_GPU_ARCH}")
+  endif()
+endfunction()
+
+# ── Apps ──────────────────────────────────────────────────────────────────────
+add_subdirectory(apps/caop_selected_basis_diagonalization)
+add_subdirectory(apps/chemistry_gdb_selected_basis_diagonalization)
+add_subdirectory(apps/chemistry_tpb_selected_basis_diagonalization)
+add_subdirectory(apps/gen_dets)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,84 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 20, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "macos-cpu",
+      "displayName": "macOS CPU (system Clang / homebrew OpenMPI + OpenBLAS)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/macos-cpu",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SBD_GPU_BACKEND": "none"
+      }
+    },
+    {
+      "name": "linux-cpu",
+      "displayName": "Linux CPU (GCC / system MPI / BLAS)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/linux-cpu",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SBD_GPU_BACKEND": "none"
+      }
+    },
+    {
+      "name": "craype-thrust",
+      "displayName": "Cray PE + nvc++ Thrust (GH200 / cc90)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/craype-thrust",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":              "Release",
+        "CMAKE_SYSTEM_NAME":             "CrayLinuxEnvironment",
+        "SBD_GPU_BACKEND":               "thrust",
+        "SBD_GPU_ARCH":                  "cc90",
+        "SBD_THRUST_SAFE_MPI_ALLREDUCE": "ON"
+      }
+    },
+    {
+      "name": "nvhpc-thrust",
+      "displayName": "Standalone nvc++ + Thrust (system MPI, cc90)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/nvhpc-thrust",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/nvhpc.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":              "Release",
+        "SBD_GPU_BACKEND":               "thrust",
+        "SBD_GPU_ARCH":                  "cc90",
+        "SBD_THRUST_SAFE_MPI_ALLREDUCE": "ON"
+      }
+    },
+    {
+      "name": "omp5-nvidia",
+      "displayName": "NVIDIA GPU — OpenMP 5 offload via nvc++ (cc100)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/omp5-nvidia",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/nvhpc.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SBD_GPU_BACKEND":  "omp5",
+        "SBD_GPU_ARCH":     "cc100"
+      }
+    },
+    {
+      "name": "omp5-amd",
+      "displayName": "AMD GPU — OpenMP 5 offload via amdclang++ (gfx90a / MI250X)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/omp5-amd",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/amdclang.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SBD_GPU_BACKEND":  "omp5",
+        "SBD_GPU_ARCH":     "gfx90a"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "macos-cpu",     "configurePreset": "macos-cpu" },
+    { "name": "linux-cpu",     "configurePreset": "linux-cpu" },
+    { "name": "craype-thrust", "configurePreset": "craype-thrust" },
+    { "name": "nvhpc-thrust",  "configurePreset": "nvhpc-thrust" },
+    { "name": "omp5-nvidia",   "configurePreset": "omp5-nvidia" },
+    { "name": "omp5-amd",      "configurePreset": "omp5-amd" }
+  ]
+}

--- a/apps/caop_selected_basis_diagonalization/CMakeLists.txt
+++ b/apps/caop_selected_basis_diagonalization/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(caop_diag main.cc)
+
+set_target_properties(caop_diag PROPERTIES
+  OUTPUT_NAME diag
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/apps/caop_selected_basis_diagonalization"
+)
+
+sbd_configure_diag(caop_diag)

--- a/apps/chemistry_gdb_selected_basis_diagonalization/CMakeLists.txt
+++ b/apps/chemistry_gdb_selected_basis_diagonalization/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(gdb_diag main.cc)
+
+set_target_properties(gdb_diag PROPERTIES
+  OUTPUT_NAME diag
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/apps/chemistry_gdb_selected_basis_diagonalization"
+)
+
+sbd_configure_diag(gdb_diag)

--- a/apps/chemistry_tpb_selected_basis_diagonalization/CMakeLists.txt
+++ b/apps/chemistry_tpb_selected_basis_diagonalization/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(tpb_diag main.cc)
+
+set_target_properties(tpb_diag PROPERTIES
+  OUTPUT_NAME diag
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/apps/chemistry_tpb_selected_basis_diagonalization"
+)
+
+sbd_configure_diag(tpb_diag)

--- a/apps/gen_dets/CMakeLists.txt
+++ b/apps/gen_dets/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(gen_dets_gdet main.cc)
+
+set_target_properties(gen_dets_gdet PROPERTIES
+  OUTPUT_NAME gdet
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/apps/gen_dets"
+)
+
+target_link_libraries(gen_dets_gdet PRIVATE
+  sbd_headers
+  MPI::MPI_CXX
+  OpenMP::OpenMP_CXX
+  BLAS::BLAS
+  LAPACK::LAPACK
+)
+
+target_compile_definitions(gen_dets_gdet PRIVATE
+  $<$<BOOL:${SBD_SBDIAG_DEBUG}>:SBD_SBDIAG_DEBUG>
+)
+

--- a/apps/gen_dets/main.cc
+++ b/apps/gen_dets/main.cc
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <cstdint>
+#include <ctime>
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/cmake/toolchains/amdclang.cmake
+++ b/cmake/toolchains/amdclang.cmake
@@ -1,0 +1,13 @@
+# AMD ROCm toolchain — amdclang++ with system MPI wrapper
+#
+# Assumes the ROCm installation is on PATH (e.g. /opt/rocm/bin) and
+# mpicxx wraps amdclang++.
+# OpenMP 5 GPU offload uses -fopenmp --offload-arch=<arch>.
+
+set(CMAKE_CXX_COMPILER mpicxx)
+set(CMAKE_C_COMPILER   mpicc)
+
+set(OpenMP_CXX_FLAGS      "-fopenmp --offload-arch=${SBD_GPU_ARCH}")
+set(OpenMP_CXX_LIB_NAMES  "")
+set(OpenMP_CXX_LIBRARIES  "")
+set(OpenMP_CXX_FLAGS_INIT "-fopenmp")

--- a/cmake/toolchains/nvhpc.cmake
+++ b/cmake/toolchains/nvhpc.cmake
@@ -1,0 +1,13 @@
+# NVHPC standalone toolchain — nvc++ with system MPI wrapper
+#
+# Assumes mpic++ wraps nvc++ and is on PATH.
+# BLAS/LAPACK are found via FindBLAS/FindLAPACK (system or module-provided).
+
+set(CMAKE_CXX_COMPILER mpic++)
+set(CMAKE_C_COMPILER   mpicc)
+
+# nvc++ uses -mp for OpenMP
+set(OpenMP_CXX_FLAGS      "-mp")
+set(OpenMP_CXX_LIB_NAMES  "")
+set(OpenMP_CXX_LIBRARIES  "")
+set(OpenMP_CXX_FLAGS_INIT "-mp")


### PR DESCRIPTION
Adds CMakeLists.txt, CMakePresets.json, and per-app CMakeLists for all
four apps (caop, gdb, tpb, gen_dets). Common options, libraries, and GPU
backend flags are centralised in sbd_configure_diag(). Presets cover
macos-cpu, linux-cpu, craype-thrust (CrayLinuxEnvironment + nvc++),
nvhpc-thrust (standalone nvc++), omp5-nvidia, and omp5-amd. Toolchain
files for nvhpc and amdclang in cmake/toolchains/.

Also add missing chrono/cstdint/ctime includes to gen_dets/main.cc.
