### PR TITLE
gdb: enable ElemT=complex<double> for CPU and GPU builds

### DIFF
--- a/apps/chemistry_gdb_selected_basis_diagonalization/main.cc
+++ b/apps/chemistry_gdb_selected_basis_diagonalization/main.cc
@@ -232,8 +232,8 @@ int main(int argc, char * argv[]) {
   if( one_p_rdm.size() != 0 ) {
     if ( mpi_rank == 0 ) {
       double zerobody = 0.0;
-      double onebody = 0.0;
-      double twobody = 0.0;
+      Elem onebody = 0.0;
+      Elem twobody = 0.0;
       double I0;
       sbd::oneInt<double> I1;
       sbd::twoInt<double> I2;

--- a/include/sbd/caop/basic/carryover.h
+++ b/include/sbd/caop/basic/carryover.h
@@ -29,7 +29,7 @@ namespace sbd {
     std::vector<RealT> r(w.size());
 #pragma omp parallel for
     for(size_t i=0; i < w.size(); i++) {
-      r[i] = GetReal(Conjugate(w[i])*w[i]);
+      r[i] = SquaredNorm(w[i]);
     }
     std::vector<size_t> ranking(r.size());
     mpi_find_ranking(r,ranking,b_comm);

--- a/include/sbd/chemistry/basic/correlation.h
+++ b/include/sbd/chemistry/basic/correlation.h
@@ -26,19 +26,19 @@ namespace sbd {
     for(int i=0; i < num_closed; i++) {
       int oi = closed.at(i)/2;
       int si = closed.at(i)%2;
-      onebody[si][oi+norb*oi] += Conjugate(WeightI)*WeightI;
+      onebody[si][oi+norb*oi] += SquaredNorm(WeightI);
       for(int j=i+1; j < num_closed; j++) {
 	int oj = closed.at(j)/2;
 	int sj = closed.at(j)%2;
 	twobody[si+2*sj][oi+norb*oj+norb*norb*oi+norb*norb*norb*oj]
-	  += Conjugate(WeightI) * WeightI;
+	  += SquaredNorm(WeightI);
 	twobody[sj+2*si][oj+norb*oi+norb*norb*oj+norb*norb*norb*oi]
-	  += Conjugate(WeightI) * WeightI;
+	  += SquaredNorm(WeightI);
 	if( si == sj ) {
 	  twobody[si+2*sj][oi+norb*oj+norb*norb*oj+norb*norb*norb*oi]
-	    += -Conjugate(WeightI) * WeightI;
+	    += -SquaredNorm(WeightI);
 	  twobody[sj+2*si][oj+norb*oi+norb*norb*oi+norb*norb*norb*oj]
-	    += -Conjugate(WeightI) * WeightI;
+	    += -SquaredNorm(WeightI);
 	}
       }
     }
@@ -71,19 +71,19 @@ namespace sbd {
       int oi = closed[i]/2;
       int si = closed[i]%2;
 #pragma omp atomic update
-      oneBody[si*norb2 + oi + norb*oi] += Conjugate(WeightI)*WeightI;
+      oneBody[si*norb2 + oi + norb*oi] += SquaredNorm(WeightI);
       for(int j=i+1; j < num_closed; j++) {
         int oj = closed[j]/2;
         int sj = closed[j]%2;
 #pragma omp atomic update
-        twoBody[(si+2*sj)*norb4 + oi+norb*oj+norb*norb*oi+norb*norb*norb*oj] += Conjugate(WeightI) * WeightI;
+        twoBody[(si+2*sj)*norb4 + oi+norb*oj+norb*norb*oi+norb*norb*norb*oj] += SquaredNorm(WeightI);
 #pragma omp atomic update
-        twoBody[(sj+2*si)*norb4 + oj+norb*oi+norb*norb*oj+norb*norb*norb*oi] += Conjugate(WeightI) * WeightI;
+        twoBody[(sj+2*si)*norb4 + oj+norb*oi+norb*norb*oj+norb*norb*norb*oi] += SquaredNorm(WeightI);
         if( si == sj ) {
 #pragma omp atomic update
-          twoBody[(si+2*sj)*norb4 + oi+norb*oj+norb*norb*oj+norb*norb*norb*oi] += -Conjugate(WeightI) * WeightI;
+          twoBody[(si+2*sj)*norb4 + oi+norb*oj+norb*norb*oj+norb*norb*norb*oi] += -SquaredNorm(WeightI);
 #pragma omp atomic update
-          twoBody[(sj+2*si)*norb4 + oj+norb*oi+norb*norb*oi+norb*norb*norb*oj] += -Conjugate(WeightI) * WeightI;
+          twoBody[(sj+2*si)*norb4 + oj+norb*oi+norb*norb*oi+norb*norb*norb*oj] += -SquaredNorm(WeightI);
         }
       }
     }

--- a/include/sbd/chemistry/basic/correlation_thrust.h
+++ b/include/sbd/chemistry/basic/correlation_thrust.h
@@ -6,6 +6,8 @@
 #ifndef SBD_CHEMISTRY_BASIC_CORRELATION_THRUST_H
 #define SBD_CHEMISTRY_BASIC_CORRELATION_THRUST_H
 
+#include "sbd/framework/cuda_utility.h"
+
 namespace sbd
 {
 
@@ -42,16 +44,16 @@ public:
             if (this->getocc(det, i)) {
                 int oi = i / 2;
                 int si = i % 2;
-                atomicAdd(onebody + si * onebody_size + oi + this->norbs * oi, Conjugate(WeightI) * WeightI);
+                sbd::atomic_add_real(onebody + si * onebody_size + oi + this->norbs * oi, SquaredNorm(WeightI));
                 for (int j = i + 1; j < 2 * this->norbs; j++) {
                     if (this->getocc(det, j)) {
                         int oj = j / 2;
                         int sj = j % 2;
-                        atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), Conjugate(WeightI) * WeightI);
-                        atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), Conjugate(WeightI) * WeightI);
+                        sbd::atomic_add_real(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), SquaredNorm(WeightI));
+                        sbd::atomic_add_real(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), SquaredNorm(WeightI));
                         if (si == sj) {
-                            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), -Conjugate(WeightI) * WeightI);
-                            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), -Conjugate(WeightI) * WeightI);
+                            sbd::atomic_add_real(twobody + (si + 2 * sj) * twobody_size + (oi + this->norbs * oj + this->norbs * this->norbs * oj + this->norbs * this->norbs * this->norbs * oi), -SquaredNorm(WeightI));
+                            sbd::atomic_add_real(twobody + (sj + 2 * si) * twobody_size + (oj + this->norbs * oi + this->norbs * this->norbs * oi + this->norbs * this->norbs * this->norbs * oj), -SquaredNorm(WeightI));
                         }
                     }
                 }
