### PR TITLE
framework: redesign Randomize to put seed first; add unseeded wrappers

### DIFF
--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -29,7 +29,7 @@ namespace sbd {
     if( init == 0 ) {
       if( mpi_rank_t == 0 ) {
 	w.resize(basis.size());
-	Randomize(w,b_comm,h_comm,seed);
+	Randomize(seed,w,b_comm,h_comm);
       }
       MpiBcast(w,0,t_comm);
     }
@@ -90,7 +90,7 @@ namespace sbd {
 	if( mpi_rank_t == 0 ) {
 	  if( mpi_rank_h == 0 ) {
 	    V[iv].resize(w_size);
-	    Randomize(V[iv],b_comm,seed+iv);
+	    Randomize(seed+iv,V[iv],b_comm);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    Normalize(V[iv],vnrm,b_comm);
@@ -291,7 +291,7 @@ namespace sbd {
 	if( mpi_rank_t == 0 ) {
 	  if( mpi_rank_h == 0 ) {
 	    V[iv].resize(w_size);
-	    Randomize(V[iv],b_comm,seed+iv);
+	    Randomize(seed+iv,V[iv],b_comm);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    MGS(V,iv,V[iv],vdot,b_comm);
 	    Normalize(V[iv],vnrm,b_comm);

--- a/include/sbd/chemistry/gdb/davidson.h
+++ b/include/sbd/chemistry/gdb/davidson.h
@@ -31,7 +31,7 @@ namespace sbd {
 	MpiBcast(w,0,t_comm);
       } else if ( init == 1 ) {
 	if( mpi_rank_t == 0 ) {
-	  Randomize(w,b_comm,h_comm,seed);
+	  Randomize(seed,w,b_comm,h_comm);
 	}
 	MpiBcast(w,0,t_comm);
       }

--- a/include/sbd/chemistry/gdb/davidson_thrust.h
+++ b/include/sbd/chemistry/gdb/davidson_thrust.h
@@ -14,7 +14,8 @@ namespace sbd {
 			 MPI_Comm h_comm,
 			 MPI_Comm b_comm,
 			 MPI_Comm t_comm,
-			 int init) {
+			 int init,
+			 size_t seed) {
       int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
       int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
       int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
@@ -30,7 +31,7 @@ namespace sbd {
 	MpiBcast(w,0,t_comm);
       } else if ( init == 1 ) {
 	if( mpi_rank_t == 0 ) {
-	  Randomize(w,b_comm,h_comm);
+	  Randomize(seed,w,b_comm,h_comm);
 	}
 	MpiBcast(w,0,t_comm);
       }

--- a/include/sbd/chemistry/tpb/davidson.h
+++ b/include/sbd/chemistry/tpb/davidson.h
@@ -80,7 +80,7 @@ x = 0    1    2    3
       MpiBcast(W,0,t_comm);
     } else if ( init == 1 ) {
       if( mpi_rank_t == 0 ) {
-	Randomize(W,b_comm,h_comm,seed);
+	Randomize(seed,W,b_comm,h_comm);
       }
       MpiBcast(W,0,t_comm);
     }
@@ -137,7 +137,7 @@ x = 0    1    2    3
       }
     } else if ( init == 1 ) {
       if( mpi_rank_t == 0 ) {
-	Randomize(W,b_comm,h_comm,seed);
+	Randomize(seed,W,b_comm,h_comm);
       }
       MpiBcast(W,0,t_comm);
     }

--- a/include/sbd/framework/dm_vector.h
+++ b/include/sbd/framework/dm_vector.h
@@ -9,6 +9,7 @@
 
 #define SBD_MAX_THREADS 192
 
+#include <chrono>
 #include <random>
 
 namespace sbd {
@@ -111,6 +112,17 @@ namespace sbd {
     return (double)(h >> 11) * (2.0 / 9007199254740992.0) - 1.0;
   }
 
+// Time+rank seed for the seed==0 case.  Uses MPI_COMM_WORLD rank so ranks
+// that share the same b_comm rank (e.g. rank 0 on different nodes) still
+// diverge.  No broadcast: random initialisation needs no cross-rank agreement.
+  static inline size_t sbd_time_seed() {
+    auto ns = static_cast<size_t>(
+      std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    return static_cast<size_t>(sbd_elem_hash(ns, static_cast<size_t>(rank)));
+  }
+
   template <typename ElemT>
   void apply_dist_seeded(ElemT & x, size_t seed, size_t idx) {
     x = ElemT(sbd_hash_to_uniform(sbd_elem_hash(seed, idx)));
@@ -123,10 +135,11 @@ namespace sbd {
   }
 
   template <typename ElemT>
-  void Randomize(std::vector<ElemT> & X,
+  void Randomize(size_t seed,
+		 std::vector<ElemT> & X,
 		 MPI_Comm b_comm,
-		 MPI_Comm h_comm,
-		 size_t seed) {
+		 MPI_Comm h_comm) {
+    if (seed == 0) seed = sbd_time_seed();
     using RealT = typename GetRealType<ElemT>::RealT;
     int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
     int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
@@ -178,9 +191,10 @@ namespace sbd {
   }
 
   template <typename ElemT>
-  void Randomize(std::vector<ElemT> & X,
-		 MPI_Comm b_comm,
-		 size_t seed) {
+  void Randomize(size_t seed,
+		 std::vector<ElemT> & X,
+		 MPI_Comm b_comm) {
+    if (seed == 0) seed = sbd_time_seed();
     using RealT = typename GetRealType<ElemT>::RealT;
     int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
     int nth = omp_get_max_threads();
@@ -225,7 +239,24 @@ namespace sbd {
       X[is] *= factor;
     }
   }
-  
+
+// Unseeded wrappers: pass seed=0, which the seeded implementations replace
+// with a local time+rank seed.  The first argument is std::vector so
+// these can never match the seeded overloads by accident (std::vector cannot
+// implicitly convert to size_t).
+  template <typename ElemT>
+  void Randomize(std::vector<ElemT> & X,
+		 MPI_Comm b_comm,
+		 MPI_Comm h_comm) {
+    Randomize(size_t(0), X, b_comm, h_comm);
+  }
+
+  template <typename ElemT>
+  void Randomize(std::vector<ElemT> & X,
+		 MPI_Comm b_comm) {
+    Randomize(size_t(0), X, b_comm);
+  }
+
   template <typename ElemT>
   void Swap(ElemT a, std::vector<ElemT> & X,
 	    ElemT b, std::vector<ElemT> & Y) {


### PR DESCRIPTION
The previous API (seed as last argument) caused silent overload-resolution bugs: MPI_Comm and size_t are both integral types, so a call missing the seed argument could silently pick the wrong seeded overload by casting the h_comm value to size_t.  This happened in davidson_thrust.h and would recur whenever a new call site omitted the seed.

New design:
- Seeded overloads: seed is the first argument (size_t), which is a distinct type from the std::vector& first argument of the unseeded overloads.  The compiler cannot confuse the two families regardless of what integral type MPI_Comm resolves to.
- seed==0 is reserved: both seeded overloads substitute a seed derived by hashing the nanosecond clock with the MPI_COMM_WORLD rank via sbd_time_seed(), so that ranks sharing the same b_comm rank (e.g. rank 0 on different nodes) still diverge.  No broadcast is needed since random initialisation requires no cross-rank agreement.
- Unseeded wrappers: Randomize(X, b_comm[, h_comm]) pass seed=0 and therefore get the time+rank hash behaviour automatically.

Also fixes the davidson_thrust.h compile breakage introduced by bd2aada: BasisInitVector now takes size_t seed and passes it to Randomize, matching the 7-argument form that sbdiag.h unconditionally calls.

All existing seeded call sites updated to seed-first order.