### PR TITLE
Fix OOM in Correlation() for large NORB: use atomics instead of per-thread copies

### DIFF
--- a/include/sbd/chemistry/basic/correlation.h
+++ b/include/sbd/chemistry/basic/correlation.h
@@ -26,17 +26,22 @@ namespace sbd {
     for(int i=0; i < num_closed; i++) {
       int oi = closed.at(i)/2;
       int si = closed.at(i)%2;
+#pragma omp atomic update
       onebody[si][oi+norb*oi] += Conjugate(WeightI)*WeightI;
       for(int j=i+1; j < num_closed; j++) {
 	int oj = closed.at(j)/2;
 	int sj = closed.at(j)%2;
+#pragma omp atomic update
 	twobody[si+2*sj][oi+norb*oj+norb*norb*oi+norb*norb*norb*oj]
 	  += Conjugate(WeightI) * WeightI;
+#pragma omp atomic update
 	twobody[sj+2*si][oj+norb*oi+norb*norb*oj+norb*norb*norb*oi]
 	  += Conjugate(WeightI) * WeightI;
 	if( si == sj ) {
+#pragma omp atomic update
 	  twobody[si+2*sj][oi+norb*oj+norb*norb*oj+norb*norb*norb*oi]
 	    += -Conjugate(WeightI) * WeightI;
+#pragma omp atomic update
 	  twobody[sj+2*si][oj+norb*oi+norb*norb*oi+norb*norb*norb*oj]
 	    += -Conjugate(WeightI) * WeightI;
 	}
@@ -110,6 +115,7 @@ namespace sbd {
     int si = i % 2;
     int oa = a / 2;
     int sa = a % 2;
+#pragma omp atomic update
     onebody[si][oi+norb*oa] += Conjugate(WeightI) * WeightJ * ElemT(sgn);
     size_t one = 1;
     for(int x=0; x < DetI.size(); x++) {
@@ -120,14 +126,18 @@ namespace sbd {
 	int oj = soj / 2;
 	int sj = soj % 2;
 
+#pragma omp atomic update
 	twobody[si+2*sj][oa+oj*norb+oi*norb*norb+oj*norb*norb*norb] += Conjugate(WeightI) * WeightJ * ElemT(sgn);
+#pragma omp atomic update
 	twobody[sj+2*si][oj+oa*norb+oj*norb*norb+oi*norb*norb*norb] += Conjugate(WeightI) * WeightJ * ElemT(sgn);
-	
+
 	if( si == sj ) {
+#pragma omp atomic update
 	  twobody[si+2*sj][oa+oj*norb+oj*norb*norb+oi*norb*norb*norb] += Conjugate(WeightI) * WeightJ * ElemT(-sgn);
+#pragma omp atomic update
 	  twobody[sj+2*si][oj+oa*norb+oi*norb*norb+oj*norb*norb*norb] += Conjugate(WeightI) * WeightJ * ElemT(-sgn);
 	}
-	
+
 	bits &= ~(one << (pos-1));
       }
     }
@@ -217,12 +227,16 @@ namespace sbd {
     int sb = B % 2;
 
     if( si == sa ) {
+#pragma omp atomic update
       twobody[si+2*sj][oa+norb*ob+norb*norb*(oi+norb*oj)] += ElemT(sgn) * Conjugate(WeightI) * WeightJ;
+#pragma omp atomic update
       twobody[sj+2*si][ob+norb*oa+norb*norb*(oj+norb*oi)] += ElemT(sgn) * Conjugate(WeightI) * WeightJ;
     }
 
     if( si == sb ) {
+#pragma omp atomic update
       twobody[si+2*sj][oa+norb*ob+norb*norb*(oj+norb*oi)] += ElemT(-sgn) * Conjugate(WeightI) * WeightJ;
+#pragma omp atomic update
       twobody[sj+2*si][ob+norb*oa+norb*norb*(oi+norb*oj)] += ElemT(-sgn) * Conjugate(WeightI) * WeightJ;
     }
 

--- a/include/sbd/chemistry/tpb/correlation.h
+++ b/include/sbd/chemistry/tpb/correlation.h
@@ -436,9 +436,6 @@ namespace sbd {
 
     size_t num_threads = 1;
     num_threads = omp_get_max_threads();
-    
-    std::vector<std::vector<std::vector<ElemT>>> onebody_t(num_threads,onebody);
-    std::vector<std::vector<std::vector<ElemT>>> twobody_t(num_threads,twobody);
 
     
     if( mpi_rank_t == 0 ) {
@@ -455,7 +452,7 @@ namespace sbd {
                      +  ib - helper[0].braBetaStart;
             if( ( i % mpi_size_h ) == mpi_rank_h ) {
               DetFromAlphaBeta(adet[ia],bdet[ib],bit_length,norb,DetT);
-              ZeroDiffCorrelation(DetT,W[i],bit_length,norb,onebody_t[thread_id],twobody_t[thread_id]);
+              ZeroDiffCorrelation(DetT,W[i],bit_length,norb,onebody,twobody);
             }
           }
         }
@@ -500,12 +497,12 @@ namespace sbd {
 		  OneDiffCorrelation(DetI,W[braIdx],T[ketIdx],bit_length,norb,
 				     helper[task].SinglesAlphaCrAnSM[ia-helper[task].braAlphaStart][2*j+0],
 				     helper[task].SinglesAlphaCrAnSM[ia-helper[task].braAlphaStart][2*j+1],
-				     onebody_t[thread_id],twobody_t[thread_id]);
+				     onebody,twobody);
 		  /*
 		  DetFromAlphaBeta(adet[ja],bdet[ib],bit_length,norb,DetJ);
 		  CorrelationTermAddition(DetI,DetJ,W[braIdx],T[ketIdx],
 					  bit_length,norb,c,d,
-					  onebody_t[thread_id],twobody_t[thread_id]);
+					  onebody,twobody);
 		  */
 		}
 		// double alpha excitation
@@ -518,12 +515,12 @@ namespace sbd {
 				     helper[task].DoublesAlphaCrAnSM[ia-helper[task].braAlphaStart][4*j+1],
 				     helper[task].DoublesAlphaCrAnSM[ia-helper[task].braAlphaStart][4*j+2],
 				     helper[task].DoublesAlphaCrAnSM[ia-helper[task].braAlphaStart][4*j+3],
-				     onebody_t[thread_id],twobody_t[thread_id]);
+				     onebody,twobody);
 		  /*
 		  DetFromAlphaBeta(adet[ja],bdet[ib],bit_length,norb,DetJ);
 		  CorrelationTermAddition(DetI,DetJ,W[braIdx],T[ketIdx],
 					  bit_length,norb,c,d,
-					  onebody_t[thread_id],twobody_t[thread_id]);
+					  onebody,twobody);
 		  */
 		}
 		
@@ -549,12 +546,12 @@ namespace sbd {
 		  OneDiffCorrelation(DetI,W[braIdx],T[ketIdx],bit_length,norb,
 				     helper[task].SinglesBetaCrAnSM[ib-helper[task].braBetaStart][2*j+0],
 				     helper[task].SinglesBetaCrAnSM[ib-helper[task].braBetaStart][2*j+1],
-				     onebody_t[thread_id],twobody_t[thread_id]);
+				     onebody,twobody);
 		  /*
 		  DetFromAlphaBeta(adet[ia],bdet[jb],bit_length,norb,DetJ);
 		  CorrelationTermAddition(DetI,DetJ,W[braIdx],T[ketIdx],
 					  bit_length,norb,c,d,
-					  onebody_t[thread_id],twobody_t[thread_id]);
+					  onebody,twobody);
 		  */
 		}
 		// double beta excitation
@@ -567,12 +564,12 @@ namespace sbd {
 				     helper[task].DoublesBetaCrAnSM[ib-helper[task].braBetaStart][4*j+1],
 				     helper[task].DoublesBetaCrAnSM[ib-helper[task].braBetaStart][4*j+2],
 				     helper[task].DoublesBetaCrAnSM[ib-helper[task].braBetaStart][4*j+3],
-				     onebody_t[thread_id],twobody_t[thread_id]);
+				     onebody,twobody);
 		  /*
 		  DetFromAlphaBeta(adet[ia],bdet[jb],bit_length,norb,DetJ);
 		  CorrelationTermAddition(DetI,DetJ,W[braIdx],T[ketIdx],
 					bit_length,norb,c,d,
-					  onebody_t[thread_id],twobody_t[thread_id]);
+					  onebody,twobody);
 		  */
 		}
 	      } // end for(size_t ib=ib_start; ib < ib_end; ib++)