@@ -74,7 +76,7 @@ public:
         int si = i % 2;
         int oa = a / 2;
         int sa = a % 2;
-        atomicAdd(onebody + si * onebody_size + (oi + this->norbs * oa), Conjugate(WeightI) * WeightJ * ElemT(sgn));
+        sbd::atomic_add(onebody + si * onebody_size + (oi + this->norbs * oa), Conjugate(WeightI) * WeightJ * ElemT(sgn));
         size_t one = 1;
         for (int x = 0; x < this->D_size; x++) {
             size_t bits = det[x];
@@ -84,12 +86,12 @@ public:
                     int oj = soj / 2;
                     int sj = soj % 2;
 
-                    atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
-                    atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
+                    sbd::atomic_add(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
+                    sbd::atomic_add(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(sgn));
 
                     if (si == sj) {
-                        atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
-                        atomicAdd(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
+                        sbd::atomic_add(twobody + (si + 2 * sj) * twobody_size + (oa + oj * this->norbs + oj * this->norbs * this->norbs + oi * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
+                        sbd::atomic_add(twobody + (sj + 2 * si) * twobody_size + (oj + oa * this->norbs + oi * this->norbs * this->norbs + oj * this->norbs * this->norbs * this->norbs), Conjugate(WeightI) * WeightJ * ElemT(-sgn));
                     }
                 }
                 bits >>= 1;
@@ -127,13 +129,13 @@ public:
         int sb = B % 2;
 
         if (si == sa) {
-            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
-            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
+            sbd::atomic_add(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
+            sbd::atomic_add(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(sgn) * Conjugate(WeightI) * WeightJ);
         }
 
         if (si == sb) {
-            atomicAdd(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
-            atomicAdd(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
+            sbd::atomic_add(twobody + (si + 2 * sj) * twobody_size + (oa + this->norbs * ob + this->norbs * this->norbs * (oj + this->norbs * oi)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
+            sbd::atomic_add(twobody + (sj + 2 * si) * twobody_size + (ob + this->norbs * oa + this->norbs * this->norbs * (oi + this->norbs * oj)), ElemT(-sgn) * Conjugate(WeightI) * WeightJ);
         }
     }
 };

--- a/include/sbd/chemistry/basic/davidson_thrust.h
+++ b/include/sbd/chemistry/basic/davidson_thrust.h
@@ -39,10 +39,13 @@ struct Determine_kernel {
     }
     __host__ __device__ void operator()(int is)
     {
-        if (std::abs(e0 - dii[is]) > eps_reg) {
-            C[is] = R[is] / (e0 - dii[is]);
+        // Use squared comparison to avoid std::abs(complex) which calls hypot
+        // (not translatable to device code by nvc++).
+        auto denom = e0 - dii[is];
+        if (SquaredNorm(denom) > eps_reg * eps_reg) {
+            C[is] = R[is] / denom;
         } else {
-            C[is] = R[is] / (e0 - dii[is] - eps_reg);
+            C[is] = R[is] / (denom - eps_reg);
         }
     }
 };

--- a/include/sbd/chemistry/gdb/carryover.h
+++ b/include/sbd/chemistry/gdb/carryover.h
@@ -19,7 +19,7 @@ namespace sbd {
       std::vector<RealT> r(w.size());
 #pragma omp parallel for
       for(size_t i=0; i < w.size(); i++) {
-	r[i] = Conjugate(w[i])*w[i];
+	r[i] = SquaredNorm(w[i]);
       }
       std::vector<size_t> ranking(r.size());
       mpi_find_ranking(r,ranking,b_comm);

--- a/include/sbd/chemistry/gdb/occupation.h
+++ b/include/sbd/chemistry/gdb/occupation.h
@@ -24,10 +24,10 @@ namespace sbd {
 	size_t thread_id = omp_get_thread_num();
 	size_t i_begin = thread_id;
 	size_t i_end   = det.size();
-	std::vector<double> local_res(2*oidx.size(),ElemT(0.0));
+	std::vector<double> local_res(2*oidx.size(),0.0);
 	for(size_t i=i_begin; i < i_end; i+=num_threads) {
 	  for(size_t io=0; io < oidx.size(); io++) {
-	    double weight = GetReal(Conjugate(w[i]) * w[i]);
+	    double weight = SquaredNorm(w[i]);
 	    if( getocc(det[i],bit_length,2*oidx[io]) ) {
 	      local_res[2*io] += weight;
 	    }

--- a/include/sbd/chemistry/gdb/sbdiag.h
+++ b/include/sbd/chemistry/gdb/sbdiag.h
@@ -169,7 +169,7 @@ namespace sbd {
 		  << " sbd: start integral construction" << std::endl;
       }
       auto time_start_model = std::chrono::high_resolution_clock::now();
-      double I0;
+      ElemT I0;
       sbd::oneInt<ElemT> I1;
       sbd::twoInt<ElemT> I2;
       sbd::SetupIntegrals(fcidump,L,N,I0,I1,I2);
@@ -242,7 +242,7 @@ namespace sbd {
       */
 #ifdef SBD_THRUST
 	// multiplyer class for TPB on Thrust
-	MultGDBThrust<double> device_mult;
+	MultGDBThrust<ElemT> device_mult;
 #endif
       if( method == 0 ) {
 
@@ -315,10 +315,10 @@ namespace sbd {
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
 #ifdef SBD_THRUST
     // copyin W
-    thrust::device_vector<double> w_dev(w.size());
+    thrust::device_vector<ElemT> w_dev(w.size());
     thrust::copy_n(w.begin(), w.size(), w_dev.begin());
 
-    thrust::device_vector<double> v(w.size(), 0.0);
+    thrust::device_vector<ElemT> v(w.size(), ElemT(0.0));
 
 	device_mult.run(hii, w_dev, v);
 

--- a/include/sbd/chemistry/tpb/extend.h
+++ b/include/sbd/chemistry/tpb/extend.h
@@ -48,7 +48,7 @@ namespace sbd {
     for(size_t ia=adet_begin; ia < adet_end; ia++) {
       for(size_t ib=bdet_begin; ib < bdet_end; ib++) {
 	size_t idx = (ia - adet_begin) * bdet_size + ib - bdet_begin;
-	RealT weight = GetReal(Conjugate(w[idx])*w[idx]);
+	RealT weight = SquaredNorm(w[idx]);
 	if( weight > cutoff ) {
 	  total_weight_local += weight;
 	  adet_count[ia]++;

--- a/include/sbd/chemistry/tpb/occupation.h
+++ b/include/sbd/chemistry/tpb/occupation.h
@@ -76,8 +76,8 @@ namespace sbd {
 	for(size_t ib = ib_start; ib < ib_end; ib++) {
 	  size_t idx = (ia-ia_start) * ib_size + (ib-ib_start);
 	  for(size_t io=0; io < oIdx.size(); io++) {
-	    local_res[2*io]   += Conjugate(W[idx]) * W[idx] * daop[io][ia-ia_start];
-	    local_res[2*io+1] += Conjugate(W[idx]) * W[idx] * dbop[io][ib-ib_start];
+	    local_res[2*io]   += SquaredNorm(W[idx]) * daop[io][ia-ia_start];
+	    local_res[2*io+1] += SquaredNorm(W[idx]) * dbop[io][ib-ib_start];
 	  }
 	}
       }

--- a/include/sbd/chemistry/tpb/rdmat.h
+++ b/include/sbd/chemistry/tpb/rdmat.h
@@ -48,8 +48,7 @@ namespace sbd {
     for(size_t ia=adet_start; ia < adet_end; ia++) {
       D[ia] = 0.0;
       for(size_t ib=bdet_start; ib < bdet_end; ib++) {
-	D[ia] += GetReal(Conjugate(W[(ia-adet_start)*bdet_range+ib-bdet_start])
-			 *W[(ia-adet_start)*bdet_range+ib-bdet_start]);
+	D[ia] += SquaredNorm(W[(ia-adet_start)*bdet_range+ib-bdet_start]);
       }
     }
     
@@ -175,8 +174,7 @@ namespace sbd {
     for(size_t ib=bdet_start; ib < bdet_end; ib++) {
       D[ib] = 0.0;
       for(size_t ia=adet_start; ia < adet_end; ia++) {
-	D[ib] += GetReal(Conjugate(W[(ia-adet_start)*bdet_range+ib-bdet_start])
-			 *W[(ia-adet_start)*bdet_range+ib-bdet_start]);
+	D[ib] += SquaredNorm(W[(ia-adet_start)*bdet_range+ib-bdet_start]);
       }
     }
     

--- a/include/sbd/framework/cuda_utility.h
+++ b/include/sbd/framework/cuda_utility.h
@@ -30,4 +30,54 @@
     } while (0)
 #endif
 
+// atomic_add: type-safe atomic accumulation for device kernels.
+// On device: decomposes complex into two double atomics.
+// On host:   falls back to non-atomic += (host path is never used
+//            for actual computation — only compiled for __host__ __device__
+//            correctness).
+namespace sbd {
+
+template <typename T>
+__host__ __device__ inline void atomic_add(T* p, T v)
+{
+#ifdef __CUDA_ARCH__
+    atomicAdd(p, v);
+#else
+    *p += v;
+#endif
+}
+
+template <>
+__host__ __device__ inline void atomic_add(std::complex<double>* p, std::complex<double> v)
+{
+#ifdef __CUDA_ARCH__
+    atomicAdd(reinterpret_cast<double*>(p),     v.real());
+    atomicAdd(reinterpret_cast<double*>(p) + 1, v.imag());
+#else
+    *p += v;
+#endif
+}
+
+// Overload: add a real value to the real part of a complex accumulator.
+__host__ __device__ inline void atomic_add_real(std::complex<double>* p, double v)
+{
+#ifdef __CUDA_ARCH__
+    atomicAdd(reinterpret_cast<double*>(p), v);
+#else
+    *p += std::complex<double>(v, 0.0);
+#endif
+}
+
+// Overload for real types (no-op specialisation needed to avoid ambiguity).
+__host__ __device__ inline void atomic_add_real(double* p, double v)
+{
+#ifdef __CUDA_ARCH__
+    atomicAdd(p, v);
+#else
+    *p += v;
+#endif
+}
+
+} // namespace sbd
+
 #endif // SBD_FRAMEWORK_CUDA_UTILITY_H

--- a/include/sbd/framework/dm_vector.h
+++ b/include/sbd/framework/dm_vector.h
@@ -66,7 +66,7 @@ namespace sbd {
       RealT val, tmp;
       #pragma omp for schedule(static)
       for(size_t is=0; is < X.size(); is++) {
-        val = GetReal( Conjugate(X[is]) * X[is] ) - eps;
+        val = SquaredNorm(X[is]) - eps;
         tmp = mysum + val;
         eps = (tmp - mysum) - val;
         mysum = tmp;
@@ -149,7 +149,7 @@ namespace sbd {
       #pragma omp for schedule(static)
       for(size_t is=0; is < X.size(); is++) {
         apply_dist_seeded(X[is], seed, (size_t)global_offset + is);
-        val = GetReal( Conjugate(X[is]) * X[is] ) - eps;
+        val = SquaredNorm(X[is]) - eps;
         tmp = mysum + val;
         eps = (tmp - mysum) - val;
         mysum = tmp;
@@ -202,7 +202,7 @@ namespace sbd {
       #pragma omp for schedule(static)
       for(size_t is=0; is < X.size(); is++) {
         apply_dist_seeded(X[is], seed, (size_t)global_offset + is);
-        val = GetReal( Conjugate(X[is]) * X[is] ) - eps;
+        val = SquaredNorm(X[is]) - eps;
         tmp = mysum + val;
         eps = (tmp - mysum) - val;
         mysum = tmp;

--- a/include/sbd/framework/thrust_kernels.h
+++ b/include/sbd/framework/thrust_kernels.h
@@ -42,23 +42,52 @@ struct AX_kernel {
 };
 
 
-// dot product
-template <typename ElemT>
-struct dot_product_kernel {
-    ElemT* A;
-    ElemT* B;
+// Binary element-wise kernel: applies f(X[i], Y[i]) for use with
+// precise_reduce_sum_with_function.  The return type is deduced from F.
+template <typename ElemT, typename F>
+struct binary_kernel {
+    const ElemT* X;
+    const ElemT* Y;
+    F f;
 
-    dot_product_kernel(const thrust::device_vector<ElemT>& a, const thrust::device_vector<ElemT>& b)
-    {
-        A = (ElemT*)thrust::raw_pointer_cast(a.data());
-        B = (ElemT*)thrust::raw_pointer_cast(b.data());
-    }
+    binary_kernel(const thrust::device_vector<ElemT>& x,
+                  const thrust::device_vector<ElemT>& y,
+                  F f_in)
+        : X(thrust::raw_pointer_cast(x.data()))
+        , Y(thrust::raw_pointer_cast(y.data()))
+        , f(f_in)
+    {}
 
-    __host__ __device__ ElemT operator()(const size_t i) const
+    __host__ __device__ auto operator()(const size_t i) const
     {
-        return A[i] * B[i];
+        return f(X[i], Y[i]);
     }
 };
+
+template <typename ElemT, typename F>
+binary_kernel<ElemT, F> make_binary_kernel(const thrust::device_vector<ElemT>& x,
+                                            const thrust::device_vector<ElemT>& y,
+                                            F f)
+{
+    return binary_kernel<ElemT, F>(x, y, f);
+}
+
+// squared-norm kernel: returns |A[i]|^2 as double (works for real and complex)
+template <typename ElemT>
+struct norm_kernel {
+    ElemT* A;
+
+    norm_kernel(const thrust::device_vector<ElemT>& a)
+    {
+        A = (ElemT*)thrust::raw_pointer_cast(a.data());
+    }
+
+    __host__ __device__ double operator()(const size_t i) const
+    {
+        return SquaredNorm(A[i]);
+    }
+};
+
 
 template <typename ElemT, typename RealT>
 void Normalize(thrust::device_vector<ElemT>& X,
@@ -83,7 +112,7 @@ void Normalize(thrust::device_vector<ElemT>& X,
     */
 
 #ifndef SBD_USE_CUBLAS
-    auto kernel = dot_product_kernel<RealT>(X, X);
+    auto kernel = norm_kernel<ElemT>(X);
     res = precise_reduce_sum_with_function(kernel, X.size());
     if (comm_size > 1) {
         SBD_NVTX_RANGE_COLOR("MPI_Allreduce", 0);
@@ -210,16 +239,17 @@ void Normalize2(thrust::device_vector<ElemT>& X0,
 }
 #endif
 
-template <typename ElemT, typename RealT>
+template <typename ElemT>
 void InnerProduct(const thrust::device_vector<ElemT>& X,
                   const thrust::device_vector<ElemT>& Y,
-                  RealT& res,
+                  ElemT& res,
                   MPI_Comm comm)
 {
+    using RealT = typename GetRealType<ElemT>::RealT;
     SBD_NVTX_RANGE_COLOR("InnerProduct", __LINE__);
 
-    res = 0.0;
-    RealT sum = 0.0;
+    res = ElemT(0);
+    ElemT sum = ElemT(0);
 
     /*
     // If CUDA native kernel can not be used, use host code
@@ -231,14 +261,38 @@ void InnerProduct(const thrust::device_vector<ElemT>& X,
     */
 
 #ifndef SBD_USE_CUBLAS
-    auto kernel = dot_product_kernel<RealT>(X, Y);
-    sum = precise_reduce_sum_with_function(kernel, X.size());
+    if constexpr (std::is_floating_point_v<ElemT>) {
+        sum = precise_reduce_sum_with_function(
+            make_binary_kernel(X, Y,
+                [] __host__ __device__ (const ElemT& x, const ElemT& y) { return x * y; }),
+            X.size());
+    } else {
+        // conj(X)*Y = (xr*yr + xi*yi) + (xr*yi - xi*yr)*i
+        // Each component reduced independently (Kahan over one product/element).
+        double sum_rr = precise_reduce_sum_with_function(
+            make_binary_kernel(X, Y,
+                [] __host__ __device__ (const ElemT& x, const ElemT& y) { return x.real() * y.real(); }),
+            X.size());
+        double sum_ii = precise_reduce_sum_with_function(
+            make_binary_kernel(X, Y,
+                [] __host__ __device__ (const ElemT& x, const ElemT& y) { return x.imag() * y.imag(); }),
+            X.size());
+        double sum_ri = precise_reduce_sum_with_function(
+            make_binary_kernel(X, Y,
+                [] __host__ __device__ (const ElemT& x, const ElemT& y) { return x.real() * y.imag(); }),
+            X.size());
+        double sum_ir = precise_reduce_sum_with_function(
+            make_binary_kernel(X, Y,
+                [] __host__ __device__ (const ElemT& x, const ElemT& y) { return x.imag() * y.real(); }),
+            X.size());
+        sum = ElemT(sum_rr + sum_ii, sum_ri - sum_ir);
+    }
 #else
     sum = sbd::Dot(X, Y);
 #endif
     {
         SBD_NVTX_RANGE_COLOR("MPI_Allreduce", 0);
-        MPI_Datatype DataT = GetMpiType<RealT>::MpiT;
+        MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
         MPI_Allreduce(&sum, &res, 1, DataT, MPI_SUM, comm);
     }
 }

--- a/include/sbd/framework/type_def.h
+++ b/include/sbd/framework/type_def.h
@@ -28,10 +28,30 @@ namespace sbd {
   template <typename T> inline __host__ __device__ T Conjugate(T a) { return a; }
   template<> inline __host__ __device__ std::complex<float> Conjugate(std::complex<float> a) { return std::conj(a); }
   template<> inline __host__ __device__ std::complex<double> Conjugate(std::complex<double> a) { return std::conj(a); }
+
+  // sbd::SquaredNorm: squared magnitude, safe for GPU device code.
+  // std::norm(complex<T>) dispatches through _Norm_helper which calls std::abs
+  // (hypot), untranslatable by nvc++. These overloads use direct arithmetic.
+  template <typename T> inline __host__ __device__ T SquaredNorm(T x) { return x * x; }
+  template <typename T> inline __host__ __device__ T SquaredNorm(const std::complex<T>& x)
+  { return x.real() * x.real() + x.imag() * x.imag(); }
+
+  // sbd::conj: conjugate, safe for GPU device code.
+  template <typename T> inline __host__ __device__ T conj(T x) { return x; }
+  template <typename T> inline __host__ __device__ std::complex<T> conj(const std::complex<T>& x)
+  { return std::complex<T>(x.real(), -x.imag()); }
 #else
   template <typename T> inline T Conjugate(T a) { return a; }
   template<> inline std::complex<float> Conjugate(std::complex<float> a) { return std::conj(a); }
   template<> inline std::complex<double> Conjugate(std::complex<double> a) { return std::conj(a); }
+
+  template <typename T> inline T SquaredNorm(T x) { return x * x; }
+  template <typename T> inline T SquaredNorm(const std::complex<T>& x)
+  { return x.real() * x.real() + x.imag() * x.imag(); }
+
+  template <typename T> inline T conj(T x) { return x; }
+  template <typename T> inline std::complex<T> conj(const std::complex<T>& x)
+  { return std::complex<T>(x.real(), -x.imag()); }
 #endif
 
   template <typename T> struct GetMpiType { static MPI_Datatype MpiT; };


### PR DESCRIPTION
Allows GDB to build with _COMPLEX and give the same energy when tested on a real Hamiltonian. Not tested on an actual complex Hamiltonian but at least the build no longer fails.

There were many places that expected Conjugate(X)*X to return a double for complex X, which is mathematically true but not in C++, so replaced with new SquaredNorm(X) that returns double.