### PR TITLE
Fix UCX inter-node GPU-Direct RDMA error on Non-CUDA-Aware MPI environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ set_property(CACHE SBD_GPU_BACKEND PROPERTY STRINGS none thrust omp5)
 set(SBD_GPU_ARCH "cc90" CACHE STRING "GPU architecture for the chosen backend")
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
-option(SBD_THRUST_SAFE_MPI_ALLREDUCE   "Safe Thrust MPI allreduce"                         OFF)
+option(SBD_NON_CUDA_AWARE_MPI           "Use host-staging for all MPI comm on device memory" OFF)
+option(SBD_THRUST_SAFE_MPI_ALLREDUCE   "Safe Thrust MPI allreduce (subset of NON_CUDA_AWARE_MPI)" OFF)
 option(SBD_TRADMODE                    "Traditional (non-Thrust) CPU mode for tpb"         OFF)
 option(SBD_USE_NVTX                    "NVTX profiling annotations"                        OFF)
 option(SBD_USE_NCCL                    "Link against NCCL"                                 OFF)
@@ -82,6 +83,7 @@ function(sbd_configure_diag target)
   if(SBD_GPU_BACKEND STREQUAL "thrust")
     target_compile_definitions(${target} PRIVATE
       SBD_THRUST
+      $<$<BOOL:${SBD_NON_CUDA_AWARE_MPI}>:SBD_NON_CUDA_AWARE_MPI>
       $<$<BOOL:${SBD_THRUST_SAFE_MPI_ALLREDUCE}>:SBD_THRUST_SAFE_MPI_ALLREDUCE>
       $<$<BOOL:${SBD_USE_NVTX}>:SBD_USE_NVTX>
       $<$<BOOL:${SBD_USE_NCCL}>:SBD_USE_NCCL>

--- a/apps/chemistry_tpb_selected_basis_diagonalization/Configuration
+++ b/apps/chemistry_tpb_selected_basis_diagonalization/Configuration
@@ -32,6 +32,10 @@ SBD_PATH=../..
              -fopenmp-offload-mandatory -foffload-lto
   LDFLAGS += -fopenmp --offload-arch=gfx90a -foffload-lto
 
+# Enable if MPI is NOT CUDA-aware (copies device buffers to host before MPI calls).
+# This includes Allreduce, Isend/Irecv on device_vector, etc.
+# CCFLAGS += -DSBD_NON_CUDA_AWARE_MPI
+
 # accelerate using Thrust
 # CCFLAGS= -mp -cuda -fast -Minfo=accel --diag_suppress declared_but_not_referenced,set_but_not_used -fmax-errors=0 -I/opt/nvidia/hpc_sdk/Linux_x86_64/2025/cuda/include/cccl -I/usr/local/cuda/include -DSBD_THRUST
 #-DSBD_PREFECT

--- a/include/sbd/framework/mpi_utility_thrust.h
+++ b/include/sbd/framework/mpi_utility_thrust.h
@@ -19,7 +19,7 @@
 namespace sbd
 {
 
-#ifdef SBD_THRUST_SAFE_MPI_ALLREDUCE
+#ifdef SBD_NON_CUDA_AWARE_MPI
 
 template <typename ElemT>
 void MpiAllreduce(thrust::device_vector<ElemT> &A, MPI_Op op, MPI_Comm comm)
@@ -59,7 +59,7 @@ void MpiAllreduce(thrust::device_vector<ElemT> &A, MPI_Op op, MPI_Comm comm)
 #endif
 }
 
-#endif // SBD_THRUST_SAFE_MPI_ALLREDUCE
+#endif // SBD_NON_CUDA_AWARE_MPI
 
 template <typename ElemT>
 void _MpiSlide(const ElemT* A,
@@ -100,6 +100,20 @@ void _MpiSlide(const ElemT* A,
     std::vector<MPI_Status> sta_data(2);
 
     MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    std::vector<ElemT> h_send(send_size), h_recv(recv_size);
+    if (send_size != 0) {
+        cudaMemcpy(h_send.data(), A, send_size * sizeof(ElemT), cudaMemcpyDefault);
+    }
+    if( send_size != 0 ) {
+        SBD_NVTX_RANGE_COLOR("MPI_Isend", 0);
+        MPI_Isend(h_send.data(),send_size,DataT,mpi_dest,1,comm,&req_data[0]);
+    }
+    if( recv_size != 0 ) {
+        SBD_NVTX_RANGE_COLOR("MPI_Irecv", 0);
+        MPI_Irecv(h_recv.data(),recv_size,DataT,mpi_source,1,comm,&req_data[1]);
+    }
+#else
     if( send_size != 0 ) {
         SBD_NVTX_RANGE_COLOR("MPI_Isend", 0);
         MPI_Isend(A,send_size,DataT,mpi_dest,1,comm,&req_data[0]);
@@ -108,6 +122,7 @@ void _MpiSlide(const ElemT* A,
         SBD_NVTX_RANGE_COLOR("MPI_Irecv", 0);
         MPI_Irecv((ElemT*)thrust::raw_pointer_cast(B.data()),recv_size,DataT,mpi_source,1,comm,&req_data[1]);
     }
+#endif
 
     if( send_size != 0 && recv_size != 0 ) {
         SBD_NVTX_RANGE_COLOR("MPI_Waitall", 0);
@@ -119,6 +134,11 @@ void _MpiSlide(const ElemT* A,
         SBD_NVTX_RANGE_COLOR("MPI_Waitall", 0);
         MPI_Waitall(1,&req_data[1],&sta_data[1]);
     }
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    if (recv_size != 0) {
+        thrust::copy(h_recv.begin(), h_recv.end(), B.begin());
+    }
+#endif
 }
 
 template <typename ElemT>
@@ -170,12 +190,25 @@ void MpiSlide(const thrust::device_vector<size_t> & A,
     std::vector<MPI_Status> sta_data(2);
 
     MPI_Datatype DataT = SBD_MPI_SIZE_T;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    std::vector<size_t> h_send(send_size), h_recv(recv_size);
+    if (send_size != 0) {
+        thrust::copy(A.begin(), A.end(), h_send.begin());
+    }
+    if( send_size != 0 ) {
+        MPI_Isend(h_send.data(),send_size,DataT,mpi_dest,1,comm,&req_data[0]);
+    }
+    if( recv_size != 0 ) {
+        MPI_Irecv(h_recv.data(),recv_size,DataT,mpi_source,1,comm,&req_data[1]);
+    }
+#else
     if( send_size != 0 ) {
         MPI_Isend((size_t*)thrust::raw_pointer_cast(A.data()),send_size,DataT,mpi_dest,1,comm,&req_data[0]);
     }
     if( recv_size != 0 ) {
         MPI_Irecv((size_t*)thrust::raw_pointer_cast(B.data()),recv_size,DataT,mpi_source,1,comm,&req_data[1]);
     }
+#endif
 
     if( send_size != 0 && recv_size != 0 ) {
         MPI_Waitall(2,req_data.data(),sta_data.data());
@@ -184,6 +217,11 @@ void MpiSlide(const thrust::device_vector<size_t> & A,
     } else if ( send_size == 0 && recv_size != 0 ) {
         MPI_Waitall(1,&req_data[1],&sta_data[1]);
     }
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    if (recv_size != 0) {
+        thrust::copy(h_recv.begin(), h_recv.end(), B.begin());
+    }
+#endif
 }
 
 
@@ -242,12 +280,25 @@ void _Mpi2dSlide(const ElemT* A,
     std::vector<MPI_Status> sta_data(2);
 
     MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    std::vector<ElemT> h_send(send_size), h_recv(recv_size);
+    if (send_size != 0) {
+        cudaMemcpy(h_send.data(), A, send_size * sizeof(ElemT), cudaMemcpyDefault);
+    }
+    if (send_size != 0) {
+        MPI_Isend(h_send.data(), send_size, DataT, mpi_dist, 1, comm, &req_data[0]);
+    }
+    if (recv_size != 0) {
+        MPI_Irecv(h_recv.data(), recv_size, DataT, mpi_source, 1, comm, &req_data[1]);
+    }
+#else
     if (send_size != 0) {
         MPI_Isend(A, send_size, DataT, mpi_dist, 1, comm, &req_data[0]);
     }
     if (recv_size != 0) {
         MPI_Irecv((ElemT*)thrust::raw_pointer_cast(B.data()), recv_size, DataT, mpi_source, 1, comm, &req_data[1]);
     }
+#endif
 
     if (send_size != 0 && recv_size != 0) {
         MPI_Waitall(2, req_data.data(), sta_data.data());
@@ -258,6 +309,11 @@ void _Mpi2dSlide(const ElemT* A,
     else if (send_size == 0 && recv_size != 0) {
         MPI_Waitall(1, &req_data[1], &sta_data[1]);
     }
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    if (recv_size != 0) {
+        thrust::copy(h_recv.begin(), h_recv.end(), B.begin());
+    }
+#endif
 }
 
 template <typename ElemT>
@@ -295,11 +351,19 @@ protected:
     MPI_Request req_recv;
     size_t send_size;
     size_t recv_size;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+    std::vector<ElemT> h_send_buf;
+    std::vector<ElemT> h_recv_buf;
+    thrust::device_vector<ElemT>* p_B;
+#endif
 public:
     Mpi2dSlider()
     {
         send_size = 0;
         recv_size = 0;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+        p_B = nullptr;
+#endif
     }
 
     void ExchangeAsync(const thrust::device_vector<ElemT> &A,
@@ -359,6 +423,23 @@ public:
         B.resize(recv_size);
 
         MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+        h_send_buf.resize(send_size);
+        h_recv_buf.resize(recv_size);
+        p_B = &B;
+        if (send_size != 0) {
+            cudaMemcpy(h_send_buf.data(), thrust::raw_pointer_cast(A.data()),
+                       send_size * sizeof(ElemT), cudaMemcpyDefault);
+        }
+        if (send_size != 0) {
+            SBD_NVTX_RANGE_COLOR("MPI_Isend", 0);
+            MPI_Isend(h_send_buf.data(), send_size, DataT, mpi_dist, task * 2 + 1, comm, &req_send);
+        }
+        if (recv_size != 0) {
+            SBD_NVTX_RANGE_COLOR("MPI_Irecv", 0);
+            MPI_Irecv(h_recv_buf.data(), recv_size, DataT, mpi_source, task * 2 + 1, comm, &req_recv);
+        }
+#else
         if (send_size != 0) {
             SBD_NVTX_RANGE_COLOR("MPI_Isend", 0);
             MPI_Isend((ElemT*)thrust::raw_pointer_cast(A.data()), send_size, DataT, mpi_dist, task * 2 + 1, comm, &req_send);
@@ -367,6 +448,7 @@ public:
             SBD_NVTX_RANGE_COLOR("MPI_Irecv", 0);
             MPI_Irecv((ElemT*)thrust::raw_pointer_cast(B.data()), recv_size, DataT, mpi_source, task * 2 + 1, comm, &req_recv);
         }
+#endif
     }
 
     bool Sync(MPI_Comm comm)
@@ -383,6 +465,9 @@ public:
             SBD_NVTX_RANGE_COLOR("MPI_Wait", 0);
             MPI_Wait(&req_recv, &st);
             recv = true;
+#ifdef SBD_NON_CUDA_AWARE_MPI
+            thrust::copy(h_recv_buf.begin(), h_recv_buf.end(), p_B->begin());
+#endif
         }
         {
             SBD_NVTX_RANGE_COLOR("MPI_Barrier", 0);

--- a/include/sbd/framework/mpi_utility_thrust.h
+++ b/include/sbd/framework/mpi_utility_thrust.h
@@ -19,7 +19,7 @@
 namespace sbd
 {
 
-#ifdef SBD_NON_CUDA_AWARE_MPI
+#if defined(SBD_NON_CUDA_AWARE_MPI) || defined(SBD_THRUST_SAFE_MPI_ALLREDUCE)
 
 template <typename ElemT>
 void MpiAllreduce(thrust::device_vector<ElemT> &A, MPI_Op op, MPI_Comm comm)
@@ -59,7 +59,7 @@ void MpiAllreduce(thrust::device_vector<ElemT> &A, MPI_Op op, MPI_Comm comm)
 #endif
 }
 
-#endif // SBD_NON_CUDA_AWARE_MPI
+#endif // SBD_NON_CUDA_AWARE_MPI || SBD_THRUST_SAFE_MPI_ALLREDUCE
 
 template <typename ElemT>
 void _MpiSlide(const ElemT* A,


### PR DESCRIPTION
### Background

Running inter-node jobs on HPC environment with non-CUDA-Aware MPI produced the following UCX error, causing MPI sends to be cancelled, for example:

```
UCX ERROR cannot find remote protocol for: ucp_context_0 inter-node cfg#2 | tag_send(multi) from cuda/GPU0
pml_ucx.c:940  Error: ucx send failed: Request canceled
```

The root cause is that raw CUDA device pointers were passed directly to `MPI_Isend`/`MPI_Irecv`. UCX detected them and attempted GPU-Direct RDMA, which is not supported for inter-node communication.

### Fix

Introduce CPU staging in `deps/sbd/include/sbd/framework/mpi_utility_thrust.h` behind the compile-time flag `SBD_NON_CUDA_AWARE_MPI`. When defined, all MPI send/receive operations copy GPU data to a host buffer first, communicate via host pointers, then copy the result back to the device. The GPU-Direct path is preserved in the `#else` branches for environments that do support it.

The four affected sites are:

| Function | Method |
|---|---|
| `MpiAllreduce` | `thrust::copy` to host → `MPI_Allreduce` → `thrust::copy` back |
| `_MpiSlide` | `cudaMemcpy(cudaMemcpyDefault)` to host → `MPI_Isend`/`Irecv` → `thrust::copy` back |
| `MpiSlide<size_t>` | `thrust::copy` to host → `MPI_Isend`/`Irecv` → `thrust::copy` back |
| `_Mpi2dSlide` | `cudaMemcpy(cudaMemcpyDefault)` to host → `MPI_Isend`/`Irecv` → `thrust::copy` back |
| `Mpi2dSlider::ExchangeAsync` / `Sync` | host buffers stored as class members (`h_send_buf`, `h_recv_buf`, `p_B`) to persist across the async pair |

`cudaMemcpyDefault` is used where the source pointer may be either a device pointer (`thrust::device_vector`) or a host pointer (`std::vector`), allowing both overloads of `MpiSlide` and `Mpi2dSlide` to share a single implementation.