@@ -602,12 +599,12 @@ namespace sbd {
 				       helper[task].SinglesBetaCrAnSM[ib-helper[task].braBetaStart][2*k+0],
 				       helper[task].SinglesAlphaCrAnSM[ia-helper[task].braAlphaStart][2*j+1],
 				       helper[task].SinglesBetaCrAnSM[ib-helper[task].braBetaStart][2*k+1],
-				       onebody_t[thread_id],twobody_t[thread_id]);
+				       onebody,twobody);
 		    /*
 		    DetFromAlphaBeta(adet[ja],bdet[jb],bit_length,norb,DetJ);
 		    CorrelationTermAddition(DetI,DetJ,W[braIdx],T[ketIdx],
 					    bit_length,norb,c,d,
-					    onebody_t[thread_id],twobody_t[thread_id]);
+					    onebody,twobody);
 		    */
 		  }
 		}
@@ -630,24 +627,6 @@ namespace sbd {
 	
     } // end for(size_t task=0; task < helper.size(); task++)
 
-    for(size_t tid = 0; tid < num_threads; tid++) {
-#pragma omp parallel for
-      for(size_t i=0; i < norb*norb; i++) {
-	for(size_t s=0; s < onebody.size(); s++) {
-	  onebody[s][i] += onebody_t[tid][s][i];
-	}
-      }
-    }
-
-    for(size_t tid = 0; tid < num_threads; tid++) {
-#pragma omp parallel for
-      for(size_t i=0; i < norb*norb*norb*norb; i++) {
-	for(size_t s=0; s < twobody.size(); s++) {
-	  twobody[s][i] += twobody_t[tid][s][i];
-	}
-      }
-    }
-    
     for(int s=0; s < 2; s++) {
       MpiAllreduce(onebody[s],MPI_SUM,b_comm);
       MpiAllreduce(onebody[s],MPI_SUM,t_comm);


### PR DESCRIPTION
## Summary

This PR fixes an out-of-memory issue in `Correlation()` for molecules with large MOs.

## Root cause

`Correlation()` in `chemistry/tpb/correlation.h` allocates one private copy of `onebody`
and `twobody` per OpenMP thread for thread-local accumulation, then reduces them into the
shared arrays after the parallel region:

```cpp
std::vector<std::vector<std::vector<ElemT>>> onebody_t(num_threads, onebody);
std::vector<std::vector<std::vector<ElemT>>> twobody_t(num_threads, twobody);
```

`twobody` has 4 spin components each of size `norb^4` doubles. The peak allocation is:

```
num_threads × 4 × norb^4 × 8 bytes
```

For example, for NORB=78 with 32 threads this is **≈ 37.8 GB**, which exceeds the 32 GB per-node
limit of supercomputer Fugaku.

## When does it trigger?

Any call that requests 2pRDM output (`--rdm 1`) where `num_threads × 4 × norb^4 × 8`
exceeds available memory. Approximate thresholds:

| `OMP_NUM_THREADS` | max safe NORB (32 GB node) |
|-------------------|---------------------------|
| 8                 | ~100                       |
| 16                | ~84                        |
| 32                | ~67                        |
| 64                | ~57                        |

The target use case (NORB=78, 32 threads) sits well above the 32-thread threshold.

## Fix

Replace the per-thread copies with `#pragma omp atomic update` writes directly into
the shared `onebody`/`twobody` arrays in the three vector overloads in
`chemistry/basic/correlation.h` (`ZeroDiffCorrelation`, `OneDiffCorrelation`,
`TwoDiffCorrelation`), and remove the `onebody_t`/`twobody_t` declarations and their
post-loop reduction from `chemistry/tpb/correlation.h`.

The `USE_OMP_OFFLOAD` raw-pointer overloads in the same file already use this
`#pragma omp atomic update` pattern and served as the reference.

Peak memory for the 2pRDM drops from `num_threads × 1.18 GB` to a single shared copy
of **1.18 GB** (NORB=78), regardless of thread count. The existing `MPI_Allreduce`
calls that follow the parallel region are unchanged.