### PR TITLE
gdb: fix BasisInitVector and Randomize in davidson_thrust.h

### DIFF
--- a/include/sbd/chemistry/gdb/davidson_thrust.h
+++ b/include/sbd/chemistry/gdb/davidson_thrust.h
@@ -14,7 +14,8 @@ namespace sbd {
 			 MPI_Comm h_comm,
 			 MPI_Comm b_comm,
 			 MPI_Comm t_comm,
-			 int init) {
+			 int init,
+			 size_t seed) {
       int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
       int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
       int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
@@ -30,7 +31,7 @@ namespace sbd {
 	MpiBcast(w,0,t_comm);
       } else if ( init == 1 ) {
 	if( mpi_rank_t == 0 ) {
-	  Randomize(w,b_comm,h_comm);
+	  Randomize(w,b_comm,h_comm,seed);
 	}
 	MpiBcast(w,0,t_comm);
       }


### PR DESCRIPTION
bd2aada updated davidson.h and sbdiag.h to thread a seed parameter through BasisInitVector and Randomize, but did not update the SBD_THRUST variant.  Under SBD_THRUST, inc_all.h includes davidson_thrust.h instead of davidson.h, so the unchanged 6-arg BasisInitVector left the thrust GDB build with a compile error (sbdiag.h unconditionally calls the 7-arg form). Additionally, Randomize(w,b_comm,h_comm) with no seed argument was silently resolving to the 3-arg overload Randomize(X,b_comm,seed) with h_comm cast to size_t as the seed.

Add size_t seed to BasisInitVector and pass it to Randomize(w,b_comm,h_comm,seed).