### PR TITLE
Fix/unused function bug

### DIFF
--- a/include/sbd/chemistry/tpb/helper.h
+++ b/include/sbd/chemistry/tpb/helper.h
@@ -129,8 +129,8 @@ namespace sbd {
 	    if( itk != BDets.begin()+ketBetaEnd ) {
 	      auto ik = std::distance(BDets.begin(),itk);
 	      helper.SinglesFromBeta[ib-braBetaStart].push_back(static_cast<size_t>(ik));
-	      helper.SinglesBetaCrAn[ib-braAlphaStart].push_back(2*open[k]+1);
-	      helper.SinglesBetaCrAn[ib-braAlphaStart].push_back(2*closed[j]+1);
+	      helper.SinglesBetaCrAn[ib-braBetaStart].push_back(2*open[k]+1);
+	      helper.SinglesBetaCrAn[ib-braBetaStart].push_back(2*closed[j]+1);
 	    }
 	  }
         }


### PR DESCRIPTION
A typo was found in an unused helper construction function in tpb/helper.h. 
Although this function is not currently used, this PR fixes it to avoid potential issues if it is used in the future.