### PR TITLE
caop: convert determinant storage from vector<vector<size_t>> to det_vector<size_t>

### DIFF
--- a/apps/caop_selected_basis_diagonalization/main.cc
+++ b/apps/caop_selected_basis_diagonalization/main.cc
@@ -87,7 +87,7 @@ int main(int argc, char * argv[]) {
   }
 
   double energy;
-  std::vector<std::vector<size_t>> cobasis;
+  sbd::det_vector<size_t> cobasis;
   sbd::caop::diag<ElemType>(comm,sbd_data,hamfile,basisfiles,
 			    loadname,savename,energy,cobasis);
 

--- a/include/sbd/caop/basic/carryover.h
+++ b/include/sbd/caop/basic/carryover.h
@@ -20,10 +20,10 @@ namespace sbd {
 
   template <typename ElemT, typename RealT>
   void CarryOverBasis(const std::vector<ElemT> & w,
-		      const std::vector<std::vector<size_t>> & bs,
+		      const det_vector<size_t> & bs,
 		      MPI_Comm b_comm,
 		      size_t kept,
-		      std::vector<std::vector<size_t>> & rbs,
+		      det_vector<size_t> & rbs,
 		      RealT & discarted_weight) {
     // using RealT = typename GetRealType<ElemT>::RealT;
     std::vector<RealT> r(w.size());

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -14,7 +14,7 @@ namespace sbd {
 
   template <typename ElemT>
   void InitVectorCAOP(std::vector<ElemT> & w,
-		      const std::vector<std::vector<size_t>> & basis,
+		      const det_vector<size_t> & basis,
 		      MPI_Comm h_comm,
 		      MPI_Comm b_comm,
 		      MPI_Comm t_comm,
@@ -38,7 +38,7 @@ namespace sbd {
   template <typename ElemT, typename RealT>
   void Davidson(const std::vector<ElemT> & hii,
 		std::vector<ElemT> & W,
-		const std::vector<std::vector<size_t>> & bs,
+		const det_vector<size_t> & bs,
 		const size_t bit_length,
 		const std::vector<int> & slide,
 		const GeneralOp<ElemT> & Ham,

--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -80,7 +80,7 @@ namespace sbd {
     friend void mult(const std::vector<ElemT_> & hd,
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
-		     const std::vector<std::vector<size_t>> & bs,
+		     const det_vector<size_t> & bs,
 		     const size_t bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
@@ -90,14 +90,14 @@ namespace sbd {
 		     MPI_Comm t_comm);
 
     template <typename ElemT_>
-    friend void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 				     const size_t bit_length,
 				     const std::vector<int> & slide,
 				     const GeneralOp<ElemT_> & H,
 				     std::vector<ElemT_> & hii);
 
     template <typename ElemT_>
-    friend void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHam(const det_vector<size_t> & bs,
 			    const size_t bit_length,
 			    const std::vector<int> & slide,
 			    const GeneralOp<ElemT_> & H,
@@ -330,7 +330,7 @@ namespace sbd {
     friend void mult(const std::vector<ElemT_> & hd,
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
-		     const std::vector<std::vector<size_t>> & bs,
+		     const det_vector<size_t> & bs,
 		     const size_t bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
@@ -340,14 +340,14 @@ namespace sbd {
 		     MPI_Comm t_comm);
 
     template <typename ElemT_>
-    friend void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 				     const size_t bit_length,
 				     const std::vector<int> & slide,
 				     const GeneralOp<ElemT_> & H,
 				     std::vector<ElemT_> & hii);
 
     template <typename ElemT_>
-    friend void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHam(const det_vector<size_t> & bs,
 			    const size_t bit_length,
 			    const std::vector<int> & slide,
 			    const GeneralOp<ElemT_> & H,
@@ -751,7 +751,7 @@ namespace sbd {
     friend void mult(const std::vector<ElemT_> & hd,
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
-		     const std::vector<std::vector<size_t>> & bs,
+		     const det_vector<size_t> & bs,
 		     const size_t bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
@@ -761,14 +761,14 @@ namespace sbd {
 		     MPI_Comm t_comm);
 
     template <typename ElemT_>
-    friend void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 				     const size_t bit_length,
 				     const std::vector<int> & slide,
 				     const GeneralOp<ElemT_> & H,
 				     std::vector<ElemT_> & hii);
 
     template <typename ElemT_>
-    friend void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHam(const det_vector<size_t> & bs,
 			    const size_t bit_length,
 			    const std::vector<int> & slide,
 			    const GeneralOp<ElemT_> & H,

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -14,7 +14,7 @@ namespace sbd {
   template <typename ElemT, typename RealT>
   void Lanczos(const std::vector<ElemT> & hii,
 	       std::vector<ElemT> & W,
-	       const std::vector<std::vector<size_t>> & bs,
+	       const det_vector<size_t> & bs,
 	       const size_t bit_length,
 	       const std::vector<int> & slide,
 	       const GeneralOp<ElemT> & Ham,

--- a/include/sbd/caop/basic/mkham.h
+++ b/include/sbd/caop/basic/mkham.h
@@ -10,7 +10,7 @@
 namespace sbd {
 
   template <typename ElemT>
-  void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+  void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 			       const size_t bit_length,
 			       const std::vector<int> & slide,
 			       const GeneralOp<ElemT> & H,
@@ -44,7 +44,7 @@ namespace sbd {
   }
   
   template <typename ElemT>
-  void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+  void makeCAOpHam(const det_vector<size_t> & bs,
 		   const size_t bit_length,
 		   const std::vector<int> & slide,
 		   const GeneralOp<ElemT> & H,
@@ -71,8 +71,8 @@ namespace sbd {
     size_t num_task = slide.size();
     size_t num_terms = H.NumOpTerms();
 
-    std::vector<std::vector<size_t>> tbs;
-    std::vector<std::vector<size_t>> rbs;
+    det_vector<size_t> tbs;
+    det_vector<size_t> rbs;
 
     if( slide.size() != 0 ) {
       if( slide[0] != 0 ) {
@@ -158,8 +158,8 @@ namespace sbd {
 					 });
 	    */
 	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk,
-					 [](const std::vector<size_t> & x,
-					    const std::vector<size_t> & y) {
+					 [](const auto & x,
+					    const auto & y) {
 					   return sbd::less_from_back(x,y);
 					 });
 	    if( itik == tbs.end() ) continue;

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -11,7 +11,7 @@ namespace sbd {
   void mult(const std::vector<ElemT> & hd,
 	    const std::vector<ElemT> & wk,
 	    std::vector<ElemT> & wb,
-	    const std::vector<std::vector<size_t>> & bs,
+	    const det_vector<size_t> & bs,
 	    const size_t bit_length,
 	    const std::vector<int> & slide,
 	    const GeneralOp<ElemT> & H,
@@ -29,8 +29,8 @@ namespace sbd {
 
     std::vector<ElemT> twk;
     std::vector<ElemT> rwk;
-    std::vector<std::vector<size_t>> tbs;
-    std::vector<std::vector<size_t>> rbs;
+    det_vector<size_t> tbs;
+    det_vector<size_t> rbs;
 
     if( slide.size() != 0 ) {
       if( slide[0] != 0 ) {
@@ -114,8 +114,8 @@ namespace sbd {
 					 });
 	    */
 	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk,
-					 [](const std::vector<size_t> & x,
-					    const std::vector<size_t> & y) {
+					 [](const auto & x,
+					    const auto & y) {
 					   return sbd::less_from_back(x,y);
 					 });
 	    if( itik == tbs.end() ) continue;

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -117,11 +117,11 @@ namespace sbd {
     void diag(const MPI_Comm & comm,
 	      const SBD & sbd_data,
 	      const GeneralOp<ElemT> & H,
-	      const std::vector<std::vector<size_t>> & basis,
+	      const det_vector<size_t> & basis,
 	      const std::string & loadname,
 	      const std::string & savename,
 	      double & energy,
-	      std::vector<std::vector<size_t>> & co_basis) {
+	      det_vector<size_t> & co_basis) {
       
       int mpi_master = 0;
       int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
@@ -349,7 +349,7 @@ namespace sbd {
 	      const std::string & loadname,
 	      const std::string & savename,
 	      double & energy,
-	      std::vector<std::vector<size_t>> & co_basis) {
+	      det_vector<size_t> & co_basis) {
 
       int mpi_master = 0;
       int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
@@ -409,7 +409,7 @@ namespace sbd {
 	std::cout << " " << make_timestamp()
 		  << " sbd: start load basis" << std::endl;
       }
-      std::vector<std::vector<size_t>> basis;
+      det_vector<size_t> basis;
       if( mpi_rank_h == 0 ) {
 	if( mpi_rank_t == 0 ) {
 	  load_basis_from_files(basisfiles,basis,


### PR DESCRIPTION
Replace std::vector<std::vector<size_t>> with sbd::det_vector<size_t> for all CAOP basis/carryover parameters and locals across davidson.h, mult.h, mkham.h, carryover.h, sbdiag.h, lanczos.h, generalop.h (friend declarations), and main.cc. Comparator lambdas updated to const auto& to avoid vector temporaries on lower_bound.