### PR TITLE
caop thrust

### DIFF
--- a/apps/caop_selected_basis_diagonalization/main.cc
+++ b/apps/caop_selected_basis_diagonalization/main.cc
@@ -87,7 +87,7 @@ int main(int argc, char * argv[]) {
   }
 
   double energy;
-  std::vector<std::vector<size_t>> cobasis;
+  sbd::det_vector<size_t> cobasis;
   sbd::caop::diag<ElemType>(comm,sbd_data,hamfile,basisfiles,
 			    loadname,savename,energy,cobasis);
 

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -204,18 +204,36 @@ namespace sbd {
 			    size_t bit_length,
 			    size_t total_bit_length) {
     if( get_extension(filename) == std::string("txt") ) {
-      std::ifstream ifs(filename);
-      if( !ifs.is_open() ) {
+      // Fast path: text is regular fixed-width records (total_bit_length chars of
+      // '0'/'1' + '\n').  Read the whole file in one shot and parse in-place.
+      std::ifstream ifs(filename, std::ios::binary);
+      if( !ifs.is_open() )
 	throw std::runtime_error("Failed to open basis bit-string file.");
-      }
-      std::string line;
-      std::vector<std::string> lines;
-      while( std::getline(ifs,line) ) {
-	lines.push_back(line);
-      }
-      config.resize(lines.size());
-      for(size_t i=0; i < lines.size(); i++) {
-	config[i] = from_string(lines[i],bit_length,total_bit_length);
+
+      ifs.seekg(0, std::ios::end);
+      const size_t file_size = ifs.tellg();
+      ifs.seekg(0, std::ios::beg);
+
+      const size_t record_size = total_bit_length + 1;  // L chars + '\n'
+      const size_t num_records = (file_size + 1) / record_size;
+      const size_t num_words   = (total_bit_length + bit_length - 1) / bit_length;
+
+      std::vector<char> buf(file_size);
+      ifs.read(buf.data(), file_size);
+      if( !ifs )
+	throw std::runtime_error("Failed to read basis bit-string file.");
+
+      config.resize(num_records);
+      for(size_t i = 0; i < num_records; i++) {
+	const char* rec = buf.data() + i * record_size;
+	config[i].resize(num_words);
+	std::fill(config[i].begin(), config[i].end(), size_t(0));
+	for(size_t j = 0; j < total_bit_length; j++) {
+	  if( rec[j] == '1' ) {
+	    size_t bit_idx = total_bit_length - 1 - j;
+	    config[i][bit_idx / bit_length] |= (size_t(1) << (bit_idx % bit_length));
+	  }
+	}
       }
     } else if ( get_extension(filename) == std::string("bin") ) {
       std::ifstream ifs(filename, std::ios::binary);

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -232,6 +232,9 @@ namespace sbd {
 	  if( rec[j] == '1' ) {
 	    size_t bit_idx = total_bit_length - 1 - j;
 	    config[i][bit_idx / bit_length] |= (size_t(1) << (bit_idx % bit_length));
+	  } else if( rec[j] != '0' ) {
+	    throw std::runtime_error(
+	      "Unexpected character in basis file: expected '0' or '1'");
 	  }
 	}
       }

--- a/include/sbd/caop/basic/carryover.h
+++ b/include/sbd/caop/basic/carryover.h
@@ -20,10 +20,10 @@ namespace sbd {
 
   template <typename ElemT, typename RealT>
   void CarryOverBasis(const std::vector<ElemT> & w,
-		      const std::vector<std::vector<size_t>> & bs,
+		      const det_vector<size_t> & bs,
 		      MPI_Comm b_comm,
 		      size_t kept,
-		      std::vector<std::vector<size_t>> & rbs,
+		      det_vector<size_t> & rbs,
 		      RealT & discarted_weight) {
     // using RealT = typename GetRealType<ElemT>::RealT;
     std::vector<RealT> r(w.size());

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -237,6 +237,198 @@ namespace sbd {
     
   }
 		
+#ifdef SBD_THRUST
+  // Davidson overload for the GPU (SBD_THRUST) path.
+  // Caller owns CaopMultThrust and has already called InitCaopMultThrust().
+  // driver.run() is called in place of the free mult() on each iteration.
+  template <typename ElemT, typename RealT>
+  void Davidson(const std::vector<ElemT> & hii,
+		std::vector<ElemT> & W,
+		CaopMultThrust<ElemT> & driver,
+		MPI_Comm h_comm,
+		MPI_Comm b_comm,
+		MPI_Comm t_comm,
+		int max_iteration,
+		int num_block,
+		int num_initvec,
+		RealT eps,
+		size_t seed) {
+
+    size_t w_size = W.size();
+    RealT eps_reg = 1.0e-8;
+
+    std::vector<std::vector<ElemT>> C(num_block,W);
+    std::vector<std::vector<ElemT>> HC(num_block,W);
+    std::vector<std::vector<ElemT>> V(num_initvec);
+    std::vector<ElemT> R(W);
+    std::vector<ElemT> dii(hii);
+    int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
+    int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
+    int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
+    int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
+    int mpi_rank_t; MPI_Comm_rank(t_comm,&mpi_rank_t);
+    int mpi_size_t; MPI_Comm_size(t_comm,&mpi_size_t);
+
+    std::vector<ElemT> vdot;
+    ElemT vnrm;
+    ElemT * H = (ElemT *) calloc(num_block*num_block,sizeof(ElemT));
+    ElemT * U = (ElemT *) calloc(num_block*num_block,sizeof(ElemT));
+    RealT * E = (RealT *) malloc(num_block*sizeof(RealT));
+    char jobz = 'V';
+    char uplo = 'U';
+    int nb = num_block;
+    MPI_Datatype DataE = GetMpiType<RealT>::MpiT;
+    MPI_Datatype DataH = GetMpiType<ElemT>::MpiT;
+
+    GetTotalD(hii,dii,h_comm);
+
+    bool do_continue = true;
+
+    for(int iv=0; iv < num_initvec; iv++) {
+      if( iv == 0 ) {
+	V[0] = std::move(W);
+      } else {
+	if( mpi_rank_t == 0 ) {
+	  if( mpi_rank_h == 0 ) {
+	    V[iv].resize(w_size);
+	    Randomize(seed+iv,V[iv],b_comm);
+	    MGS(V,iv,V[iv],vdot,b_comm);
+	    MGS(V,iv,V[iv],vdot,b_comm);
+	    Normalize(V[iv],vnrm,b_comm);
+	  }
+	  MpiBcast(V[iv],0,h_comm);
+	}
+	MpiBcast(V[iv],0,t_comm);
+      }
+    }
+
+    for(int it=0; it < max_iteration; it++) {
+      for(int iv=0; iv < num_initvec; iv++) {
+#pragma omp parallel for
+	for(size_t is=0; is < w_size; is++) {
+	  C[iv][is] = V[iv][is];
+	}
+      }
+
+      for(int ib=0; ib < nb; ib++) {
+	Zero(HC[ib]);
+	driver.run(C[ib], HC[ib]);
+	for(int jb=0; jb <= ib; jb++) {
+	  InnerProduct(C[jb],HC[ib],H[jb+nb*ib],b_comm);
+	  H[ib+nb*jb] = Conjugate(H[jb+nb*ib]);
+	}
+	if( ib < num_initvec-1 ) continue;
+
+	for(int jb=0; jb <= ib; jb++) {
+	  for(int kb=0; kb <= ib; kb++) {
+	    U[jb+nb*kb] = H[jb+nb*kb];
+	  }
+	}
+	hp_numeric::MatHeev(jobz,uplo,ib+1,U,nb,E);
+
+	for(int iv=0; iv < num_initvec; iv++) {
+	  ElemT x = U[0+nb*iv];
+#pragma omp parallel for
+	  for(size_t is=0; is < w_size; is++) {
+	    V[iv][is] = C[0][is] * x;
+	  }
+	  for(int kb=1; kb <= ib; kb++) {
+	    x = U[kb+nb*iv];
+#pragma omp parallel for
+	    for(size_t is=0; is < w_size; is++) {
+	      V[iv][is] += C[kb][is] * x;
+	    }
+	  }
+	}
+
+
+	ElemT x = ElemT(-1.0) * U[0];
+#pragma omp parallel for
+	for(size_t is=0; is < w_size; is++) {
+	  R[is] = HC[0][is] * x;
+	}
+	for(int kb=1; kb <= ib; kb++) {
+	  x = ElemT(-1.0) * U[kb];
+#pragma omp parallel for
+	  for(size_t is=0; is < w_size; is++) {
+	    R[is] += HC[kb][is] * x;
+	  }
+	}
+#pragma omp parallel for
+	for(size_t is=0; is < w_size; is++) {
+	  R[is] += E[0]*V[0][is];
+	}
+
+	for(int iv=0; iv < num_initvec; iv++) {
+	  MpiAllreduce(V[iv],MPI_SUM,t_comm);
+	  MpiAllreduce(V[iv],MPI_SUM,h_comm);
+	}
+	MpiAllreduce(R,MPI_SUM,t_comm);
+	MpiAllreduce(R,MPI_SUM,h_comm);
+        ElemT volp(1.0/(mpi_size_h*mpi_size_t));
+	for(int iv=0; iv < num_initvec; iv++) {
+#pragma	omp parallel for
+	  for(size_t is=0; is < w_size; is++) {
+	    V[iv][is] *= volp;
+	  }
+	  RealT norm_V;
+	  Normalize(V[iv],norm_V,b_comm);
+	}
+#pragma omp parallel for
+	for(size_t is=0; is < w_size; is++) {
+          R[is] *= volp;
+	}
+	RealT norm_R;
+	Normalize(R,norm_R,b_comm);
+
+	if( mpi_rank_h == 0 ) {
+	  if( mpi_rank_t == 0 ) {
+	    if( mpi_rank_b == 0 ) {
+	      std::cout << " " << make_timestamp()
+			<< " Davidson iteration " << it << "." << ib
+			<< " (tol=" << norm_R << "):";
+	      for(int p=0; p < std::min(ib+1,4); p++) {
+		std::cout << " " << E[p];
+	      }
+	      std::cout << std::endl;
+	    }
+	  }
+	}
+	if( norm_R < eps ) {
+	  do_continue = false;
+	  break;
+	}
+
+	if( ib < nb-1 ) {
+#pragma omp parallel for
+	  for(size_t is=0; is < w_size; is++) {
+	    if( std::abs(E[0]-dii[is]) > eps_reg ) {
+	      C[ib+1][is] = R[is]/(E[0] - dii[is]);
+	    } else {
+	      C[ib+1][is] = R[is]/(E[0] - dii[is] - eps_reg);
+	    }
+	  }
+
+	  // 2-step Gram-Schmidt orthogonalization
+	  MGS(C,ib+1,C[ib+1],vdot,b_comm);
+	  MGS(C,ib+1,C[ib+1],vdot,b_comm);
+	  RealT norm_C;
+	  Normalize(C[ib+1],norm_C,b_comm);
+	}
+      }
+      if( !do_continue ) {
+	break;
+      }
+    }
+
+    W = std::move(V[0]);
+
+    free(H);
+    free(U);
+    free(E);
+  }
+#endif // SBD_THRUST
+
   template <typename ElemT, typename RealT>
   void Davidson(const std::vector<ElemT> & hii,
 		const std::vector<std::vector<std::vector<size_t>>> & ih,

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -39,7 +39,7 @@ namespace sbd {
   void Davidson(const std::vector<ElemT> & hii,
 		std::vector<ElemT> & W,
 		const det_vector<size_t> & bs,
-		const size_t bit_length,
+		const int bit_length,
 		const std::vector<int> & slide,
 		const GeneralOp<ElemT> & Ham,
 		bool sign,

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -115,15 +115,13 @@ namespace sbd {
 
       for(int ib=0; ib < nb; ib++) {
 	Zero(HC[ib]);
+	mult(hii,C[ib],HC[ib],
+	     bs,bit_length,
+	     slide,Ham,sign,h_comm,b_comm,t_comm
 #ifdef SBD_THRUST
-	mult(hii,C[ib],HC[ib],
-	     bs,bit_length,
-	     slide,Ham,sign,h_comm,b_comm,t_comm,caop_driver);
-#else
-	mult(hii,C[ib],HC[ib],
-	     bs,bit_length,
-	     slide,Ham,sign,h_comm,b_comm,t_comm);
+	     , caop_driver
 #endif
+	     );
 	for(int jb=0; jb <= ib; jb++) {
 	  InnerProduct(C[jb],HC[ib],H[jb+nb*ib],b_comm);
 	  H[ib+nb*jb] = Conjugate(H[jb+nb*ib]);

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -14,7 +14,7 @@ namespace sbd {
 
   template <typename ElemT>
   void InitVectorCAOP(std::vector<ElemT> & w,
-		      const std::vector<std::vector<size_t>> & basis,
+		      const det_vector<size_t> & basis,
 		      MPI_Comm h_comm,
 		      MPI_Comm b_comm,
 		      MPI_Comm t_comm,
@@ -38,7 +38,7 @@ namespace sbd {
   template <typename ElemT, typename RealT>
   void Davidson(const std::vector<ElemT> & hii,
 		std::vector<ElemT> & W,
-		const std::vector<std::vector<size_t>> & bs,
+		const det_vector<size_t> & bs,
 		const size_t bit_length,
 		const std::vector<int> & slide,
 		const GeneralOp<ElemT> & Ham,

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -101,6 +101,10 @@ namespace sbd {
       }
     }
 
+#ifdef SBD_THRUST
+    CaopMultThrust<ElemT> caop_driver;
+#endif
+
     for(int it=0; it < max_iteration; it++) {
       for(int iv=0; iv < num_initvec; iv++) {
 #pragma omp parallel for
@@ -111,9 +115,15 @@ namespace sbd {
 
       for(int ib=0; ib < nb; ib++) {
 	Zero(HC[ib]);
+#ifdef SBD_THRUST
+	mult(hii,C[ib],HC[ib],
+	     bs,bit_length,
+	     slide,Ham,sign,h_comm,b_comm,t_comm,caop_driver);
+#else
 	mult(hii,C[ib],HC[ib],
 	     bs,bit_length,
 	     slide,Ham,sign,h_comm,b_comm,t_comm);
+#endif
 	for(int jb=0; jb <= ib; jb++) {
 	  InnerProduct(C[jb],HC[ib],H[jb+nb*ib],b_comm);
 	  H[ib+nb*jb] = Conjugate(H[jb+nb*ib]);
@@ -237,197 +247,6 @@ namespace sbd {
     
   }
 		
-#ifdef SBD_THRUST
-  // Davidson overload for the GPU (SBD_THRUST) path.
-  // Caller owns CaopMultThrust and has already called InitCaopMultThrust().
-  // driver.run() is called in place of the free mult() on each iteration.
-  template <typename ElemT, typename RealT>
-  void Davidson(const std::vector<ElemT> & hii,
-		std::vector<ElemT> & W,
-		CaopMultThrust<ElemT> & driver,
-		MPI_Comm h_comm,
-		MPI_Comm b_comm,
-		MPI_Comm t_comm,
-		int max_iteration,
-		int num_block,
-		int num_initvec,
-		RealT eps,
-		size_t seed) {
-
-    size_t w_size = W.size();
-    RealT eps_reg = 1.0e-8;
-
-    std::vector<std::vector<ElemT>> C(num_block,W);
-    std::vector<std::vector<ElemT>> HC(num_block,W);
-    std::vector<std::vector<ElemT>> V(num_initvec);
-    std::vector<ElemT> R(W);
-    std::vector<ElemT> dii(hii);
-    int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
-    int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
-    int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
-    int mpi_size_b; MPI_Comm_size(b_comm,&mpi_size_b);
-    int mpi_rank_t; MPI_Comm_rank(t_comm,&mpi_rank_t);
-    int mpi_size_t; MPI_Comm_size(t_comm,&mpi_size_t);
-
-    std::vector<ElemT> vdot;
-    ElemT vnrm;
-    ElemT * H = (ElemT *) calloc(num_block*num_block,sizeof(ElemT));
-    ElemT * U = (ElemT *) calloc(num_block*num_block,sizeof(ElemT));
-    RealT * E = (RealT *) malloc(num_block*sizeof(RealT));
-    char jobz = 'V';
-    char uplo = 'U';
-    int nb = num_block;
-    MPI_Datatype DataE = GetMpiType<RealT>::MpiT;
-    MPI_Datatype DataH = GetMpiType<ElemT>::MpiT;
-
-    GetTotalD(hii,dii,h_comm);
-
-    bool do_continue = true;
-
-    for(int iv=0; iv < num_initvec; iv++) {
-      if( iv == 0 ) {
-	V[0] = std::move(W);
-      } else {
-	if( mpi_rank_t == 0 ) {
-	  if( mpi_rank_h == 0 ) {
-	    V[iv].resize(w_size);
-	    Randomize(seed+iv,V[iv],b_comm);
-	    MGS(V,iv,V[iv],vdot,b_comm);
-	    MGS(V,iv,V[iv],vdot,b_comm);
-	    Normalize(V[iv],vnrm,b_comm);
-	  }
-	  MpiBcast(V[iv],0,h_comm);
-	}
-	MpiBcast(V[iv],0,t_comm);
-      }
-    }
-
-    for(int it=0; it < max_iteration; it++) {
-      for(int iv=0; iv < num_initvec; iv++) {
-#pragma omp parallel for
-	for(size_t is=0; is < w_size; is++) {
-	  C[iv][is] = V[iv][is];
-	}
-      }
-
-      for(int ib=0; ib < nb; ib++) {
-	Zero(HC[ib]);
-	driver.run(C[ib], HC[ib]);
-	for(int jb=0; jb <= ib; jb++) {
-	  InnerProduct(C[jb],HC[ib],H[jb+nb*ib],b_comm);
-	  H[ib+nb*jb] = Conjugate(H[jb+nb*ib]);
-	}
-	if( ib < num_initvec-1 ) continue;
-
-	for(int jb=0; jb <= ib; jb++) {
-	  for(int kb=0; kb <= ib; kb++) {
-	    U[jb+nb*kb] = H[jb+nb*kb];
-	  }
-	}
-	hp_numeric::MatHeev(jobz,uplo,ib+1,U,nb,E);
-
-	for(int iv=0; iv < num_initvec; iv++) {
-	  ElemT x = U[0+nb*iv];
-#pragma omp parallel for
-	  for(size_t is=0; is < w_size; is++) {
-	    V[iv][is] = C[0][is] * x;
-	  }
-	  for(int kb=1; kb <= ib; kb++) {
-	    x = U[kb+nb*iv];
-#pragma omp parallel for
-	    for(size_t is=0; is < w_size; is++) {
-	      V[iv][is] += C[kb][is] * x;
-	    }
-	  }
-	}
-
-
-	ElemT x = ElemT(-1.0) * U[0];
-#pragma omp parallel for
-	for(size_t is=0; is < w_size; is++) {
-	  R[is] = HC[0][is] * x;
-	}
-	for(int kb=1; kb <= ib; kb++) {
-	  x = ElemT(-1.0) * U[kb];
-#pragma omp parallel for
-	  for(size_t is=0; is < w_size; is++) {
-	    R[is] += HC[kb][is] * x;
-	  }
-	}
-#pragma omp parallel for
-	for(size_t is=0; is < w_size; is++) {
-	  R[is] += E[0]*V[0][is];
-	}
-
-	for(int iv=0; iv < num_initvec; iv++) {
-	  MpiAllreduce(V[iv],MPI_SUM,t_comm);
-	  MpiAllreduce(V[iv],MPI_SUM,h_comm);
-	}
-	MpiAllreduce(R,MPI_SUM,t_comm);
-	MpiAllreduce(R,MPI_SUM,h_comm);
-        ElemT volp(1.0/(mpi_size_h*mpi_size_t));
-	for(int iv=0; iv < num_initvec; iv++) {
-#pragma	omp parallel for
-	  for(size_t is=0; is < w_size; is++) {
-	    V[iv][is] *= volp;
-	  }
-	  RealT norm_V;
-	  Normalize(V[iv],norm_V,b_comm);
-	}
-#pragma omp parallel for
-	for(size_t is=0; is < w_size; is++) {
-          R[is] *= volp;
-	}
-	RealT norm_R;
-	Normalize(R,norm_R,b_comm);
-
-	if( mpi_rank_h == 0 ) {
-	  if( mpi_rank_t == 0 ) {
-	    if( mpi_rank_b == 0 ) {
-	      std::cout << " " << make_timestamp()
-			<< " Davidson iteration " << it << "." << ib
-			<< " (tol=" << norm_R << "):";
-	      for(int p=0; p < std::min(ib+1,4); p++) {
-		std::cout << " " << E[p];
-	      }
-	      std::cout << std::endl;
-	    }
-	  }
-	}
-	if( norm_R < eps ) {
-	  do_continue = false;
-	  break;
-	}
-
-	if( ib < nb-1 ) {
-#pragma omp parallel for
-	  for(size_t is=0; is < w_size; is++) {
-	    if( std::abs(E[0]-dii[is]) > eps_reg ) {
-	      C[ib+1][is] = R[is]/(E[0] - dii[is]);
-	    } else {
-	      C[ib+1][is] = R[is]/(E[0] - dii[is] - eps_reg);
-	    }
-	  }
-
-	  // 2-step Gram-Schmidt orthogonalization
-	  MGS(C,ib+1,C[ib+1],vdot,b_comm);
-	  MGS(C,ib+1,C[ib+1],vdot,b_comm);
-	  RealT norm_C;
-	  Normalize(C[ib+1],norm_C,b_comm);
-	}
-      }
-      if( !do_continue ) {
-	break;
-      }
-    }
-
-    W = std::move(V[0]);
-
-    free(H);
-    free(U);
-    free(E);
-  }
-#endif // SBD_THRUST
 
   template <typename ElemT, typename RealT>
   void Davidson(const std::vector<ElemT> & hii,

--- a/include/sbd/caop/basic/davidson.h
+++ b/include/sbd/caop/basic/davidson.h
@@ -50,7 +50,11 @@ namespace sbd {
 		int num_block,
 		int num_initvec,
 		RealT eps,
-		size_t seed) {
+		size_t seed
+#ifdef SBD_THRUST
+		, CaopMultThrust<ElemT>& caop_driver
+#endif
+		) {
 
     // RealT eps_reg = 1.0e-12;
     size_t w_size = W.size();
@@ -100,10 +104,6 @@ namespace sbd {
 	MpiBcast(V[iv],0,t_comm);
       }
     }
-
-#ifdef SBD_THRUST
-    CaopMultThrust<ElemT> caop_driver;
-#endif
 
     for(int it=0; it < max_iteration; it++) {
       for(int iv=0; iv < num_initvec; iv++) {

--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -80,7 +80,7 @@ namespace sbd {
     friend void mult(const std::vector<ElemT_> & hd,
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
-		     const std::vector<std::vector<size_t>> & bs,
+		     const det_vector<size_t> & bs,
 		     const size_t bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
@@ -90,14 +90,14 @@ namespace sbd {
 		     MPI_Comm t_comm);
 
     template <typename ElemT_>
-    friend void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 				     const size_t bit_length,
 				     const std::vector<int> & slide,
 				     const GeneralOp<ElemT_> & H,
 				     std::vector<ElemT_> & hii);
 
     template <typename ElemT_>
-    friend void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHam(const det_vector<size_t> & bs,
 			    const size_t bit_length,
 			    const std::vector<int> & slide,
 			    const GeneralOp<ElemT_> & H,
@@ -330,7 +330,7 @@ namespace sbd {
     friend void mult(const std::vector<ElemT_> & hd,
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
-		     const std::vector<std::vector<size_t>> & bs,
+		     const det_vector<size_t> & bs,
 		     const size_t bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
@@ -340,14 +340,14 @@ namespace sbd {
 		     MPI_Comm t_comm);
 
     template <typename ElemT_>
-    friend void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 				     const size_t bit_length,
 				     const std::vector<int> & slide,
 				     const GeneralOp<ElemT_> & H,
 				     std::vector<ElemT_> & hii);
 
     template <typename ElemT_>
-    friend void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHam(const det_vector<size_t> & bs,
 			    const size_t bit_length,
 			    const std::vector<int> & slide,
 			    const GeneralOp<ElemT_> & H,
@@ -751,7 +751,7 @@ namespace sbd {
     friend void mult(const std::vector<ElemT_> & hd,
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
-		     const std::vector<std::vector<size_t>> & bs,
+		     const det_vector<size_t> & bs,
 		     const size_t bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
@@ -761,14 +761,14 @@ namespace sbd {
 		     MPI_Comm t_comm);
 
     template <typename ElemT_>
-    friend void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 				     const size_t bit_length,
 				     const std::vector<int> & slide,
 				     const GeneralOp<ElemT_> & H,
 				     std::vector<ElemT_> & hii);
 
     template <typename ElemT_>
-    friend void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+    friend void makeCAOpHam(const det_vector<size_t> & bs,
 			    const size_t bit_length,
 			    const std::vector<int> & slide,
 			    const GeneralOp<ElemT_> & H,

--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -81,7 +81,7 @@ namespace sbd {
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
 		     const det_vector<size_t> & bs,
-		     const size_t bit_length,
+		     const int bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
 		     bool sign,
@@ -331,7 +331,7 @@ namespace sbd {
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
 		     const det_vector<size_t> & bs,
-		     const size_t bit_length,
+		     const int bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
 		     bool sign,
@@ -752,7 +752,7 @@ namespace sbd {
 		     const std::vector<ElemT_> & wk,
 		     std::vector<ElemT_> & wb,
 		     const det_vector<size_t> & bs,
-		     const size_t bit_length,
+		     const int bit_length,
 		     const std::vector<int> & slide,
 		     const GeneralOp<ElemT_> & H,
 		     bool sign,
@@ -804,16 +804,46 @@ namespace sbd {
     friend std::ostream & operator << (std::ostream & s,
 				       const GeneralOp<ElemT_> & gop);
 
+    // Precompute per-term bitmasks for fast rejection in mult (method 0).
+    // m1_[n]: bits that must be occupied in bra (creation targets in o_[n]).
+    // m2_[n]: bits that must be unoccupied in bra (annihilation targets in o_[n]).
+    // Mutable so mult() can populate lazily on first call.
+    void PrecomputeMasks(size_t bit_length) const {
+      size_t det_words = (size_t)(max_index() / (int)bit_length) + 1;
+      std::vector<size_t> zero(det_words, 0);
+      m1_ = det_vector<size_t>(o_.size(), zero);
+      m2_ = det_vector<size_t>(o_.size(), zero);
+      for (size_t n = 0; n < o_.size(); n++) {
+        for (int k = 0; k < o_[n].n_dag_; k++) {
+          size_t q = (size_t)o_[n].fops_[k].q_;
+          m1_[n][q / bit_length] |= (size_t(1) << (q % bit_length));
+        }
+        for (int k = o_[n].n_dag_; k < (int)o_[n].fops_.size(); k++) {
+          size_t q = (size_t)o_[n].fops_[k].q_;
+          m2_[n][q / bit_length] |= (size_t(1) << (q % bit_length));
+        }
+        // bits already in m1_ will be cleared before the undo-annihilation pass
+        // checks them; no bra-level check is needed for those bits in m2_.
+        for (size_t w = 0; w < det_words; w++) {
+          m2_[n][w] &= ~m1_[n][w];
+        }
+      }
+    }
+
   private:
     std::vector<ElemT> e_; // coefficient for diagonal part
     std::vector<ElemT> c_; // coefficient for off-diagonal part
     std::vector<ProductOp> d_; // diagonal part
     std::vector<ProductOp> o_; // off-diagonal part
+    mutable det_vector<size_t> m1_; // per-term occupied-required mask
+    mutable det_vector<size_t> m2_; // per-term unoccupied-required mask
     void copy(const GeneralOp & other) {
       e_ = other.e_;
       c_ = other.c_;
       d_ = other.d_;
       o_ = other.o_;
+      m1_ = other.m1_;
+      m2_ = other.m2_;
     }
 
     void init() {
@@ -821,6 +851,8 @@ namespace sbd {
       c_.resize(0);
       d_.resize(0);
       o_.resize(0);
+      m1_ = det_vector<size_t>();
+      m2_ = det_vector<size_t>();
     }
     
   }; // end GeneralOp

--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -850,28 +850,27 @@ namespace sbd {
     friend std::ostream & operator << (std::ostream & s,
 				       const GeneralOp<ElemT_> & gop);
 
-    // Precompute per-term bitmasks for fast rejection in mult (method 0).
-    // m1_[n]: bits that must be occupied in bra (creation targets in o_[n]).
-    // m2_[n]: bits that must be unoccupied in bra (annihilation targets in o_[n]).
-    // Mutable so mult() can populate lazily on first call.
-    void PrecomputeMasks(size_t bit_length) const {
+    // Compute per-term bitmasks for fast rejection in mult (method 0).
+    // m1[n]: bits that must be occupied in bra (creation targets in o_[n]).
+    // m2[n]: bits that must be unoccupied in bra (annihilation targets in o_[n]).
+    void PrecomputeMasks(size_t bit_length,
+                         det_vector<size_t>& m1,
+                         det_vector<size_t>& m2) const {
       size_t det_words = (size_t)(max_index() / (int)bit_length) + 1;
       std::vector<size_t> zero(det_words, 0);
-      m1_ = det_vector<size_t>(o_.size(), zero);
-      m2_ = det_vector<size_t>(o_.size(), zero);
+      m1 = det_vector<size_t>(o_.size(), zero);
+      m2 = det_vector<size_t>(o_.size(), zero);
       for (size_t n = 0; n < o_.size(); n++) {
         for (int k = 0; k < o_[n].n_dag_; k++) {
           size_t q = (size_t)o_[n].fops_[k].q_;
-          m1_[n][q / bit_length] |= (size_t(1) << (q % bit_length));
+          m1[n][q / bit_length] |= (size_t(1) << (q % bit_length));
         }
         for (int k = o_[n].n_dag_; k < (int)o_[n].fops_.size(); k++) {
           size_t q = (size_t)o_[n].fops_[k].q_;
-          m2_[n][q / bit_length] |= (size_t(1) << (q % bit_length));
+          m2[n][q / bit_length] |= (size_t(1) << (q % bit_length));
         }
-        // bits already in m1_ will be cleared before the undo-annihilation pass
-        // checks them; no bra-level check is needed for those bits in m2_.
         for (size_t w = 0; w < det_words; w++) {
-          m2_[n][w] &= ~m1_[n][w];
+          m2[n][w] &= ~m1[n][w];
         }
       }
     }
@@ -881,15 +880,11 @@ namespace sbd {
     std::vector<ElemT> c_; // coefficient for off-diagonal part
     std::vector<ProductOp> d_; // diagonal part
     std::vector<ProductOp> o_; // off-diagonal part
-    mutable det_vector<size_t> m1_; // per-term occupied-required mask
-    mutable det_vector<size_t> m2_; // per-term unoccupied-required mask
     void copy(const GeneralOp & other) {
       e_ = other.e_;
       c_ = other.c_;
       d_ = other.d_;
       o_ = other.o_;
-      m1_ = other.m1_;
-      m2_ = other.m2_;
     }
 
     void init() {
@@ -897,8 +892,6 @@ namespace sbd {
       c_.resize(0);
       d_.resize(0);
       o_.resize(0);
-      m1_ = det_vector<size_t>();
-      m2_ = det_vector<size_t>();
     }
     
   }; // end GeneralOp

--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -16,15 +16,6 @@ namespace sbd {
 
 #ifdef SBD_THRUST
   template <typename ElemT_> class CaopMultThrust;
-  template <typename ElemT_>
-  void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
-                           const std::vector<ElemT_>& hd,
-                           const det_vector<size_t>& bs,
-                           int bit_length,
-                           const GeneralOp<ElemT_>& H,
-                           bool sign,
-                           const std::vector<int>& slide,
-                           MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
 #endif
 
   class CAOp {
@@ -102,15 +93,7 @@ namespace sbd {
 		     MPI_Comm b_comm,
 		     MPI_Comm t_comm);
 #ifdef SBD_THRUST
-    template <typename ElemT_>
-    friend void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
-                                    const std::vector<ElemT_>& hd,
-                                    const det_vector<size_t>& bs,
-                                    int bit_length,
-                                    const GeneralOp<ElemT_>& H,
-                                    bool sign,
-                                    const std::vector<int>& slide,
-                                    MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+    template <typename ElemT_> friend class CaopMultThrust;
 #endif
 
     template <typename ElemT_>
@@ -363,15 +346,7 @@ namespace sbd {
 		     MPI_Comm b_comm,
 		     MPI_Comm t_comm);
 #ifdef SBD_THRUST
-    template <typename ElemT_>
-    friend void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
-                                    const std::vector<ElemT_>& hd,
-                                    const det_vector<size_t>& bs,
-                                    int bit_length,
-                                    const GeneralOp<ElemT_>& H,
-                                    bool sign,
-                                    const std::vector<int>& slide,
-                                    MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+    template <typename ElemT_> friend class CaopMultThrust;
 #endif
 
     template <typename ElemT_>
@@ -795,15 +770,7 @@ namespace sbd {
 		     MPI_Comm b_comm,
 		     MPI_Comm t_comm);
 #ifdef SBD_THRUST
-    template <typename ElemT_>
-    friend void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
-                                    const std::vector<ElemT_>& hd,
-                                    const det_vector<size_t>& bs,
-                                    int bit_length,
-                                    const GeneralOp<ElemT_>& H,
-                                    bool sign,
-                                    const std::vector<int>& slide,
-                                    MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+    template <typename ElemT_> friend class CaopMultThrust;
 #endif
 
     template <typename ElemT_>

--- a/include/sbd/caop/basic/generalop.h
+++ b/include/sbd/caop/basic/generalop.h
@@ -14,6 +14,19 @@ namespace sbd {
   template <typename ElemT>
   class GeneralOp;
 
+#ifdef SBD_THRUST
+  template <typename ElemT_> class CaopMultThrust;
+  template <typename ElemT_>
+  void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
+                           const std::vector<ElemT_>& hd,
+                           const det_vector<size_t>& bs,
+                           int bit_length,
+                           const GeneralOp<ElemT_>& H,
+                           bool sign,
+                           const std::vector<int>& slide,
+                           MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+#endif
+
   class CAOp {
   public:
     CAOp()
@@ -88,6 +101,17 @@ namespace sbd {
 		     MPI_Comm h_comm,
 		     MPI_Comm b_comm,
 		     MPI_Comm t_comm);
+#ifdef SBD_THRUST
+    template <typename ElemT_>
+    friend void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
+                                    const std::vector<ElemT_>& hd,
+                                    const det_vector<size_t>& bs,
+                                    int bit_length,
+                                    const GeneralOp<ElemT_>& H,
+                                    bool sign,
+                                    const std::vector<int>& slide,
+                                    MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+#endif
 
     template <typename ElemT_>
     friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
@@ -338,6 +362,17 @@ namespace sbd {
 		     MPI_Comm h_comm,
 		     MPI_Comm b_comm,
 		     MPI_Comm t_comm);
+#ifdef SBD_THRUST
+    template <typename ElemT_>
+    friend void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
+                                    const std::vector<ElemT_>& hd,
+                                    const det_vector<size_t>& bs,
+                                    int bit_length,
+                                    const GeneralOp<ElemT_>& H,
+                                    bool sign,
+                                    const std::vector<int>& slide,
+                                    MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+#endif
 
     template <typename ElemT_>
     friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
@@ -759,6 +794,17 @@ namespace sbd {
 		     MPI_Comm h_comm,
 		     MPI_Comm b_comm,
 		     MPI_Comm t_comm);
+#ifdef SBD_THRUST
+    template <typename ElemT_>
+    friend void InitCaopMultThrust(CaopMultThrust<ElemT_>& driver,
+                                    const std::vector<ElemT_>& hd,
+                                    const det_vector<size_t>& bs,
+                                    int bit_length,
+                                    const GeneralOp<ElemT_>& H,
+                                    bool sign,
+                                    const std::vector<int>& slide,
+                                    MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm);
+#endif
 
     template <typename ElemT_>
     friend void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -14,7 +14,7 @@ namespace sbd {
   template <typename ElemT, typename RealT>
   void Lanczos(const std::vector<ElemT> & hii,
 	       std::vector<ElemT> & W,
-	       const std::vector<std::vector<size_t>> & bs,
+	       const det_vector<size_t> & bs,
 	       const size_t bit_length,
 	       const std::vector<int> & slide,
 	       const GeneralOp<ElemT> & Ham,

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -24,8 +24,12 @@ namespace sbd {
 	       MPI_Comm t_comm,
 	       int max_iteration,
 	       int num_block,
-	       RealT eps) {
-    
+	       RealT eps
+#ifdef SBD_THRUST
+	       , CaopMultThrust<ElemT>& caop_driver
+#endif
+	       ) {
+
     char jobz = 'V';
     char uplo = 'U';
     int lda   = num_block;
@@ -44,9 +48,6 @@ namespace sbd {
     std::vector<ElemT> HC(W);
     std::vector<std::vector<ElemT>> C(num_block,W);
     std::vector<ElemT> edot;
-#ifdef SBD_THRUST
-    CaopMultThrust<ElemT> caop_driver;
-#endif
 
     for(int it=0; it < max_iteration; it++) {
 

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -44,6 +44,9 @@ namespace sbd {
     std::vector<ElemT> HC(W);
     std::vector<std::vector<ElemT>> C(num_block,W);
     std::vector<ElemT> edot;
+#ifdef SBD_THRUST
+    CaopMultThrust<ElemT> caop_driver;
+#endif
 
     for(int it=0; it < max_iteration; it++) {
 
@@ -63,14 +66,20 @@ namespace sbd {
       bool stop_it = false;
 
       for(int ib=0; ib < num_block; ib++) {
-	
+
 	n++;
 	int ii = ib + lda * ib;
 	int ij = ib + lda * (ib+1);
 	int ji = ib+1 + lda * ib;
+#ifdef SBD_THRUST
+	mult(hii,C[ib],HC,
+	     bs,bit_length,
+	     slide,Ham,sign,h_comm,b_comm,t_comm,caop_driver);
+#else
 	mult(hii,C[ib],HC,
 	     bs,bit_length,
 	     slide,Ham,sign,h_comm,b_comm,t_comm);
+#endif
 	InnerProduct(C[ib],HC,Aii,b_comm);
 	A[ii] = GetReal(Aii);
 	for(int i=0; i < n; i++) {

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -15,7 +15,7 @@ namespace sbd {
   void Lanczos(const std::vector<ElemT> & hii,
 	       std::vector<ElemT> & W,
 	       const det_vector<size_t> & bs,
-	       const size_t bit_length,
+	       const int bit_length,
 	       const std::vector<int> & slide,
 	       const GeneralOp<ElemT> & Ham,
 	       bool sign,

--- a/include/sbd/caop/basic/lanczos.h
+++ b/include/sbd/caop/basic/lanczos.h
@@ -72,15 +72,13 @@ namespace sbd {
 	int ii = ib + lda * ib;
 	int ij = ib + lda * (ib+1);
 	int ji = ib+1 + lda * ib;
+	mult(hii,C[ib],HC,
+	     bs,bit_length,
+	     slide,Ham,sign,h_comm,b_comm,t_comm
 #ifdef SBD_THRUST
-	mult(hii,C[ib],HC,
-	     bs,bit_length,
-	     slide,Ham,sign,h_comm,b_comm,t_comm,caop_driver);
-#else
-	mult(hii,C[ib],HC,
-	     bs,bit_length,
-	     slide,Ham,sign,h_comm,b_comm,t_comm);
+	     , caop_driver
 #endif
+	     );
 	InnerProduct(C[ib],HC,Aii,b_comm);
 	A[ii] = GetReal(Aii);
 	for(int i=0; i < n; i++) {

--- a/include/sbd/caop/basic/mkham.h
+++ b/include/sbd/caop/basic/mkham.h
@@ -10,7 +10,7 @@
 namespace sbd {
 
   template <typename ElemT>
-  void makeCAOpHamDiagTerms(const std::vector<std::vector<size_t>> & bs,
+  void makeCAOpHamDiagTerms(const det_vector<size_t> & bs,
 			       const size_t bit_length,
 			       const std::vector<int> & slide,
 			       const GeneralOp<ElemT> & H,
@@ -44,7 +44,7 @@ namespace sbd {
   }
   
   template <typename ElemT>
-  void makeCAOpHam(const std::vector<std::vector<size_t>> & bs,
+  void makeCAOpHam(const det_vector<size_t> & bs,
 		   const size_t bit_length,
 		   const std::vector<int> & slide,
 		   const GeneralOp<ElemT> & H,
@@ -71,8 +71,8 @@ namespace sbd {
     size_t num_task = slide.size();
     size_t num_terms = H.NumOpTerms();
 
-    std::vector<std::vector<size_t>> tbs;
-    std::vector<std::vector<size_t>> rbs;
+    det_vector<size_t> tbs;
+    det_vector<size_t> rbs;
 
     if( slide.size() != 0 ) {
       if( slide[0] != 0 ) {
@@ -158,8 +158,8 @@ namespace sbd {
 					 });
 	    */
 	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk,
-					 [](const std::vector<size_t> & x,
-					    const std::vector<size_t> & y) {
+					 [](const auto & x,
+					    const auto & y) {
 					   return sbd::less_from_back(x,y);
 					 });
 	    if( itik == tbs.end() ) continue;

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -11,7 +11,7 @@ namespace sbd {
   void mult(const std::vector<ElemT> & hd,
 	    const std::vector<ElemT> & wk,
 	    std::vector<ElemT> & wb,
-	    const std::vector<std::vector<size_t>> & bs,
+	    const det_vector<size_t> & bs,
 	    const size_t bit_length,
 	    const std::vector<int> & slide,
 	    const GeneralOp<ElemT> & H,
@@ -29,8 +29,8 @@ namespace sbd {
 
     std::vector<ElemT> twk;
     std::vector<ElemT> rwk;
-    std::vector<std::vector<size_t>> tbs;
-    std::vector<std::vector<size_t>> rbs;
+    det_vector<size_t> tbs;
+    det_vector<size_t> rbs;
 
     if( slide.size() != 0 ) {
       if( slide[0] != 0 ) {
@@ -114,8 +114,8 @@ namespace sbd {
 					 });
 	    */
 	    auto itik = std::lower_bound(tbs.begin(),tbs.end(),vk,
-					 [](const std::vector<size_t> & x,
-					    const std::vector<size_t> & y) {
+					 [](const auto & x,
+					    const auto & y) {
 					   return sbd::less_from_back(x,y);
 					 });
 	    if( itik == tbs.end() ) continue;

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -5,8 +5,13 @@
 #ifndef SBD_CAOP_BASIC_MULT_H
 #define SBD_CAOP_BASIC_MULT_H
 
+#ifdef SBD_THRUST
+#include "sbd/caop/basic/mult_thrust.h"
+#endif
+
 namespace sbd {
 
+#ifndef SBD_THRUST
   template <typename ElemT>
   void mult(const std::vector<ElemT> & hd,
 	    const std::vector<ElemT> & wk,
@@ -137,8 +142,9 @@ namespace sbd {
     }
     MpiAllreduce(wb,MPI_SUM,t_comm);
     MpiAllreduce(wb,MPI_SUM,h_comm);
-    
+
   }
+#endif // !SBD_THRUST
 
   template <typename ElemT>
   void mult(const std::vector<ElemT> & hii,

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -12,7 +12,7 @@ namespace sbd {
 	    const std::vector<ElemT> & wk,
 	    std::vector<ElemT> & wb,
 	    const det_vector<size_t> & bs,
-	    const size_t bit_length,
+	    const int bit_length,
 	    const std::vector<int> & slide,
 	    const GeneralOp<ElemT> & H,
 	    bool sign,
@@ -42,6 +42,8 @@ namespace sbd {
       }
     }
 
+    if( H.m1_.empty() ) H.PrecomputeMasks(bit_length);
+
     ElemT volp(1.0/(mpi_size_h*mpi_size_t));
 #pragma omp parallel for
     for(size_t i=0; i < wb.size(); i++) {
@@ -63,47 +65,44 @@ namespace sbd {
 	std::vector<size_t> vb;
 	std::vector<size_t> vk;
 	int sign_count;
-	bool check;
 	size_t size_t_one = static_cast<size_t>(1);
-	
+
 #pragma omp for schedule(dynamic)
 	for(size_t ib = ib_start; ib < ib_end; ib++) {
 
 	  vb = bs[ib];
 	  for(size_t n=0; n < H.o_.size(); n++) {
+	    // fast reject: required bits absent or forbidden bits present
+	    {
+	      bool reject = false;
+	      for(size_t w=0; w < H.m1_[n].size(); w++) {
+		if( (~vb[w] & H.m1_[n][w]) || (vb[w] & H.m2_[n][w]) ) {
+		  reject = true; break;
+		}
+	      }
+	      if( reject ) continue;
+	    }
+	    // survivor: construct ket and accumulate sign
 	    sign_count = 1;
 	    vk = vb;
-	    check = false;
 	    for(int k=0; k < H.o_[n].n_dag_; k++) {
-	      size_t q = static_cast<size_t>(H.o_[n].fops_[k].q_);
-	      size_t r = q / bit_length;
-	      size_t x = q % bit_length;
-	      if( ( vk[r] & ( size_t_one << x ) ) != 0 ) {
-		vk[r] = vk[r] ^ ( size_t_one << x );
-		if( sign ) {
-		  sign_count *= bit_string_sign_factor(vk,bit_length,x,r);
-		}
-	      } else {
-		check = true;
-		break;
+	      int q = H.o_[n].fops_[k].q_;
+	      int r = q / bit_length;
+	      int x = q % bit_length;
+	      vk[r] ^= ( size_t_one << x );
+	      if( sign ) {
+		sign_count *= bit_string_sign_factor(vk,bit_length,x,r);
 	      }
 	    }
-	    if( check ) continue;
-	    for(int k = H.o_[n].n_dag_; k < H.o_[n].fops_.size(); k++) {
-	      size_t q = static_cast<size_t>(H.o_[n].fops_[k].q_);
-	      size_t r = q / bit_length;
-	      size_t x = q % bit_length;
-	      if( ( vk[r] & ( size_t_one << x ) ) == 0 ) {
-		vk[r] = vk[r] | ( size_t_one << x );
-		if( sign ) {
-		  sign_count *= bit_string_sign_factor(vk,bit_length,x,r);
-		}
-	      } else {
-		check = true;
-		break;
+	    for(int k = H.o_[n].n_dag_; k < (int)H.o_[n].fops_.size(); k++) {
+	      int q = H.o_[n].fops_[k].q_;
+	      int r = q / bit_length;
+	      int x = q % bit_length;
+	      vk[r] |= ( size_t_one << x );
+	      if( sign ) {
+		sign_count *= bit_string_sign_factor(vk,bit_length,x,r);
 	      }
 	    }
-	    if( check ) continue;
 
 	    // we assume that tbs is aligned in ascending order
 	    /*

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -47,7 +47,8 @@ namespace sbd {
       }
     }
 
-    if( H.m1_.empty() ) H.PrecomputeMasks(bit_length);
+    det_vector<size_t> m1, m2;
+    H.PrecomputeMasks(bit_length, m1, m2);
 
     ElemT volp(1.0/(mpi_size_h*mpi_size_t));
 #pragma omp parallel for
@@ -81,7 +82,7 @@ namespace sbd {
 	    {
 	      bool reject = false;
 	      for(size_t w=0; w < H.m1_[n].size(); w++) {
-		if( (~vb[w] & H.m1_[n][w]) || (vb[w] & H.m2_[n][w]) ) {
+		if( (~vb[w] & m1[n][w]) || (vb[w] & m2[n][w]) ) {
 		  reject = true; break;
 		}
 	      }

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -81,7 +81,7 @@ namespace sbd {
 	    // fast reject: required bits absent or forbidden bits present
 	    {
 	      bool reject = false;
-	      for(size_t w=0; w < H.m1_[n].size(); w++) {
+	      for(size_t w=0; w < m1[n].size(); w++) {
 		if( (~vb[w] & m1[n][w]) || (vb[w] & m2[n][w]) ) {
 		  reject = true; break;
 		}

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -1,0 +1,664 @@
+/**
+@file sbd/caop/basic/mult_thrust.h
+@brief Thrust/CUDA GPU implementation of CAOP mult() — subwarp ballot-dispatch kernel.
+Included by mult.h when SBD_THRUST is defined. Same call signature as the CPU version.
+*/
+#ifndef SBD_CAOP_BASIC_MULT_THRUST_H
+#define SBD_CAOP_BASIC_MULT_THRUST_H
+
+#include <thrust/device_vector.h>
+#include <thrust/copy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <cub/warp/warp_reduce.cuh>
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <vector>
+#include <cstring>
+
+#include "sbd/caop/basic/generalop.h"
+#include "sbd/framework/det_vector.h"
+#include "sbd/framework/mpi_utility.h"
+#include "sbd/framework/mpi_utility_thrust.h"
+
+namespace sbd {
+
+// ============================================================
+// Tunable kernel parameters (override at compile time)
+// ============================================================
+#ifndef SBD_CAOP_MULT_BLOCK_SIZE
+  #define SBD_CAOP_MULT_BLOCK_SIZE 128
+#endif
+#ifndef SBD_CAOP_MULT_SUBWARP_SIZE
+  #define SBD_CAOP_MULT_SUBWARP_SIZE 32
+#endif
+#ifndef SBD_CAOP_MULT_MIN_BLOCKS_PER_SM
+  #define SBD_CAOP_MULT_MIN_BLOCKS_PER_SM 4
+#endif
+
+static_assert(SBD_CAOP_MULT_BLOCK_SIZE % SBD_CAOP_MULT_SUBWARP_SIZE == 0,
+              "SBD_CAOP_MULT_BLOCK_SIZE must be a multiple of SBD_CAOP_MULT_SUBWARP_SIZE");
+
+// ============================================================
+// CaopBufferSlider<ElemT>: CPU-staging MPI slider for twk.
+// ============================================================
+template <typename ElemT>
+class CaopBufferSlider {
+    MPI_Request req_sz_send_, req_sz_recv_, req_data_send_, req_data_recv_;
+    size_t sz_send_buf_, sz_recv_buf_;
+    bool have_send_, have_recv_;
+    size_t recv_size_;
+public:
+    CaopBufferSlider() : sz_send_buf_(0), sz_recv_buf_(0),
+                         have_send_(false), have_recv_(false), recv_size_(0) {}
+
+    size_t get_recv_size() const { return recv_size_; }
+
+    void ExchangeAsyncHost(const ElemT* h_send, size_t send_size,
+                           ElemT* h_recv,  size_t max_recv,
+                           int slide, MPI_Comm comm, int tag_base) {
+        int mpi_rank, mpi_size;
+        MPI_Comm_rank(comm, &mpi_rank);
+        MPI_Comm_size(comm, &mpi_size);
+        int dest   = (mpi_size + mpi_rank + slide) % mpi_size;
+        int source = (mpi_size + mpi_rank - slide) % mpi_size;
+
+        sz_send_buf_ = send_size;
+        MPI_Isend(&sz_send_buf_, 1, SBD_MPI_SIZE_T, dest,   tag_base,   comm, &req_sz_send_);
+        MPI_Irecv(&sz_recv_buf_, 1, SBD_MPI_SIZE_T, source, tag_base,   comm, &req_sz_recv_);
+
+        MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+        have_send_ = (send_size > 0);
+        if (have_send_)
+            MPI_Isend(const_cast<ElemT*>(h_send), (int)send_size, DataT,
+                      dest, tag_base + 1, comm, &req_data_send_);
+        have_recv_ = (max_recv > 0);
+        if (have_recv_)
+            MPI_Irecv(h_recv, (int)max_recv, DataT,
+                      source, tag_base + 1, comm, &req_data_recv_);
+    }
+
+    bool Sync() {
+        MPI_Status st;
+        MPI_Wait(&req_sz_send_, &st);
+        MPI_Wait(&req_sz_recv_, &st);
+        recv_size_ = sz_recv_buf_;
+        if (have_send_) { MPI_Wait(&req_data_send_, &st); have_send_ = false; }
+        if (have_recv_) { MPI_Wait(&req_data_recv_, &st); have_recv_ = false; }
+        return true;
+    }
+};
+
+// ============================================================
+// Wb_init_kernel: scale wb and add diagonal term (for t_rank==0)
+// ============================================================
+template <typename ElemT>
+struct CaopWbInitKernel {
+    ElemT* d_wb;
+    const ElemT* d_hd;
+    const ElemT* d_twk;
+    ElemT volp;
+    bool add_diag;
+
+    __host__ __device__ void operator()(size_t i) const {
+        d_wb[i] *= volp;
+        if (add_diag) d_wb[i] += d_hd[i] * d_twk[i];
+    }
+};
+
+// ============================================================
+// CaopMultKernel<ElemT>: GPU functor, one subwarp per bra.
+// ============================================================
+template <typename ElemT>
+struct CaopMultKernel {
+    static constexpr int SUBWARP       = SBD_CAOP_MULT_SUBWARP_SIZE;
+    static constexpr int BlockSize     = SBD_CAOP_MULT_BLOCK_SIZE;
+    static constexpr int GROUPS        = BlockSize / SUBWARP;
+    static constexpr int BUF_PG        = 2 * SUBWARP;
+    static constexpr int MinBlocksPerSM = SBD_CAOP_MULT_MIN_BLOCKS_PER_SM;
+
+    // bra / output
+    const size_t* d_bs;     // flat bra dets [n_bras * elem_size]
+    ElemT*        d_wb;     // output [n_bras]
+    int           n_bras;
+    int           elem_size;
+
+    // ket (current task)
+    const size_t* d_tbs;    // flat ket dets [n_kets * elem_size]
+    const ElemT*  d_twk;    // ket coefficients [n_kets]
+    int           n_kets;
+
+    // operator data (init-time)
+    const size_t* d_m1;             // must-be-occupied  [n_terms * elem_size]
+    const size_t* d_m2;             // must-be-unoccupied [n_terms * elem_size]
+    const ElemT*  d_coeff;          // coefficients+reordering sign [n_terms]
+    const int*    d_fops_bpos;      // bit positions (word-desc sorted) [total_fops]
+    const int*    d_word_start;     // [n_terms * (elem_size+1)]
+    const int*    d_ndag_per_word;  // creation ops per word [n_terms * elem_size]
+    int           n_terms;
+    bool          sign_flag;
+
+    __device__ void operator()(size_t arg_i) {
+        constexpr int SW   = SUBWARP;
+        constexpr int G    = GROUPS;
+        constexpr int BPGP = BUF_PG;
+
+        const int ib   = (int)(arg_i / SW);
+        const int lane = (int)(arg_i % SW);
+        const int grp  = (int)(threadIdx.x / SW);
+
+        if (ib >= n_bras) return;
+
+        // Dynamic shared memory layout:
+        //   s_bra  [G * (ES+1)] size_t   — bra cache, padded stride
+        //   s_n    [G * BPGP]   int      — ballot candidate buffer
+        //   vk_scr [G * SW * (ES+1)] size_t — per-lane ket scratch
+        //   wr_tmp [G]  WarpReduce::TempStorage
+        const int ps = elem_size + 1;  // padded stride
+        extern __shared__ char raw[];
+        size_t* s_bra  = (size_t*)raw;
+        int*    s_n    = (int*)(s_bra + G * ps);
+        size_t* vk_scr = (size_t*)(s_n  + G * BPGP);
+
+        using WR = cub::WarpReduce<ElemT, SW>;
+        typename WR::TempStorage* wr_tmp =
+            (typename WR::TempStorage*)(vk_scr + G * SW * ps);
+
+        size_t* my_bra = s_bra + grp * ps;
+        int*    my_n   = s_n   + grp * BPGP;
+        size_t* my_vk  = vk_scr + ((size_t)grp * SW + lane) * ps;
+
+        // Per-subwarp ballot mask (handles SW < 32 with multiple groups per warp)
+        const unsigned lane_in_warp = (unsigned)threadIdx.x % 32u;
+        const unsigned grp_in_warp  = lane_in_warp / (unsigned)SW;
+        const unsigned sw_lanes     = (SW == 32) ? 0xFFFFFFFFu : ((1u << SW) - 1u);
+        const unsigned sw_mask      = sw_lanes << (grp_in_warp * SW);
+
+        // Cooperative bra load (handles elem_size > SW)
+        for (int w = lane; w < elem_size; w += SW)
+            my_bra[w] = d_bs[(size_t)ib * elem_size + w];
+        __syncwarp(sw_mask);
+
+        ElemT thread_sum(0);
+        int s_count = 0;
+
+        for (int n_base = 0; n_base < n_terms; n_base += SW) {
+            int n = n_base + lane;
+            bool survives = false;
+            if (n < n_terms) {
+                survives = true;
+                const size_t* m1 = d_m1 + (size_t)n * elem_size;
+                const size_t* m2 = d_m2 + (size_t)n * elem_size;
+                for (int w = 0; w < elem_size && survives; w++) {
+                    if ((~my_bra[w] & m1[w]) || (my_bra[w] & m2[w]))
+                        survives = false;
+                }
+            }
+            unsigned ballot = __ballot_sync(sw_mask, survives);
+            if (survives) {
+                int rank = __popc(ballot & ((1u << lane_in_warp) - 1u));
+                my_n[s_count + rank] = n;
+            }
+            s_count += __popc(ballot);
+
+            if (s_count >= SW) {
+                __syncwarp(sw_mask);
+                if (lane < s_count)
+                    thread_sum += compute_contribution(my_bra, my_vk, my_n[lane]);
+                // compact: shift remainder left by SW
+                int next_idx = lane + SW;
+                int next_val = (next_idx < s_count) ? my_n[next_idx] : 0;
+                // fence before write
+                __syncwarp(sw_mask);
+                my_n[lane] = next_val;
+                s_count -= SW;
+            }
+        }
+
+        // drain remainder
+        if (s_count > 0) {
+            __syncwarp(sw_mask);
+            if (lane < s_count)
+                thread_sum += compute_contribution(my_bra, my_vk, my_n[lane]);
+        }
+
+        ElemT total = WR(wr_tmp[grp]).Sum(thread_sum);
+        if (lane == 0) d_wb[ib] += total;
+    }
+
+    __device__ ElemT compute_contribution(const size_t* my_bra, size_t* my_vk, int m) {
+        for (int w = 0; w < elem_size; w++) my_vk[w] = my_bra[w];
+
+        int sign = 1;
+        size_t lo = 0, hi = (size_t)n_kets;
+
+        for (int w = elem_size - 1; w >= 0; w--) {
+            int wi       = elem_size - 1 - w;
+            int op_start = d_word_start[m * (elem_size + 1) + wi];
+            int op_end   = d_word_start[m * (elem_size + 1) + wi + 1];
+            int n_dag_w  = (op_start < op_end) ? d_ndag_per_word[m * elem_size + wi] : 0;
+
+            // creation ops
+            for (int k = op_start, ke = op_start + n_dag_w; k < ke; k++) {
+                size_t bit = (size_t)1 << d_fops_bpos[k];
+                my_vk[w] ^= bit;
+                if (sign_flag) {
+                    long long n_occ = __popcll((unsigned long long)(my_vk[w] & (bit - 1)));
+                    for (int w2 = 0; w2 < w; w2++)
+                        n_occ += __popcll((unsigned long long)my_vk[w2]);
+                    if (n_occ & 1) sign = -sign;
+                }
+            }
+            // annihilation ops
+            for (int k = op_start + n_dag_w; k < op_end; k++) {
+                size_t bit = (size_t)1 << d_fops_bpos[k];
+                my_vk[w] |= bit;
+                if (sign_flag) {
+                    long long n_occ = __popcll((unsigned long long)(my_vk[w] & (bit - 1)));
+                    for (int w2 = 0; w2 < w; w2++)
+                        n_occ += __popcll((unsigned long long)my_vk[w2]);
+                    if (n_occ & 1) sign = -sign;
+                }
+            }
+
+            // lower_bound for my_vk[w]
+            {
+                size_t L = lo, R = hi;
+                while (L < R) {
+                    size_t mid = L + (R - L) / 2;
+                    if (d_tbs[mid * elem_size + w] < my_vk[w]) L = mid + 1;
+                    else R = mid;
+                }
+                lo = L;
+            }
+            if (lo >= hi || d_tbs[lo * elem_size + w] != my_vk[w]) return ElemT(0);
+
+            if (w > 0) {
+                // upper_bound
+                size_t L = lo, R = hi;
+                while (L < R) {
+                    size_t mid = L + (R - L) / 2;
+                    if (d_tbs[mid * elem_size + w] <= my_vk[w]) L = mid + 1;
+                    else R = mid;
+                }
+                hi = L;
+            }
+        }
+
+        return d_coeff[m] * ElemT(sign) * d_twk[lo];
+    }
+};
+
+// ============================================================
+// Kernel launcher with dynamic shared memory
+// ============================================================
+template <typename F>
+__global__ __launch_bounds__(F::BlockSize, F::MinBlocksPerSM)
+void caop_mult_kernel_fn(size_t n_threads, F f) {
+    size_t i = (size_t)blockIdx.x * F::BlockSize + threadIdx.x;
+    if (i < n_threads) f(i);
+}
+
+template <typename F>
+inline void launch_caop_mult(size_t n_bras, F f, size_t smem_bytes, cudaStream_t stream) {
+    if (n_bras == 0) return;
+    constexpr int BS = F::BlockSize;
+    constexpr int SW = F::SUBWARP;
+    size_t n_threads = n_bras * SW;
+    size_t grid = (n_threads + BS - 1) / BS;
+    caop_mult_kernel_fn<F><<<grid, BS, smem_bytes, stream>>>(n_threads, f);
+}
+
+// ============================================================
+// CaopMultThrust<ElemT>: host-side driver
+// ============================================================
+template <typename ElemT>
+class CaopMultThrust {
+    // init-time GPU data
+    thrust::device_vector<size_t> d_bs_;
+    thrust::device_vector<ElemT>  d_hd_;
+    thrust::device_vector<size_t> d_m1_;
+    thrust::device_vector<size_t> d_m2_;
+    thrust::device_vector<ElemT>  d_coeff_;
+    thrust::device_vector<int>    d_fops_bpos_;
+    thrust::device_vector<int>    d_word_start_;
+    thrust::device_vector<int>    d_ndag_per_word_;
+
+    // per-task ket det sequences (precomputed at Init; fixed for all Davidson iters)
+    std::vector<thrust::device_vector<size_t>> d_tbs_seq_;
+    std::vector<size_t> n_kets_per_task_;
+    size_t global_max_kets_;
+
+    int n_bras_;
+    int n_terms_;
+    int elem_size_;
+    bool sign_;
+    size_t smem_bytes_;
+
+    std::vector<int> slide_;
+    MPI_Comm h_comm_, b_comm_, t_comm_;
+
+public:
+    CaopMultThrust() : n_bras_(0), n_terms_(0), elem_size_(0), sign_(false),
+                       smem_bytes_(0), global_max_kets_(0) {}
+
+    void Init(const std::vector<ElemT>& hd,
+              const det_vector<size_t>& bs,
+              int bit_length,
+              const GeneralOp<ElemT>& H,
+              bool sign,
+              const std::vector<int>& slide,
+              MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
+        h_comm_ = h_comm; b_comm_ = b_comm; t_comm_ = t_comm;
+        sign_   = sign;
+        slide_  = slide;
+        n_bras_ = (int)bs.size();
+        elem_size_ = (n_bras_ > 0) ? (int)bs.elem_size() : 0;
+
+        if (H.m1_.empty()) H.PrecomputeMasks(bit_length);
+
+        // Upload bras
+        {
+            const auto& flat = bs.cflat();
+            d_bs_.resize(flat.size());
+            thrust::copy_n(flat.begin(), flat.size(), d_bs_.begin());
+        }
+        // Upload diagonal
+        d_hd_.resize(hd.size());
+        thrust::copy_n(hd.begin(), hd.size(), d_hd_.begin());
+
+        n_terms_ = (int)H.o_.size();
+
+        if (n_terms_ > 0 && elem_size_ > 0) {
+            // Upload masks
+            {
+                const auto& fm1 = H.m1_.cflat();
+                d_m1_.resize(fm1.size());
+                thrust::copy_n(fm1.begin(), fm1.size(), d_m1_.begin());
+            }
+            {
+                const auto& fm2 = H.m2_.cflat();
+                d_m2_.resize(fm2.size());
+                thrust::copy_n(fm2.begin(), fm2.size(), d_m2_.begin());
+            }
+
+            // Build sorted operator tables
+            const int ES = elem_size_;
+            std::vector<ElemT> coeff_host(n_terms_);
+            std::vector<int>   word_start_host(n_terms_ * (ES + 1), 0);
+            std::vector<int>   ndag_per_word_host(n_terms_ * ES, 0);
+            std::vector<int>   fops_bpos_host;
+            fops_bpos_host.reserve(n_terms_ * 4);
+
+            int fpos = 0;
+            for (int m = 0; m < n_terms_; m++) {
+                const auto& op   = H.o_[m];
+                int n_fops = (int)op.fops_.size();
+                int n_dag  = op.n_dag_;
+
+                struct OpInfo { int orig_idx, word, bpos, type; };
+                std::vector<OpInfo> ops(n_fops);
+                for (int k = 0; k < n_fops; k++) {
+                    int q = op.fops_[k].q_;
+                    ops[k] = { k, q / bit_length, q % bit_length, (k < n_dag) ? 0 : 1 };
+                }
+
+                // Sort: word DESC, creation (0) before annihilation (1), original order within
+                std::stable_sort(ops.begin(), ops.end(), [](const OpInfo& a, const OpInfo& b) {
+                    if (a.word != b.word) return a.word > b.word;
+                    if (a.type != b.type) return a.type < b.type;
+                    return a.orig_idx < b.orig_idx;
+                });
+
+                // Count inversions in the permutation (original_idx sequence after sort)
+                std::vector<int> perm(n_fops);
+                for (int i = 0; i < n_fops; i++) perm[i] = ops[i].orig_idx;
+                int inv = 0;
+                for (int i = 0; i < n_fops; i++)
+                    for (int j = i + 1; j < n_fops; j++)
+                        if (perm[i] > perm[j]) inv++;
+                coeff_host[m] = H.c_[m] * ((inv & 1) ? ElemT(-1) : ElemT(1));
+
+                // Fill word_start and ndag_per_word
+                int cur_wi   = 0;
+                int cur_word = ES - 1;
+                word_start_host[m * (ES + 1) + 0] = fpos;
+
+                for (int i = 0; i < n_fops; i++) {
+                    // Advance word index while cur_word > ops[i].word
+                    while (ops[i].word < cur_word) {
+                        cur_wi++;
+                        cur_word--;
+                        word_start_host[m * (ES + 1) + cur_wi] = fpos;
+                    }
+                    fops_bpos_host.push_back(ops[i].bpos);
+                    if (ops[i].type == 0) ndag_per_word_host[m * ES + cur_wi]++;
+                    fpos++;
+                }
+                // Fill remaining word entries
+                for (int wi = cur_wi + 1; wi <= ES; wi++)
+                    word_start_host[m * (ES + 1) + wi] = fpos;
+            }
+
+            d_coeff_.resize(n_terms_);
+            thrust::copy_n(coeff_host.begin(), n_terms_, d_coeff_.begin());
+            d_fops_bpos_.resize(fops_bpos_host.size());
+            if (!fops_bpos_host.empty())
+                thrust::copy_n(fops_bpos_host.begin(), fops_bpos_host.size(), d_fops_bpos_.begin());
+            d_word_start_.resize(word_start_host.size());
+            thrust::copy_n(word_start_host.begin(), word_start_host.size(), d_word_start_.begin());
+            d_ndag_per_word_.resize(ndag_per_word_host.size());
+            thrust::copy_n(ndag_per_word_host.begin(), ndag_per_word_host.size(), d_ndag_per_word_.begin());
+        }
+
+        // Precompute tbs_seq (one MpiSlide per task)
+        size_t n_tasks = slide.size();
+        d_tbs_seq_.resize(n_tasks);
+        n_kets_per_task_.resize(n_tasks, 0);
+        global_max_kets_ = 0;
+
+        if (n_tasks > 0) {
+            det_vector<size_t> cur_tbs;
+            if (!slide.empty() && slide[0] != 0) {
+                MpiSlide(bs, cur_tbs, slide[0], b_comm_);
+            } else {
+                cur_tbs = bs;
+            }
+
+            for (size_t task = 0; task < n_tasks; task++) {
+                n_kets_per_task_[task] = cur_tbs.size();
+                if (cur_tbs.size() > global_max_kets_) global_max_kets_ = cur_tbs.size();
+                const auto& flat = cur_tbs.cflat();
+                d_tbs_seq_[task].resize(flat.size());
+                if (!flat.empty())
+                    thrust::copy_n(flat.begin(), flat.size(), d_tbs_seq_[task].begin());
+
+                if (task + 1 < n_tasks) {
+                    int bslide = slide[task] - slide[task + 1];
+                    det_vector<size_t> next_tbs;
+                    MpiSlide(cur_tbs, next_tbs, bslide, b_comm_);
+                    cur_tbs = std::move(next_tbs);
+                }
+            }
+        }
+
+        // Compute smem per block
+        constexpr int SW   = CaopMultKernel<ElemT>::SUBWARP;
+        constexpr int G    = CaopMultKernel<ElemT>::GROUPS;
+        constexpr int BPGP = CaopMultKernel<ElemT>::BUF_PG;
+        using WR = cub::WarpReduce<ElemT, SW>;
+        int ps = elem_size_ + 1;
+        smem_bytes_ = (size_t)G * ps * sizeof(size_t)          // s_bra
+                    + (size_t)G * BPGP * sizeof(int)            // s_n
+                    + (size_t)G * SW * ps * sizeof(size_t)       // vk_scr
+                    + (size_t)G * sizeof(typename WR::TempStorage); // wr_tmp
+    }
+
+    void run(const std::vector<ElemT>& wk, std::vector<ElemT>& wb) {
+        if (slide_.empty()) return;
+
+        int mpi_size_h; MPI_Comm_size(h_comm_, &mpi_size_h);
+        int mpi_rank_h; MPI_Comm_rank(h_comm_, &mpi_rank_h);
+        int mpi_size_t; MPI_Comm_size(t_comm_, &mpi_size_t);
+        int mpi_rank_t; MPI_Comm_rank(t_comm_, &mpi_rank_t);
+
+        // Upload wb to GPU
+        thrust::device_vector<ElemT> d_wb(wb.size());
+        thrust::copy_n(wb.begin(), wb.size(), d_wb.begin());
+
+        // Initial slide of wk
+        std::vector<ElemT> twk_init;
+        if (slide_[0] != 0) {
+            MpiSlide(wk, twk_init, slide_[0], b_comm_);
+        } else {
+            twk_init = wk;
+        }
+
+        // Find global max for pre-allocation
+        size_t local_ket = twk_init.size();
+        size_t gmax_ket  = global_max_kets_;
+        {
+            size_t tmp;
+            MPI_Allreduce(&local_ket, &tmp, 1, SBD_MPI_SIZE_T, MPI_MAX, b_comm_);
+            if (tmp > gmax_ket) gmax_ket = tmp;
+        }
+
+        // Allocate double buffers
+        int active_buf = 0, recv_buf = 1;
+        size_t twk_size[2] = { twk_init.size(), gmax_ket };
+
+        thrust::device_vector<ElemT> d_twk[2];
+        d_twk[0].resize(gmax_ket);
+        d_twk[1].resize(gmax_ket);
+
+        ElemT* h_twk[2] = { nullptr, nullptr };
+        cudaMallocHost(&h_twk[0], gmax_ket * sizeof(ElemT));
+        cudaMallocHost(&h_twk[1], gmax_ket * sizeof(ElemT));
+
+        // Create streams and events
+        cudaStream_t compute_stream, copy_stream;
+        cudaStreamCreateWithFlags(&compute_stream, cudaStreamNonBlocking);
+        cudaStreamCreateWithFlags(&copy_stream,    cudaStreamNonBlocking);
+        cudaEvent_t copy_done[2], compute_done[2];
+        cudaEventCreateWithFlags(&copy_done[0],    cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&copy_done[1],    cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&compute_done[0], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&compute_done[1], cudaEventDisableTiming);
+        // Mark both compute_done slots as completed so the first copy_stream wait
+        // on the unused recv_buf slot doesn't hang.
+        cudaEventRecord(compute_done[0], 0);
+        cudaEventRecord(compute_done[1], 0);
+        cudaDeviceSynchronize();
+
+        // Seed active buffer: CPU → pinned → GPU
+        if (!twk_init.empty())
+            std::memcpy(h_twk[active_buf], twk_init.data(), twk_size[active_buf] * sizeof(ElemT));
+        cudaMemcpyAsync(thrust::raw_pointer_cast(d_twk[active_buf].data()),
+                        h_twk[active_buf],
+                        twk_size[active_buf] * sizeof(ElemT),
+                        cudaMemcpyHostToDevice, copy_stream);
+        cudaEventRecord(copy_done[active_buf], copy_stream);
+        cudaEventRecord(copy_done[recv_buf],   copy_stream);
+
+        // Wb_init: scale + add diagonal (on compute_stream, after d_twk[active_buf] is ready)
+        {
+            ElemT volp = ElemT(1.0 / ((double)mpi_size_h * (double)mpi_size_t));
+            CaopWbInitKernel<ElemT> wbinit;
+            wbinit.d_wb  = thrust::raw_pointer_cast(d_wb.data());
+            wbinit.d_hd  = thrust::raw_pointer_cast(d_hd_.data());
+            wbinit.d_twk = thrust::raw_pointer_cast(d_twk[active_buf].data());
+            wbinit.volp  = volp;
+            wbinit.add_diag = (mpi_rank_t == 0);
+            auto ci = thrust::counting_iterator<size_t>(0);
+            cudaStreamWaitEvent(compute_stream, copy_done[active_buf]);
+            thrust::for_each_n(thrust::cuda::par.on(compute_stream), ci, (size_t)n_bras_, wbinit);
+        }
+
+        CaopBufferSlider<ElemT> slider;
+
+        for (size_t task = 0; task < slide_.size(); task++) {
+            cudaStreamWaitEvent(compute_stream, copy_done[active_buf]);
+
+            if (n_terms_ > 0) {
+                CaopMultKernel<ElemT> kernel;
+                kernel.d_bs          = thrust::raw_pointer_cast(d_bs_.data());
+                kernel.d_wb          = thrust::raw_pointer_cast(d_wb.data());
+                kernel.n_bras        = n_bras_;
+                kernel.elem_size     = elem_size_;
+                kernel.d_tbs         = thrust::raw_pointer_cast(d_tbs_seq_[task].data());
+                kernel.d_twk         = thrust::raw_pointer_cast(d_twk[active_buf].data());
+                kernel.n_kets        = (int)n_kets_per_task_[task];
+                kernel.d_m1          = thrust::raw_pointer_cast(d_m1_.data());
+                kernel.d_m2          = thrust::raw_pointer_cast(d_m2_.data());
+                kernel.d_coeff       = thrust::raw_pointer_cast(d_coeff_.data());
+                kernel.d_fops_bpos   = thrust::raw_pointer_cast(d_fops_bpos_.data());
+                kernel.d_word_start  = thrust::raw_pointer_cast(d_word_start_.data());
+                kernel.d_ndag_per_word = thrust::raw_pointer_cast(d_ndag_per_word_.data());
+                kernel.n_terms       = n_terms_;
+                kernel.sign_flag     = sign_;
+                launch_caop_mult((size_t)n_bras_, kernel, smem_bytes_, compute_stream);
+            }
+
+            cudaEventRecord(compute_done[active_buf], compute_stream);
+
+            if (task + 1 < slide_.size()) {
+                int bslide = slide_[task] - slide_[task + 1];
+                cudaEventSynchronize(copy_done[recv_buf]);
+                slider.ExchangeAsyncHost(
+                    h_twk[active_buf], twk_size[active_buf],
+                    h_twk[recv_buf],   gmax_ket,
+                    bslide, b_comm_, (int)task * 4);
+                if (slider.Sync()) {
+                    twk_size[recv_buf] = slider.get_recv_size();
+                    cudaStreamWaitEvent(copy_stream, compute_done[recv_buf]);
+                    cudaMemcpyAsync(thrust::raw_pointer_cast(d_twk[recv_buf].data()),
+                                    h_twk[recv_buf],
+                                    twk_size[recv_buf] * sizeof(ElemT),
+                                    cudaMemcpyHostToDevice, copy_stream);
+                    cudaEventRecord(copy_done[recv_buf], copy_stream);
+                    std::swap(active_buf, recv_buf);
+                    // After swap: twk_size[active_buf] already holds the correct recv_size
+                    // (set before the swap at twk_size[old_recv_buf]). No update needed.
+                }
+            } else {
+                cudaEventSynchronize(compute_done[active_buf]);
+            }
+        }
+
+        // Cleanup
+        cudaFreeHost(h_twk[0]); cudaFreeHost(h_twk[1]);
+        cudaEventDestroy(copy_done[0]);    cudaEventDestroy(copy_done[1]);
+        cudaEventDestroy(compute_done[0]); cudaEventDestroy(compute_done[1]);
+        cudaStreamDestroy(copy_stream);
+        cudaStreamDestroy(compute_stream);
+
+        // Allreduce
+        MpiAllreduce(d_wb, MPI_SUM, t_comm_);
+        MpiAllreduce(d_wb, MPI_SUM, h_comm_);
+
+        // Download wb
+        thrust::copy_n(d_wb.begin(), wb.size(), wb.begin());
+    }
+};
+
+// ============================================================
+// Free mult() — same signature as CPU version, selected by SBD_THRUST
+// ============================================================
+template <typename ElemT>
+void mult(const std::vector<ElemT>& hd,
+          const std::vector<ElemT>& wk,
+          std::vector<ElemT>& wb,
+          const det_vector<size_t>& bs,
+          const int bit_length,
+          const std::vector<int>& slide,
+          const GeneralOp<ElemT>& H,
+          bool sign,
+          MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
+    CaopMultThrust<ElemT> data;
+    data.Init(hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
+    data.run(wk, wb);
+}
+
+} // namespace sbd
+
+#endif // SBD_CAOP_BASIC_MULT_THRUST_H

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -322,22 +322,6 @@ inline void launch_caop_mult(size_t n_bras, F f, size_t smem_bytes, cudaStream_t
 }
 
 // ============================================================
-// POD structs for pre-extracted GeneralOp data.
-// CaopMultThrust::Init() takes these instead of GeneralOp directly
-// (GeneralOp members are private; only the friend mult() function
-// can read them and pass them here).
-// ============================================================
-struct CaopRawOp {
-    int q;        // orbital index
-    int is_dag;   // 1 = creation, 0 = annihilation
-};
-
-struct CaopRawTerm {
-    int n_dag;                    // number of leading creation ops
-    std::vector<CaopRawOp> fops; // ops in original order
-};
-
-// ============================================================
 // CaopMultThrust<ElemT>: host-side driver
 // ============================================================
 template <typename ElemT>
@@ -448,28 +432,23 @@ public:
         free_run_resources();
     }
 
-    // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
-    // terms as CaopRawTerm, c as coefficient vector). Extracts are done by
-    // InitCaopMultThrust() (friend of GeneralOp) and forwarded here.
-    // Does NOT precompute tbs_seq — that happens lazily on the first run() call.
+    // Init: uploads Hamiltonian and basis data to the GPU.
     // Idempotent: returns immediately if already initialized for the same problem.
     // Throws std::logic_error if dimensions changed without reset() being called.
+    // Does NOT precompute tbs_seq — that happens lazily on the first run() call.
     void Init(const std::vector<ElemT>& hd,
               const det_vector<size_t>& bs,
               int bit_length,
-              const std::vector<ElemT>& c,
-              const std::vector<CaopRawTerm>& terms,
-              const std::vector<size_t>& m1_flat,
-              const std::vector<size_t>& m2_flat,
+              const GeneralOp<ElemT>& H,
               bool sign,
               const std::vector<int>& slide,
               MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
         // Idempotent: return if already initialized for the same problem.
         // Throw if dimensions changed without reset() being called first.
         if (init_done_) {
-            if ((int)terms.size() != n_terms_ ||
-                (int)bs.size()    != n_bras_  ||
-                slide.size()      != slide_.size())
+            if ((int)H.o_.size() != n_terms_ ||
+                (int)bs.size()   != n_bras_  ||
+                slide.size()     != slide_.size())
                 throw std::logic_error(
                     "CaopMultThrust::Init: problem dimensions changed; call reset() before reinitializing");
             return;
@@ -498,14 +477,22 @@ public:
         d_hd_.resize(hd.size());
         thrust::copy_n(hd.begin(), hd.size(), d_hd_.begin());
 
-        n_terms_ = (int)terms.size();
+        n_terms_ = (int)H.o_.size();
 
         if (n_terms_ > 0 && elem_size_ > 0) {
-            // Upload masks
-            d_m1_.resize(m1_flat.size());
-            thrust::copy_n(m1_flat.begin(), m1_flat.size(), d_m1_.begin());
-            d_m2_.resize(m2_flat.size());
-            thrust::copy_n(m2_flat.begin(), m2_flat.size(), d_m2_.begin());
+            // Compute and upload masks
+            det_vector<size_t> m1, m2;
+            H.PrecomputeMasks(bit_length, m1, m2);
+            {
+                const auto& fm1 = m1.cflat();
+                d_m1_.resize(fm1.size());
+                thrust::copy_n(fm1.begin(), fm1.size(), d_m1_.begin());
+            }
+            {
+                const auto& fm2 = m2.cflat();
+                d_m2_.resize(fm2.size());
+                thrust::copy_n(fm2.begin(), fm2.size(), d_m2_.begin());
+            }
 
             // Build sorted operator tables
             const int ES = elem_size_;
@@ -517,14 +504,14 @@ public:
 
             int fpos = 0;
             for (int m = 0; m < n_terms_; m++) {
-                const auto& term  = terms[m];
-                int n_fops = (int)term.fops.size();
-                int n_dag  = term.n_dag;
+                const auto& op = H.o_[m];
+                int n_fops = (int)op.fops_.size();
+                int n_dag  = op.n_dag_;
 
                 struct OpInfo { int orig_idx, word, bpos, type; };
                 std::vector<OpInfo> ops(n_fops);
                 for (int k = 0; k < n_fops; k++) {
-                    int q = term.fops[k].q;
+                    int q = op.fops_[k].q_;
                     ops[k] = { k, q / bit_length, q % bit_length, (k < n_dag) ? 0 : 1 };
                 }
 
@@ -542,7 +529,7 @@ public:
                 for (int i = 0; i < n_fops; i++)
                     for (int j = i + 1; j < n_fops; j++)
                         if (perm[i] > perm[j]) inv++;
-                coeff_host[m] = c[m] * ((sign && (inv & 1)) ? ElemT(-1) : ElemT(1));
+                coeff_host[m] = H.c_[m] * ((sign && (inv & 1)) ? ElemT(-1) : ElemT(1));
 
                 // Fill word_start and ndag_per_word
                 int cur_wi   = 0;
@@ -732,46 +719,9 @@ public:
 };
 
 // ============================================================
-// InitCaopMultThrust — extracts GeneralOp data and calls driver.Init().
-// Declared as a friend of GeneralOp / CAOp / ProductOp in generalop.h.
-// driver.Init() is idempotent: returns immediately on the second call if
-// dimensions haven't changed; throws if they changed without reset().
-// ============================================================
-template <typename ElemT>
-void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
-                         const std::vector<ElemT>& hd,
-                         const det_vector<size_t>& bs,
-                         int bit_length,
-                         const GeneralOp<ElemT>& H,
-                         bool sign,
-                         const std::vector<int>& slide,
-                         MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
-    det_vector<size_t> m1, m2;
-    H.PrecomputeMasks(bit_length, m1, m2);
-
-    std::vector<CaopRawTerm> terms;
-    terms.reserve(H.o_.size());
-    for (const auto& op : H.o_) {
-        CaopRawTerm t;
-        t.n_dag = op.n_dag_;
-        for (const auto& f : op.fops_)
-            t.fops.push_back({ f.q_, f.d_ ? 1 : 0 });
-        terms.push_back(std::move(t));
-    }
-
-    const auto& fm1 = m1.cflat();
-    const auto& fm2 = m2.cflat();
-    std::vector<size_t> m1_flat(fm1.begin(), fm1.end());
-    std::vector<size_t> m2_flat(fm2.begin(), fm2.end());
-
-    driver.Init(hd, bs, bit_length, H.c_, terms, m1_flat, m2_flat,
-                sign, slide, h_comm, b_comm, t_comm);
-}
-
-// ============================================================
 // Free mult() — caller supplies a CaopMultThrust<ElemT>& to own GPU resources.
-// Calls InitCaopMultThrust() on every invocation; Init() returns immediately if
-// the driver is already initialized for the same problem (idempotent).
+// driver.Init() is idempotent: returns immediately if already initialized for
+// the same problem; throws if dimensions changed without reset().
 // Call reset() on the driver before reuse if H or the basis changes.
 // ============================================================
 template <typename ElemT>
@@ -785,7 +735,7 @@ void mult(const std::vector<ElemT>& hd,
           bool sign,
           MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm,
           CaopMultThrust<ElemT>& driver) {
-    InitCaopMultThrust(driver, hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
+    driver.Init(hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
     driver.run(wk, wb);
 }
 

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -27,17 +27,19 @@ namespace sbd {
 // Tunable kernel parameters (override at compile time)
 // ============================================================
 #ifndef SBD_CAOP_MULT_BLOCK_SIZE
-  #define SBD_CAOP_MULT_BLOCK_SIZE 128
+  #define SBD_CAOP_MULT_BLOCK_SIZE 64
 #endif
 #ifndef SBD_CAOP_MULT_SUBWARP_SIZE
   #define SBD_CAOP_MULT_SUBWARP_SIZE 32
 #endif
 #ifndef SBD_CAOP_MULT_MIN_BLOCKS_PER_SM
-  #define SBD_CAOP_MULT_MIN_BLOCKS_PER_SM 4
+  #define SBD_CAOP_MULT_MIN_BLOCKS_PER_SM 32
 #endif
 
-static_assert(SBD_CAOP_MULT_BLOCK_SIZE % SBD_CAOP_MULT_SUBWARP_SIZE == 0,
-              "SBD_CAOP_MULT_BLOCK_SIZE must be a multiple of SBD_CAOP_MULT_SUBWARP_SIZE");
+static_assert(SBD_CAOP_MULT_BLOCK_SIZE % 32 == 0,
+              "SBD_CAOP_MULT_BLOCK_SIZE must be a multiple of 32 (full warp)");
+static_assert(32 % SBD_CAOP_MULT_SUBWARP_SIZE == 0,
+              "SBD_CAOP_MULT_SUBWARP_SIZE must divide 32 (must be 1, 2, 4, 8, 16, or 32)");
 
 // ============================================================
 // CaopBufferSlider<ElemT>: CPU-staging MPI slider for twk.

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -735,7 +735,8 @@ void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
                          bool sign,
                          const std::vector<int>& slide,
                          MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
-    if (H.m1_.empty()) H.PrecomputeMasks(bit_length);
+    det_vector<size_t> m1, m2;
+    H.PrecomputeMasks(bit_length, m1, m2);
 
     std::vector<CaopRawTerm> terms;
     terms.reserve(H.o_.size());
@@ -747,8 +748,8 @@ void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
         terms.push_back(std::move(t));
     }
 
-    const auto& fm1 = H.m1_.cflat();
-    const auto& fm2 = H.m2_.cflat();
+    const auto& fm1 = m1.cflat();
+    const auto& fm2 = m2.cflat();
     std::vector<size_t> m1_flat(fm1.begin(), fm1.end());
     std::vector<size_t> m2_flat(fm2.begin(), fm2.end());
 

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -225,12 +225,18 @@ struct CaopMultKernel {
     }
 
     __device__ ElemT compute_contribution(const size_t* my_bra, int m) {
-        // No vk_scr scratch: cur_w is a register tracking this word's evolving state.
-        // The outer loop descends (w = elem_size-1 .. 0), so at word w all lower
-        // words w2 < w are still my_bra[w2] — never written.  n_occ_base accumulates
-        // their popcount once per word instead of once per op.
+        // n_occ_base starts as the full-bra popcount across all words.  At the
+        // top of each w iteration we subtract __popcll(cur_w) — which equals
+        // __popcll(my_bra[w]) before any ops touch cur_w — leaving the sum for
+        // words w2 < w, which is what the sign logic needs.
         int sign = 1;
         size_t lo = 0, hi = (size_t)n_kets;
+
+        int n_occ_base = 0;
+        if (sign_flag) {
+            for (int w2 = 0; w2 < elem_size; w2++)
+                n_occ_base += __popcll((unsigned long long)my_bra[w2]);
+        }
 
         for (int w = elem_size - 1; w >= 0; w--) {
             int wi       = elem_size - 1 - w;
@@ -240,13 +246,8 @@ struct CaopMultKernel {
 
             size_t cur_w = my_bra[w];  // register: evolves as ops are applied
 
-            // popcount of lower words — computed once per word, reused by all ops.
-            // For elem_size==1 (30-orbital common case) w==0 always, loop never runs.
-            int n_occ_base = 0;
-            if (sign_flag) {
-                for (int w2 = 0; w2 < w; w2++)
-                    n_occ_base += __popcll((unsigned long long)my_bra[w2]);
-            }
+            if (sign_flag)
+                n_occ_base -= __popcll((unsigned long long)cur_w);
 
             // creation ops
             for (int k = op_start, ke = op_start + n_dag_w; k < ke; k++) {

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -152,21 +152,19 @@ struct CaopMultKernel {
         // Dynamic shared memory layout:
         //   s_bra  [G * (ES+1)] size_t   — bra cache, padded stride
         //   s_n    [G * BPGP]   int      — ballot candidate buffer
-        //   vk_scr [G * SW * (ES+1)] size_t — per-lane ket scratch
         //   wr_tmp [G]  WarpReduce::TempStorage
+        // vk_scr removed: compute_contribution tracks cur_w in a register per lane.
         const int ps = elem_size + 1;  // padded stride
         extern __shared__ char raw[];
-        size_t* s_bra  = (size_t*)raw;
-        int*    s_n    = (int*)(s_bra + G * ps);
-        size_t* vk_scr = (size_t*)(s_n  + G * BPGP);
+        size_t* s_bra = (size_t*)raw;
+        int*    s_n   = (int*)(s_bra + G * ps);
 
         using WR = cub::WarpReduce<ElemT, SW>;
         typename WR::TempStorage* wr_tmp =
-            (typename WR::TempStorage*)(vk_scr + G * SW * ps);
+            (typename WR::TempStorage*)(s_n + G * BPGP);
 
         size_t* my_bra = s_bra + grp * ps;
         int*    my_n   = s_n   + grp * BPGP;
-        size_t* my_vk  = vk_scr + ((size_t)grp * SW + lane) * ps;
 
         // Per-subwarp ballot mask (handles SW < 32 with multiple groups per warp)
         const unsigned lane_in_warp = (unsigned)threadIdx.x % 32u;
@@ -204,7 +202,7 @@ struct CaopMultKernel {
             if (s_count >= SW) {
                 __syncwarp(sw_mask);
                 if (lane < s_count)
-                    thread_sum += compute_contribution(my_bra, my_vk, my_n[lane]);
+                    thread_sum += compute_contribution(my_bra, my_n[lane]);
                 // compact: shift remainder left by SW
                 int next_idx = lane + SW;
                 int next_val = (next_idx < s_count) ? my_n[next_idx] : 0;
@@ -219,16 +217,18 @@ struct CaopMultKernel {
         if (s_count > 0) {
             __syncwarp(sw_mask);
             if (lane < s_count)
-                thread_sum += compute_contribution(my_bra, my_vk, my_n[lane]);
+                thread_sum += compute_contribution(my_bra, my_n[lane]);
         }
 
         ElemT total = WR(wr_tmp[grp]).Sum(thread_sum);
         if (lane == 0) d_wb[ib] += total;
     }
 
-    __device__ ElemT compute_contribution(const size_t* my_bra, size_t* my_vk, int m) {
-        for (int w = 0; w < elem_size; w++) my_vk[w] = my_bra[w];
-
+    __device__ ElemT compute_contribution(const size_t* my_bra, int m) {
+        // No vk_scr scratch: cur_w is a register tracking this word's evolving state.
+        // The outer loop descends (w = elem_size-1 .. 0), so at word w all lower
+        // words w2 < w are still my_bra[w2] — never written.  n_occ_base accumulates
+        // their popcount once per word instead of once per op.
         int sign = 1;
         size_t lo = 0, hi = (size_t)n_kets;
 
@@ -238,47 +238,53 @@ struct CaopMultKernel {
             int op_end   = d_word_start[m * (elem_size + 1) + wi + 1];
             int n_dag_w  = (op_start < op_end) ? d_ndag_per_word[m * elem_size + wi] : 0;
 
+            size_t cur_w = my_bra[w];  // register: evolves as ops are applied
+
+            // popcount of lower words — computed once per word, reused by all ops.
+            // For elem_size==1 (30-orbital common case) w==0 always, loop never runs.
+            int n_occ_base = 0;
+            if (sign_flag) {
+                for (int w2 = 0; w2 < w; w2++)
+                    n_occ_base += __popcll((unsigned long long)my_bra[w2]);
+            }
+
             // creation ops
             for (int k = op_start, ke = op_start + n_dag_w; k < ke; k++) {
                 size_t bit = (size_t)1 << d_fops_bpos[k];
-                my_vk[w] ^= bit;
+                cur_w ^= bit;
                 if (sign_flag) {
-                    long long n_occ = __popcll((unsigned long long)(my_vk[w] & (bit - 1)));
-                    for (int w2 = 0; w2 < w; w2++)
-                        n_occ += __popcll((unsigned long long)my_vk[w2]);
+                    int n_occ = __popcll((unsigned long long)(cur_w & (bit - 1))) + n_occ_base;
                     if (n_occ & 1) sign = -sign;
                 }
             }
             // annihilation ops
             for (int k = op_start + n_dag_w; k < op_end; k++) {
                 size_t bit = (size_t)1 << d_fops_bpos[k];
-                my_vk[w] |= bit;
+                cur_w |= bit;
                 if (sign_flag) {
-                    long long n_occ = __popcll((unsigned long long)(my_vk[w] & (bit - 1)));
-                    for (int w2 = 0; w2 < w; w2++)
-                        n_occ += __popcll((unsigned long long)my_vk[w2]);
+                    int n_occ = __popcll((unsigned long long)(cur_w & (bit - 1))) + n_occ_base;
                     if (n_occ & 1) sign = -sign;
                 }
             }
 
-            // lower_bound for my_vk[w]
+            // lower_bound for cur_w
             {
                 size_t L = lo, R = hi;
                 while (L < R) {
                     size_t mid = L + (R - L) / 2;
-                    if (d_tbs[mid * elem_size + w] < my_vk[w]) L = mid + 1;
+                    if (d_tbs[mid * elem_size + w] < cur_w) L = mid + 1;
                     else R = mid;
                 }
                 lo = L;
             }
-            if (lo >= hi || d_tbs[lo * elem_size + w] != my_vk[w]) return ElemT(0);
+            if (lo >= hi || d_tbs[lo * elem_size + w] != cur_w) return ElemT(0);
 
             if (w > 0) {
                 // upper_bound
                 size_t L = lo, R = hi;
                 while (L < R) {
                     size_t mid = L + (R - L) / 2;
-                    if (d_tbs[mid * elem_size + w] <= my_vk[w]) L = mid + 1;
+                    if (d_tbs[mid * elem_size + w] <= cur_w) L = mid + 1;
                     else R = mid;
                 }
                 hi = L;
@@ -521,7 +527,6 @@ public:
         int ps = elem_size_ + 1;
         smem_bytes_ = (size_t)G * ps * sizeof(size_t)          // s_bra
                     + (size_t)G * BPGP * sizeof(int)            // s_n
-                    + (size_t)G * SW * ps * sizeof(size_t)       // vk_scr
                     + (size_t)G * sizeof(typename WR::TempStorage); // wr_tmp
     }
 

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -230,7 +230,7 @@ struct CaopMultKernel {
         // __popcll(my_bra[w]) before any ops touch cur_w — leaving the sum for
         // words w2 < w, which is what the sign logic needs.
         int sign = 1;
-        size_t lo = 0, hi = (size_t)n_kets;
+        int lo = 0, hi = n_kets;
 
         int n_occ_base = 0;
         if (sign_flag) {
@@ -268,11 +268,13 @@ struct CaopMultKernel {
                 }
             }
 
+            int lo0 = lo;  // save before lower_bound narrows it
+
             // lower_bound for cur_w
             {
-                size_t L = lo, R = hi;
+                int L = lo, R = hi;
                 while (L < R) {
-                    size_t mid = L + (R - L) / 2;
+                    int mid = L + (R - L) / 2;
                     if (d_tbs[mid * elem_size + w] < cur_w) L = mid + 1;
                     else R = mid;
                 }
@@ -281,10 +283,10 @@ struct CaopMultKernel {
             if (lo >= hi || d_tbs[lo * elem_size + w] != cur_w) return ElemT(0);
 
             if (w > 0) {
-                // upper_bound
-                size_t L = lo, R = hi;
+                // upper_bound — start from lo0 (same as lower_bound) for uniform access
+                int L = lo0, R = hi;
                 while (L < R) {
-                    size_t mid = L + (R - L) / 2;
+                    int mid = L + (R - L) / 2;
                     if (d_tbs[mid * elem_size + w] <= cur_w) L = mid + 1;
                     else R = mid;
                 }

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -340,10 +340,17 @@ class CaopMultThrust {
     thrust::device_vector<int>    d_word_start_;
     thrust::device_vector<int>    d_ndag_per_word_;
 
-    // per-task ket det sequences (precomputed at Init; fixed for all Davidson iters)
+    // per-task ket det sequences — populated lazily on the first run() call
+    // via live MPI slides, then cached on GPU for all subsequent iterations.
     std::vector<thrust::device_vector<size_t>> d_tbs_seq_;
     std::vector<size_t> n_kets_per_task_;
-    size_t global_max_kets_;
+    bool tbs_initialized_;
+
+    // local bra det_vector (CPU) — stored at Init for seeding the first-run tbs slide
+    det_vector<size_t> bs_;
+
+    // global max n_kets across b_comm ranks (Allreduce at Init; fixed for all Davidson iters)
+    size_t global_max_n_;
 
     int n_bras_;
     int n_terms_;
@@ -354,13 +361,47 @@ class CaopMultThrust {
     std::vector<int> slide_;
     MPI_Comm h_comm_, b_comm_, t_comm_;
 
+    // Compute tbs_seq via live MPI slides, upload to GPU.
+    // Called once on the first run(); results cached in d_tbs_seq_ / n_kets_per_task_.
+    void precompute_tbs_seq() {
+        size_t n_tasks = slide_.size();
+        d_tbs_seq_.resize(n_tasks);
+        n_kets_per_task_.resize(n_tasks, 0);
+
+        if (n_tasks == 0) return;
+
+        det_vector<size_t> cur_tbs;
+        if (slide_[0] != 0) {
+            MpiSlide(bs_, cur_tbs, slide_[0], b_comm_);
+        } else {
+            cur_tbs = bs_;
+        }
+
+        for (size_t task = 0; task < n_tasks; task++) {
+            n_kets_per_task_[task] = cur_tbs.size();
+            const auto& flat = cur_tbs.cflat();
+            d_tbs_seq_[task].resize(flat.size());
+            if (!flat.empty())
+                thrust::copy_n(flat.begin(), flat.size(), d_tbs_seq_[task].begin());
+
+            if (task + 1 < n_tasks) {
+                int bslide = slide_[task] - slide_[task + 1];
+                det_vector<size_t> next_tbs;
+                MpiSlide(cur_tbs, next_tbs, bslide, b_comm_);
+                cur_tbs = std::move(next_tbs);
+            }
+        }
+    }
+
 public:
-    CaopMultThrust() : n_bras_(0), n_terms_(0), elem_size_(0), sign_(false),
-                       smem_bytes_(0), global_max_kets_(0) {}
+    CaopMultThrust() : tbs_initialized_(false), global_max_n_(0),
+                       n_bras_(0), n_terms_(0), elem_size_(0),
+                       sign_(false), smem_bytes_(0) {}
 
     // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
     // terms as CaopRawTerm, c as coefficient vector). The friend mult()
     // function extracts these from GeneralOp and passes them here.
+    // Does NOT precompute tbs_seq — that happens lazily on the first run() call.
     void Init(const std::vector<ElemT>& hd,
               const det_vector<size_t>& bs,
               int bit_length,
@@ -376,6 +417,9 @@ public:
         slide_  = slide;
         n_bras_ = (int)bs.size();
         elem_size_ = (n_bras_ > 0) ? (int)bs.elem_size() : 0;
+
+        // Store local bra det_vector for seeding the first-run tbs slide
+        bs_ = bs;
 
         // Upload bras
         {
@@ -463,35 +507,10 @@ public:
             thrust::copy_n(ndag_per_word_host.begin(), ndag_per_word_host.size(), d_ndag_per_word_.begin());
         }
 
-        // Precompute tbs_seq (one MpiSlide per task; bs is fixed for all Davidson iters)
-        size_t n_tasks = slide.size();
-        d_tbs_seq_.resize(n_tasks);
-        n_kets_per_task_.resize(n_tasks, 0);
-        global_max_kets_ = 0;
-
-        if (n_tasks > 0) {
-            det_vector<size_t> cur_tbs;
-            if (!slide.empty() && slide[0] != 0) {
-                MpiSlide(bs, cur_tbs, slide[0], b_comm_);
-            } else {
-                cur_tbs = bs;
-            }
-
-            for (size_t task = 0; task < n_tasks; task++) {
-                n_kets_per_task_[task] = cur_tbs.size();
-                if (cur_tbs.size() > global_max_kets_) global_max_kets_ = cur_tbs.size();
-                const auto& flat = cur_tbs.cflat();
-                d_tbs_seq_[task].resize(flat.size());
-                if (!flat.empty())
-                    thrust::copy_n(flat.begin(), flat.size(), d_tbs_seq_[task].begin());
-
-                if (task + 1 < n_tasks) {
-                    int bslide = slide[task] - slide[task + 1];
-                    det_vector<size_t> next_tbs;
-                    MpiSlide(cur_tbs, next_tbs, bslide, b_comm_);
-                    cur_tbs = std::move(next_tbs);
-                }
-            }
+        // Compute global max n_kets for buffer sizing (fixed across all Davidson iterations)
+        {
+            size_t local_n = (size_t)n_bras_;
+            MPI_Allreduce(&local_n, &global_max_n_, 1, SBD_MPI_SIZE_T, MPI_MAX, b_comm_);
         }
 
         // Compute smem per block
@@ -508,6 +527,13 @@ public:
 
     void run(const std::vector<ElemT>& wk, std::vector<ElemT>& wb) {
         if (slide_.empty()) return;
+
+        // First call: compute tbs_seq via live MPI slides and cache on GPU.
+        // All subsequent calls use the cached d_tbs_seq_ directly.
+        if (!tbs_initialized_) {
+            precompute_tbs_seq();
+            tbs_initialized_ = true;
+        }
 
         int mpi_size_h; MPI_Comm_size(h_comm_, &mpi_size_h);
         int mpi_rank_h; MPI_Comm_rank(h_comm_, &mpi_rank_h);
@@ -526,14 +552,8 @@ public:
             twk_init = wk;
         }
 
-        // Find global max for pre-allocation
-        size_t local_ket = twk_init.size();
-        size_t gmax_ket  = global_max_kets_;
-        {
-            size_t tmp;
-            MPI_Allreduce(&local_ket, &tmp, 1, SBD_MPI_SIZE_T, MPI_MAX, b_comm_);
-            if (tmp > gmax_ket) gmax_ket = tmp;
-        }
+        // Use global_max_n_ from Init (no per-run Allreduce needed)
+        size_t gmax_ket = global_max_n_;
 
         // Allocate double buffers
         int active_buf = 0, recv_buf = 1;
@@ -629,8 +649,6 @@ public:
                                     cudaMemcpyHostToDevice, copy_stream);
                     cudaEventRecord(copy_done[recv_buf], copy_stream);
                     std::swap(active_buf, recv_buf);
-                    // After swap: twk_size[active_buf] already holds the correct recv_size
-                    // (set before the swap at twk_size[old_recv_buf]). No update needed.
                 }
             } else {
                 cudaEventSynchronize(compute_done[active_buf]);
@@ -658,8 +676,7 @@ public:
 // Declared as a friend of GeneralOp in generalop.h, so it can access
 // H.o_, H.c_, H.m1_, H.m2_ and the private members of ProductOp/CAOp.
 // Extracts them into POD structs, then forwards to CaopMultThrust.
-// Uses a static instance to avoid re-running the expensive Init
-// (MpiSlide for each task) on every Davidson/Lanczos iteration.
+// Uses a static instance to avoid re-running Init on every Davidson iteration.
 // ============================================================
 template <typename ElemT>
 void mult(const std::vector<ElemT>& hd,

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -15,6 +15,7 @@ Included by mult.h when SBD_THRUST is defined. Same call signature as the CPU ve
 #include <algorithm>
 #include <vector>
 #include <cstring>
+#include <cassert>
 
 #include "sbd/caop/basic/generalop.h"
 #include "sbd/framework/det_vector.h"
@@ -433,9 +434,11 @@ public:
     }
 
     // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
-    // terms as CaopRawTerm, c as coefficient vector). The friend mult()
-    // function extracts these from GeneralOp and passes them here.
+    // terms as CaopRawTerm, c as coefficient vector). Extracts are done by
+    // InitCaopMultThrust() (friend of GeneralOp) and forwarded here.
     // Does NOT precompute tbs_seq — that happens lazily on the first run() call.
+    // Safe to call multiple times: resets all lazy state so run() re-initializes
+    // for the new problem (H or basis may have changed between calls).
     void Init(const std::vector<ElemT>& hd,
               const det_vector<size_t>& bs,
               int bit_length,
@@ -446,6 +449,22 @@ public:
               bool sign,
               const std::vector<int>& slide,
               MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
+        // Reset lazy state so run() re-initializes for this problem.
+        tbs_initialized_ = false;
+        d_tbs_seq_.clear();
+        n_kets_per_task_.clear();
+        // Free persistent run() resources if previously allocated, so run()
+        // re-allocates them sized for the (possibly different) global_max_n_.
+        if (h_twk_[0] != nullptr) {
+            cudaFreeHost(h_twk_[0]); h_twk_[0] = nullptr;
+            cudaFreeHost(h_twk_[1]); h_twk_[1] = nullptr;
+            cudaEventDestroy(copy_done_[0]);
+            cudaEventDestroy(copy_done_[1]);
+            cudaEventDestroy(compute_done_[0]);
+            cudaEventDestroy(compute_done_[1]);
+            cudaStreamDestroy(copy_stream_);  copy_stream_  = nullptr;
+            cudaStreamDestroy(compute_stream_); compute_stream_ = nullptr;
+        }
         h_comm_ = h_comm; b_comm_ = b_comm; t_comm_ = t_comm;
         sign_   = sign;
         slide_  = slide;
@@ -582,6 +601,12 @@ public:
             tbs_initialized_ = true;
         }
 
+        // Verify mask sizes are consistent with elem_size_ set at Init().
+        assert((n_terms_ == 0 || elem_size_ == 0 ||
+                ((int)d_m1_.size() == n_terms_ * elem_size_ &&
+                 (int)d_m2_.size() == n_terms_ * elem_size_)) &&
+               "CaopMultThrust::run: mask size mismatch — elem_size_ changed after Init()");
+
         int mpi_size_h; MPI_Comm_size(h_comm_, &mpi_size_h);
         int mpi_rank_h; MPI_Comm_rank(h_comm_, &mpi_rank_h);
         int mpi_size_t; MPI_Comm_size(t_comm_, &mpi_size_t);
@@ -691,11 +716,47 @@ public:
 };
 
 // ============================================================
+// InitCaopMultThrust — extracts GeneralOp data and calls driver.Init().
+// Declared as a friend of GeneralOp / CAOp / ProductOp in generalop.h.
+// Callers (e.g. sbdiag.h method==0) own the CaopMultThrust lifetime and
+// call Init() again whenever H or basis changes between sbd::diag() calls.
+// ============================================================
+template <typename ElemT>
+void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
+                         const std::vector<ElemT>& hd,
+                         const det_vector<size_t>& bs,
+                         int bit_length,
+                         const GeneralOp<ElemT>& H,
+                         bool sign,
+                         const std::vector<int>& slide,
+                         MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
+    if (H.m1_.empty()) H.PrecomputeMasks(bit_length);
+
+    std::vector<CaopRawTerm> terms;
+    terms.reserve(H.o_.size());
+    for (const auto& op : H.o_) {
+        CaopRawTerm t;
+        t.n_dag = op.n_dag_;
+        for (const auto& f : op.fops_)
+            t.fops.push_back({ f.q_, f.d_ ? 1 : 0 });
+        terms.push_back(std::move(t));
+    }
+
+    const auto& fm1 = H.m1_.cflat();
+    const auto& fm2 = H.m2_.cflat();
+    std::vector<size_t> m1_flat(fm1.begin(), fm1.end());
+    std::vector<size_t> m2_flat(fm2.begin(), fm2.end());
+
+    driver.Init(hd, bs, bit_length, H.c_, terms, m1_flat, m2_flat,
+                sign, slide, h_comm, b_comm, t_comm);
+}
+
+// ============================================================
 // Free mult() — same signature as CPU version, selected by SBD_THRUST.
-// Declared as a friend of GeneralOp in generalop.h, so it can access
-// H.o_, H.c_, H.m1_, H.m2_ and the private members of ProductOp/CAOp.
-// Extracts them into POD structs, then forwards to CaopMultThrust.
-// Uses a static instance to avoid re-running Init on every Davidson iteration.
+// Declared as a friend of GeneralOp in generalop.h.
+// Single-shot wrapper: creates a fresh driver, inits, and runs once.
+// Callers that iterate (e.g. Davidson) should own a CaopMultThrust directly,
+// call InitCaopMultThrust() once, and call driver.run() per iteration.
 // ============================================================
 template <typename ElemT>
 void mult(const std::vector<ElemT>& hd,
@@ -707,34 +768,9 @@ void mult(const std::vector<ElemT>& hd,
           const GeneralOp<ElemT>& H,
           bool sign,
           MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
-
-    static CaopMultThrust<ElemT>* driver = nullptr;
-    if (!driver) {
-        if (H.m1_.empty()) H.PrecomputeMasks(bit_length);
-
-        // Extract operator terms from GeneralOp (friend access).
-        std::vector<CaopRawTerm> terms;
-        terms.reserve(H.o_.size());
-        for (const auto& op : H.o_) {
-            CaopRawTerm t;
-            t.n_dag = op.n_dag_;
-            for (const auto& f : op.fops_)
-                t.fops.push_back({ f.q_, f.d_ ? 1 : 0 });
-            terms.push_back(std::move(t));
-        }
-
-        // Extract m1/m2 flat arrays.
-        const auto& fm1 = H.m1_.cflat();
-        const auto& fm2 = H.m2_.cflat();
-        std::vector<size_t> m1_flat(fm1.begin(), fm1.end());
-        std::vector<size_t> m2_flat(fm2.begin(), fm2.end());
-
-        driver = new CaopMultThrust<ElemT>();
-        driver->Init(hd, bs, bit_length,
-                     H.c_, terms, m1_flat, m2_flat,
-                     sign, slide, h_comm, b_comm, t_comm);
-    }
-    driver->run(wk, wb);
+    CaopMultThrust<ElemT> driver;
+    InitCaopMultThrust(driver, hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
+    driver.run(wk, wb);
 }
 
 } // namespace sbd

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -15,7 +15,7 @@ Included by mult.h when SBD_THRUST is defined. Same call signature as the CPU ve
 #include <algorithm>
 #include <vector>
 #include <cstring>
-#include <cassert>
+#include <stdexcept>
 
 #include "sbd/caop/basic/generalop.h"
 #include "sbd/framework/det_vector.h"
@@ -357,6 +357,7 @@ class CaopMultThrust {
     std::vector<thrust::device_vector<size_t>> d_tbs_seq_;
     std::vector<size_t> n_kets_per_task_;
     bool tbs_initialized_;
+    bool init_done_;
 
     // local bra det_vector (CPU) — stored at Init for seeding the first-run tbs slide
     det_vector<size_t> bs_;
@@ -412,7 +413,7 @@ class CaopMultThrust {
     }
 
 public:
-    CaopMultThrust() : tbs_initialized_(false), global_max_n_(0),
+    CaopMultThrust() : tbs_initialized_(false), init_done_(false), global_max_n_(0),
                        n_bras_(0), n_terms_(0), elem_size_(0),
                        sign_(false), smem_bytes_(0),
                        h_twk_{ nullptr, nullptr },
@@ -432,6 +433,8 @@ public:
             cudaStreamDestroy(compute_stream_);
         }
     }
+
+    bool is_initialized() const { return init_done_; }
 
     // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
     // terms as CaopRawTerm, c as coefficient vector). Extracts are done by
@@ -575,6 +578,7 @@ public:
         smem_bytes_ = (size_t)G * ps * sizeof(size_t)          // s_bra
                     + (size_t)G * BPGP * sizeof(int)            // s_n
                     + (size_t)G * sizeof(typename WR::TempStorage); // wr_tmp
+        init_done_ = true;
     }
 
     void run(const std::vector<ElemT>& wk, std::vector<ElemT>& wb) {
@@ -602,10 +606,11 @@ public:
         }
 
         // Verify mask sizes are consistent with elem_size_ set at Init().
-        assert((n_terms_ == 0 || elem_size_ == 0 ||
-                ((int)d_m1_.size() == n_terms_ * elem_size_ &&
-                 (int)d_m2_.size() == n_terms_ * elem_size_)) &&
-               "CaopMultThrust::run: mask size mismatch — elem_size_ changed after Init()");
+        if (n_terms_ != 0 && elem_size_ != 0 &&
+            ((int)d_m1_.size() != n_terms_ * elem_size_ ||
+             (int)d_m2_.size() != n_terms_ * elem_size_))
+            throw std::logic_error(
+                "CaopMultThrust::run: mask size mismatch (n_terms_ or elem_size_ changed after Init())");
 
         int mpi_size_h; MPI_Comm_size(h_comm_, &mpi_size_h);
         int mpi_rank_h; MPI_Comm_rank(h_comm_, &mpi_rank_h);
@@ -752,11 +757,11 @@ void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
 }
 
 // ============================================================
-// Free mult() — same signature as CPU version, selected by SBD_THRUST.
-// Declared as a friend of GeneralOp in generalop.h.
-// Single-shot wrapper: creates a fresh driver, inits, and runs once.
-// Callers that iterate (e.g. Davidson) should own a CaopMultThrust directly,
-// call InitCaopMultThrust() once, and call driver.run() per iteration.
+// Free mult() — caller supplies a CaopMultThrust<ElemT>& to own GPU resources.
+// Lazily calls InitCaopMultThrust() on the first invocation (!driver.is_initialized());
+// subsequent calls with the same driver skip Init and go directly to run().
+// To force re-initialization (e.g. after H or basis changes), call
+// InitCaopMultThrust() explicitly before the next mult() call.
 // ============================================================
 template <typename ElemT>
 void mult(const std::vector<ElemT>& hd,
@@ -767,9 +772,10 @@ void mult(const std::vector<ElemT>& hd,
           const std::vector<int>& slide,
           const GeneralOp<ElemT>& H,
           bool sign,
-          MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
-    CaopMultThrust<ElemT> driver;
-    InitCaopMultThrust(driver, hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
+          MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm,
+          CaopMultThrust<ElemT>& driver) {
+    if (!driver.is_initialized())
+        InitCaopMultThrust(driver, hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
     driver.run(wk, wb);
 }
 

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -504,7 +504,7 @@ public:
                 for (int i = 0; i < n_fops; i++)
                     for (int j = i + 1; j < n_fops; j++)
                         if (perm[i] > perm[j]) inv++;
-                coeff_host[m] = c[m] * ((inv & 1) ? ElemT(-1) : ElemT(1));
+                coeff_host[m] = c[m] * ((sign && (inv & 1)) ? ElemT(-1) : ElemT(1));
 
                 // Fill word_start and ndag_per_word
                 int cur_wi   = 0;

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -367,6 +367,12 @@ class CaopMultThrust {
     std::vector<int> slide_;
     MPI_Comm h_comm_, b_comm_, t_comm_;
 
+    // Persistent run() resources — allocated once on first run(), reused every Davidson iter.
+    thrust::device_vector<ElemT> d_twk_[2];
+    ElemT*          h_twk_[2];
+    cudaStream_t    compute_stream_, copy_stream_;
+    cudaEvent_t     copy_done_[2], compute_done_[2];
+
     // Compute tbs_seq via live MPI slides, upload to GPU.
     // Called once on the first run(); results cached in d_tbs_seq_ / n_kets_per_task_.
     void precompute_tbs_seq() {
@@ -402,7 +408,24 @@ class CaopMultThrust {
 public:
     CaopMultThrust() : tbs_initialized_(false), global_max_n_(0),
                        n_bras_(0), n_terms_(0), elem_size_(0),
-                       sign_(false), smem_bytes_(0) {}
+                       sign_(false), smem_bytes_(0),
+                       h_twk_{ nullptr, nullptr },
+                       compute_stream_(nullptr), copy_stream_(nullptr),
+                       copy_done_{ nullptr, nullptr },
+                       compute_done_{ nullptr, nullptr } {}
+
+    ~CaopMultThrust() {
+        if (h_twk_[0] != nullptr) {
+            cudaFreeHost(h_twk_[0]);
+            cudaFreeHost(h_twk_[1]);
+            cudaEventDestroy(copy_done_[0]);
+            cudaEventDestroy(copy_done_[1]);
+            cudaEventDestroy(compute_done_[0]);
+            cudaEventDestroy(compute_done_[1]);
+            cudaStreamDestroy(copy_stream_);
+            cudaStreamDestroy(compute_stream_);
+        }
+    }
 
     // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
     // terms as CaopRawTerm, c as coefficient vector). The friend mult()
@@ -533,9 +556,23 @@ public:
     void run(const std::vector<ElemT>& wk, std::vector<ElemT>& wb) {
         if (slide_.empty()) return;
 
-        // First call: compute tbs_seq via live MPI slides and cache on GPU.
-        // All subsequent calls use the cached d_tbs_seq_ directly.
+        // First call: allocate persistent buffers and compute tbs_seq.
+        // All subsequent calls reuse d_twk_/h_twk_/streams/events and d_tbs_seq_.
         if (!tbs_initialized_) {
+            d_twk_[0].resize(global_max_n_);
+            d_twk_[1].resize(global_max_n_);
+            cudaMallocHost(&h_twk_[0], global_max_n_ * sizeof(ElemT));
+            cudaMallocHost(&h_twk_[1], global_max_n_ * sizeof(ElemT));
+            cudaStreamCreateWithFlags(&compute_stream_, cudaStreamNonBlocking);
+            cudaStreamCreateWithFlags(&copy_stream_,    cudaStreamNonBlocking);
+            cudaEventCreateWithFlags(&copy_done_[0],    cudaEventDisableTiming);
+            cudaEventCreateWithFlags(&copy_done_[1],    cudaEventDisableTiming);
+            cudaEventCreateWithFlags(&compute_done_[0], cudaEventDisableTiming);
+            cudaEventCreateWithFlags(&compute_done_[1], cudaEventDisableTiming);
+            // Pre-signal both compute_done slots so the first copy_stream wait doesn't hang.
+            cudaEventRecord(compute_done_[0], 0);
+            cudaEventRecord(compute_done_[1], 0);
+            cudaDeviceSynchronize();
             precompute_tbs_seq();
             tbs_initialized_ = true;
         }
@@ -549,53 +586,32 @@ public:
         thrust::device_vector<ElemT> d_wb(wb.size());
         thrust::copy_n(wb.begin(), wb.size(), d_wb.begin());
 
-        // Initial slide of wk
-        std::vector<ElemT> twk_init;
+        // Initial slide of wk — when slide_[0]==0 (common case) use wk directly;
+        // no intermediate copy.
+        std::vector<ElemT> twk_init_buf;
+        const ElemT* twk0_data;
+        size_t twk0_size;
         if (slide_[0] != 0) {
-            MpiSlide(wk, twk_init, slide_[0], b_comm_);
+            MpiSlide(wk, twk_init_buf, slide_[0], b_comm_);
+            twk0_data = twk_init_buf.data();
+            twk0_size = twk_init_buf.size();
         } else {
-            twk_init = wk;
+            twk0_data = wk.data();
+            twk0_size = wk.size();
         }
 
-        // Use global_max_n_ from Init (no per-run Allreduce needed)
-        size_t gmax_ket = global_max_n_;
-
-        // Allocate double buffers
         int active_buf = 0, recv_buf = 1;
-        size_t twk_size[2] = { twk_init.size(), gmax_ket };
-
-        thrust::device_vector<ElemT> d_twk[2];
-        d_twk[0].resize(gmax_ket);
-        d_twk[1].resize(gmax_ket);
-
-        ElemT* h_twk[2] = { nullptr, nullptr };
-        cudaMallocHost(&h_twk[0], gmax_ket * sizeof(ElemT));
-        cudaMallocHost(&h_twk[1], gmax_ket * sizeof(ElemT));
-
-        // Create streams and events
-        cudaStream_t compute_stream, copy_stream;
-        cudaStreamCreateWithFlags(&compute_stream, cudaStreamNonBlocking);
-        cudaStreamCreateWithFlags(&copy_stream,    cudaStreamNonBlocking);
-        cudaEvent_t copy_done[2], compute_done[2];
-        cudaEventCreateWithFlags(&copy_done[0],    cudaEventDisableTiming);
-        cudaEventCreateWithFlags(&copy_done[1],    cudaEventDisableTiming);
-        cudaEventCreateWithFlags(&compute_done[0], cudaEventDisableTiming);
-        cudaEventCreateWithFlags(&compute_done[1], cudaEventDisableTiming);
-        // Mark both compute_done slots as completed so the first copy_stream wait
-        // on the unused recv_buf slot doesn't hang.
-        cudaEventRecord(compute_done[0], 0);
-        cudaEventRecord(compute_done[1], 0);
-        cudaDeviceSynchronize();
+        size_t twk_size[2] = { twk0_size, global_max_n_ };
 
         // Seed active buffer: CPU → pinned → GPU
-        if (!twk_init.empty())
-            std::memcpy(h_twk[active_buf], twk_init.data(), twk_size[active_buf] * sizeof(ElemT));
-        cudaMemcpyAsync(thrust::raw_pointer_cast(d_twk[active_buf].data()),
-                        h_twk[active_buf],
-                        twk_size[active_buf] * sizeof(ElemT),
-                        cudaMemcpyHostToDevice, copy_stream);
-        cudaEventRecord(copy_done[active_buf], copy_stream);
-        cudaEventRecord(copy_done[recv_buf],   copy_stream);
+        if (twk0_size > 0)
+            std::memcpy(h_twk_[active_buf], twk0_data, twk0_size * sizeof(ElemT));
+        cudaMemcpyAsync(thrust::raw_pointer_cast(d_twk_[active_buf].data()),
+                        h_twk_[active_buf],
+                        twk0_size * sizeof(ElemT),
+                        cudaMemcpyHostToDevice, copy_stream_);
+        cudaEventRecord(copy_done_[active_buf], copy_stream_);
+        cudaEventRecord(copy_done_[recv_buf],   copy_stream_);
 
         // Wb_init: scale + add diagonal (on compute_stream, after d_twk[active_buf] is ready)
         {
@@ -603,18 +619,18 @@ public:
             CaopWbInitKernel<ElemT> wbinit;
             wbinit.d_wb  = thrust::raw_pointer_cast(d_wb.data());
             wbinit.d_hd  = thrust::raw_pointer_cast(d_hd_.data());
-            wbinit.d_twk = thrust::raw_pointer_cast(d_twk[active_buf].data());
+            wbinit.d_twk = thrust::raw_pointer_cast(d_twk_[active_buf].data());
             wbinit.volp  = volp;
             wbinit.add_diag = (mpi_rank_t == 0);
             auto ci = thrust::counting_iterator<size_t>(0);
-            cudaStreamWaitEvent(compute_stream, copy_done[active_buf]);
-            thrust::for_each_n(thrust::cuda::par.on(compute_stream), ci, (size_t)n_bras_, wbinit);
+            cudaStreamWaitEvent(compute_stream_, copy_done_[active_buf]);
+            thrust::for_each_n(thrust::cuda::par.on(compute_stream_), ci, (size_t)n_bras_, wbinit);
         }
 
         CaopBufferSlider<ElemT> slider;
 
         for (size_t task = 0; task < slide_.size(); task++) {
-            cudaStreamWaitEvent(compute_stream, copy_done[active_buf]);
+            cudaStreamWaitEvent(compute_stream_, copy_done_[active_buf]);
 
             if (n_terms_ > 0) {
                 CaopMultKernel<ElemT> kernel;
@@ -623,7 +639,7 @@ public:
                 kernel.n_bras        = n_bras_;
                 kernel.elem_size     = elem_size_;
                 kernel.d_tbs         = thrust::raw_pointer_cast(d_tbs_seq_[task].data());
-                kernel.d_twk         = thrust::raw_pointer_cast(d_twk[active_buf].data());
+                kernel.d_twk         = thrust::raw_pointer_cast(d_twk_[active_buf].data());
                 kernel.n_kets        = (int)n_kets_per_task_[task];
                 kernel.d_m1          = thrust::raw_pointer_cast(d_m1_.data());
                 kernel.d_m2          = thrust::raw_pointer_cast(d_m2_.data());
@@ -633,39 +649,32 @@ public:
                 kernel.d_ndag_per_word = thrust::raw_pointer_cast(d_ndag_per_word_.data());
                 kernel.n_terms       = n_terms_;
                 kernel.sign_flag     = sign_;
-                launch_caop_mult((size_t)n_bras_, kernel, smem_bytes_, compute_stream);
+                launch_caop_mult((size_t)n_bras_, kernel, smem_bytes_, compute_stream_);
             }
 
-            cudaEventRecord(compute_done[active_buf], compute_stream);
+            cudaEventRecord(compute_done_[active_buf], compute_stream_);
 
             if (task + 1 < slide_.size()) {
                 int bslide = slide_[task] - slide_[task + 1];
-                cudaEventSynchronize(copy_done[recv_buf]);
+                cudaEventSynchronize(copy_done_[recv_buf]);
                 slider.ExchangeAsyncHost(
-                    h_twk[active_buf], twk_size[active_buf],
-                    h_twk[recv_buf],   gmax_ket,
+                    h_twk_[active_buf], twk_size[active_buf],
+                    h_twk_[recv_buf],   global_max_n_,
                     bslide, b_comm_, (int)task * 4);
                 if (slider.Sync()) {
                     twk_size[recv_buf] = slider.get_recv_size();
-                    cudaStreamWaitEvent(copy_stream, compute_done[recv_buf]);
-                    cudaMemcpyAsync(thrust::raw_pointer_cast(d_twk[recv_buf].data()),
-                                    h_twk[recv_buf],
+                    cudaStreamWaitEvent(copy_stream_, compute_done_[recv_buf]);
+                    cudaMemcpyAsync(thrust::raw_pointer_cast(d_twk_[recv_buf].data()),
+                                    h_twk_[recv_buf],
                                     twk_size[recv_buf] * sizeof(ElemT),
-                                    cudaMemcpyHostToDevice, copy_stream);
-                    cudaEventRecord(copy_done[recv_buf], copy_stream);
+                                    cudaMemcpyHostToDevice, copy_stream_);
+                    cudaEventRecord(copy_done_[recv_buf], copy_stream_);
                     std::swap(active_buf, recv_buf);
                 }
             } else {
-                cudaEventSynchronize(compute_done[active_buf]);
+                cudaEventSynchronize(compute_done_[active_buf]);
             }
         }
-
-        // Cleanup
-        cudaFreeHost(h_twk[0]); cudaFreeHost(h_twk[1]);
-        cudaEventDestroy(copy_done[0]);    cudaEventDestroy(copy_done[1]);
-        cudaEventDestroy(compute_done[0]); cudaEventDestroy(compute_done[1]);
-        cudaStreamDestroy(copy_stream);
-        cudaStreamDestroy(compute_stream);
 
         // Allreduce
         MpiAllreduce(d_wb, MPI_SUM, t_comm_);

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -310,6 +310,22 @@ inline void launch_caop_mult(size_t n_bras, F f, size_t smem_bytes, cudaStream_t
 }
 
 // ============================================================
+// POD structs for pre-extracted GeneralOp data.
+// CaopMultThrust::Init() takes these instead of GeneralOp directly
+// (GeneralOp members are private; only the friend mult() function
+// can read them and pass them here).
+// ============================================================
+struct CaopRawOp {
+    int q;        // orbital index
+    int is_dag;   // 1 = creation, 0 = annihilation
+};
+
+struct CaopRawTerm {
+    int n_dag;                    // number of leading creation ops
+    std::vector<CaopRawOp> fops; // ops in original order
+};
+
+// ============================================================
 // CaopMultThrust<ElemT>: host-side driver
 // ============================================================
 template <typename ElemT>
@@ -342,10 +358,16 @@ public:
     CaopMultThrust() : n_bras_(0), n_terms_(0), elem_size_(0), sign_(false),
                        smem_bytes_(0), global_max_kets_(0) {}
 
+    // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
+    // terms as CaopRawTerm, c as coefficient vector). The friend mult()
+    // function extracts these from GeneralOp and passes them here.
     void Init(const std::vector<ElemT>& hd,
               const det_vector<size_t>& bs,
               int bit_length,
-              const GeneralOp<ElemT>& H,
+              const std::vector<ElemT>& c,
+              const std::vector<CaopRawTerm>& terms,
+              const std::vector<size_t>& m1_flat,
+              const std::vector<size_t>& m2_flat,
               bool sign,
               const std::vector<int>& slide,
               MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
@@ -354,8 +376,6 @@ public:
         slide_  = slide;
         n_bras_ = (int)bs.size();
         elem_size_ = (n_bras_ > 0) ? (int)bs.elem_size() : 0;
-
-        if (H.m1_.empty()) H.PrecomputeMasks(bit_length);
 
         // Upload bras
         {
@@ -367,20 +387,14 @@ public:
         d_hd_.resize(hd.size());
         thrust::copy_n(hd.begin(), hd.size(), d_hd_.begin());
 
-        n_terms_ = (int)H.o_.size();
+        n_terms_ = (int)terms.size();
 
         if (n_terms_ > 0 && elem_size_ > 0) {
             // Upload masks
-            {
-                const auto& fm1 = H.m1_.cflat();
-                d_m1_.resize(fm1.size());
-                thrust::copy_n(fm1.begin(), fm1.size(), d_m1_.begin());
-            }
-            {
-                const auto& fm2 = H.m2_.cflat();
-                d_m2_.resize(fm2.size());
-                thrust::copy_n(fm2.begin(), fm2.size(), d_m2_.begin());
-            }
+            d_m1_.resize(m1_flat.size());
+            thrust::copy_n(m1_flat.begin(), m1_flat.size(), d_m1_.begin());
+            d_m2_.resize(m2_flat.size());
+            thrust::copy_n(m2_flat.begin(), m2_flat.size(), d_m2_.begin());
 
             // Build sorted operator tables
             const int ES = elem_size_;
@@ -392,14 +406,14 @@ public:
 
             int fpos = 0;
             for (int m = 0; m < n_terms_; m++) {
-                const auto& op   = H.o_[m];
-                int n_fops = (int)op.fops_.size();
-                int n_dag  = op.n_dag_;
+                const auto& term  = terms[m];
+                int n_fops = (int)term.fops.size();
+                int n_dag  = term.n_dag;
 
                 struct OpInfo { int orig_idx, word, bpos, type; };
                 std::vector<OpInfo> ops(n_fops);
                 for (int k = 0; k < n_fops; k++) {
-                    int q = op.fops_[k].q_;
+                    int q = term.fops[k].q;
                     ops[k] = { k, q / bit_length, q % bit_length, (k < n_dag) ? 0 : 1 };
                 }
 
@@ -410,14 +424,14 @@ public:
                     return a.orig_idx < b.orig_idx;
                 });
 
-                // Count inversions in the permutation (original_idx sequence after sort)
+                // Count inversions (number of anticommuting swaps from original to sorted order)
                 std::vector<int> perm(n_fops);
                 for (int i = 0; i < n_fops; i++) perm[i] = ops[i].orig_idx;
                 int inv = 0;
                 for (int i = 0; i < n_fops; i++)
                     for (int j = i + 1; j < n_fops; j++)
                         if (perm[i] > perm[j]) inv++;
-                coeff_host[m] = H.c_[m] * ((inv & 1) ? ElemT(-1) : ElemT(1));
+                coeff_host[m] = c[m] * ((inv & 1) ? ElemT(-1) : ElemT(1));
 
                 // Fill word_start and ndag_per_word
                 int cur_wi   = 0;
@@ -425,7 +439,6 @@ public:
                 word_start_host[m * (ES + 1) + 0] = fpos;
 
                 for (int i = 0; i < n_fops; i++) {
-                    // Advance word index while cur_word > ops[i].word
                     while (ops[i].word < cur_word) {
                         cur_wi++;
                         cur_word--;
@@ -435,7 +448,6 @@ public:
                     if (ops[i].type == 0) ndag_per_word_host[m * ES + cur_wi]++;
                     fpos++;
                 }
-                // Fill remaining word entries
                 for (int wi = cur_wi + 1; wi <= ES; wi++)
                     word_start_host[m * (ES + 1) + wi] = fpos;
             }
@@ -451,7 +463,7 @@ public:
             thrust::copy_n(ndag_per_word_host.begin(), ndag_per_word_host.size(), d_ndag_per_word_.begin());
         }
 
-        // Precompute tbs_seq (one MpiSlide per task)
+        // Precompute tbs_seq (one MpiSlide per task; bs is fixed for all Davidson iters)
         size_t n_tasks = slide.size();
         d_tbs_seq_.resize(n_tasks);
         n_kets_per_task_.resize(n_tasks, 0);
@@ -642,7 +654,12 @@ public:
 };
 
 // ============================================================
-// Free mult() — same signature as CPU version, selected by SBD_THRUST
+// Free mult() — same signature as CPU version, selected by SBD_THRUST.
+// Declared as a friend of GeneralOp in generalop.h, so it can access
+// H.o_, H.c_, H.m1_, H.m2_ and the private members of ProductOp/CAOp.
+// Extracts them into POD structs, then forwards to CaopMultThrust.
+// Uses a static instance to avoid re-running the expensive Init
+// (MpiSlide for each task) on every Davidson/Lanczos iteration.
 // ============================================================
 template <typename ElemT>
 void mult(const std::vector<ElemT>& hd,
@@ -654,9 +671,34 @@ void mult(const std::vector<ElemT>& hd,
           const GeneralOp<ElemT>& H,
           bool sign,
           MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
-    CaopMultThrust<ElemT> data;
-    data.Init(hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
-    data.run(wk, wb);
+
+    static CaopMultThrust<ElemT>* driver = nullptr;
+    if (!driver) {
+        if (H.m1_.empty()) H.PrecomputeMasks(bit_length);
+
+        // Extract operator terms from GeneralOp (friend access).
+        std::vector<CaopRawTerm> terms;
+        terms.reserve(H.o_.size());
+        for (const auto& op : H.o_) {
+            CaopRawTerm t;
+            t.n_dag = op.n_dag_;
+            for (const auto& f : op.fops_)
+                t.fops.push_back({ f.q_, f.d_ ? 1 : 0 });
+            terms.push_back(std::move(t));
+        }
+
+        // Extract m1/m2 flat arrays.
+        const auto& fm1 = H.m1_.cflat();
+        const auto& fm2 = H.m2_.cflat();
+        std::vector<size_t> m1_flat(fm1.begin(), fm1.end());
+        std::vector<size_t> m2_flat(fm2.begin(), fm2.end());
+
+        driver = new CaopMultThrust<ElemT>();
+        driver->Init(hd, bs, bit_length,
+                     H.c_, terms, m1_flat, m2_flat,
+                     sign, slide, h_comm, b_comm, t_comm);
+    }
+    driver->run(wk, wb);
 }
 
 } // namespace sbd

--- a/include/sbd/caop/basic/mult_thrust.h
+++ b/include/sbd/caop/basic/mult_thrust.h
@@ -412,52 +412,7 @@ class CaopMultThrust {
         }
     }
 
-public:
-    CaopMultThrust() : tbs_initialized_(false), init_done_(false), global_max_n_(0),
-                       n_bras_(0), n_terms_(0), elem_size_(0),
-                       sign_(false), smem_bytes_(0),
-                       h_twk_{ nullptr, nullptr },
-                       compute_stream_(nullptr), copy_stream_(nullptr),
-                       copy_done_{ nullptr, nullptr },
-                       compute_done_{ nullptr, nullptr } {}
-
-    ~CaopMultThrust() {
-        if (h_twk_[0] != nullptr) {
-            cudaFreeHost(h_twk_[0]);
-            cudaFreeHost(h_twk_[1]);
-            cudaEventDestroy(copy_done_[0]);
-            cudaEventDestroy(copy_done_[1]);
-            cudaEventDestroy(compute_done_[0]);
-            cudaEventDestroy(compute_done_[1]);
-            cudaStreamDestroy(copy_stream_);
-            cudaStreamDestroy(compute_stream_);
-        }
-    }
-
-    bool is_initialized() const { return init_done_; }
-
-    // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
-    // terms as CaopRawTerm, c as coefficient vector). Extracts are done by
-    // InitCaopMultThrust() (friend of GeneralOp) and forwarded here.
-    // Does NOT precompute tbs_seq — that happens lazily on the first run() call.
-    // Safe to call multiple times: resets all lazy state so run() re-initializes
-    // for the new problem (H or basis may have changed between calls).
-    void Init(const std::vector<ElemT>& hd,
-              const det_vector<size_t>& bs,
-              int bit_length,
-              const std::vector<ElemT>& c,
-              const std::vector<CaopRawTerm>& terms,
-              const std::vector<size_t>& m1_flat,
-              const std::vector<size_t>& m2_flat,
-              bool sign,
-              const std::vector<int>& slide,
-              MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
-        // Reset lazy state so run() re-initializes for this problem.
-        tbs_initialized_ = false;
-        d_tbs_seq_.clear();
-        n_kets_per_task_.clear();
-        // Free persistent run() resources if previously allocated, so run()
-        // re-allocates them sized for the (possibly different) global_max_n_.
+    void free_run_resources() {
         if (h_twk_[0] != nullptr) {
             cudaFreeHost(h_twk_[0]); h_twk_[0] = nullptr;
             cudaFreeHost(h_twk_[1]); h_twk_[1] = nullptr;
@@ -468,6 +423,62 @@ public:
             cudaStreamDestroy(copy_stream_);  copy_stream_  = nullptr;
             cudaStreamDestroy(compute_stream_); compute_stream_ = nullptr;
         }
+    }
+
+public:
+    CaopMultThrust() : tbs_initialized_(false), init_done_(false), global_max_n_(0),
+                       n_bras_(0), n_terms_(0), elem_size_(0),
+                       sign_(false), smem_bytes_(0),
+                       h_twk_{ nullptr, nullptr },
+                       compute_stream_(nullptr), copy_stream_(nullptr),
+                       copy_done_{ nullptr, nullptr },
+                       compute_done_{ nullptr, nullptr } {}
+
+    ~CaopMultThrust() { free_run_resources(); }
+
+    bool is_initialized() const { return init_done_; }
+
+    // Reset to uninitialized state. Must be called if H or the basis size changes
+    // between sbd::diag() calls, to discard stale cached data.
+    void reset() {
+        tbs_initialized_ = false;
+        init_done_ = false;
+        d_tbs_seq_.clear();
+        n_kets_per_task_.clear();
+        free_run_resources();
+    }
+
+    // Init: accepts pre-extracted GeneralOp data (m1/m2 as flat vectors,
+    // terms as CaopRawTerm, c as coefficient vector). Extracts are done by
+    // InitCaopMultThrust() (friend of GeneralOp) and forwarded here.
+    // Does NOT precompute tbs_seq — that happens lazily on the first run() call.
+    // Idempotent: returns immediately if already initialized for the same problem.
+    // Throws std::logic_error if dimensions changed without reset() being called.
+    void Init(const std::vector<ElemT>& hd,
+              const det_vector<size_t>& bs,
+              int bit_length,
+              const std::vector<ElemT>& c,
+              const std::vector<CaopRawTerm>& terms,
+              const std::vector<size_t>& m1_flat,
+              const std::vector<size_t>& m2_flat,
+              bool sign,
+              const std::vector<int>& slide,
+              MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm) {
+        // Idempotent: return if already initialized for the same problem.
+        // Throw if dimensions changed without reset() being called first.
+        if (init_done_) {
+            if ((int)terms.size() != n_terms_ ||
+                (int)bs.size()    != n_bras_  ||
+                slide.size()      != slide_.size())
+                throw std::logic_error(
+                    "CaopMultThrust::Init: problem dimensions changed; call reset() before reinitializing");
+            return;
+        }
+        // Clear lazy state and free persistent run() resources for the new problem.
+        tbs_initialized_ = false;
+        d_tbs_seq_.clear();
+        n_kets_per_task_.clear();
+        free_run_resources();
         h_comm_ = h_comm; b_comm_ = b_comm; t_comm_ = t_comm;
         sign_   = sign;
         slide_  = slide;
@@ -723,8 +734,8 @@ public:
 // ============================================================
 // InitCaopMultThrust — extracts GeneralOp data and calls driver.Init().
 // Declared as a friend of GeneralOp / CAOp / ProductOp in generalop.h.
-// Callers (e.g. sbdiag.h method==0) own the CaopMultThrust lifetime and
-// call Init() again whenever H or basis changes between sbd::diag() calls.
+// driver.Init() is idempotent: returns immediately on the second call if
+// dimensions haven't changed; throws if they changed without reset().
 // ============================================================
 template <typename ElemT>
 void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
@@ -759,10 +770,9 @@ void InitCaopMultThrust(CaopMultThrust<ElemT>& driver,
 
 // ============================================================
 // Free mult() — caller supplies a CaopMultThrust<ElemT>& to own GPU resources.
-// Lazily calls InitCaopMultThrust() on the first invocation (!driver.is_initialized());
-// subsequent calls with the same driver skip Init and go directly to run().
-// To force re-initialization (e.g. after H or basis changes), call
-// InitCaopMultThrust() explicitly before the next mult() call.
+// Calls InitCaopMultThrust() on every invocation; Init() returns immediately if
+// the driver is already initialized for the same problem (idempotent).
+// Call reset() on the driver before reuse if H or the basis changes.
 // ============================================================
 template <typename ElemT>
 void mult(const std::vector<ElemT>& hd,
@@ -775,8 +785,7 @@ void mult(const std::vector<ElemT>& hd,
           bool sign,
           MPI_Comm h_comm, MPI_Comm b_comm, MPI_Comm t_comm,
           CaopMultThrust<ElemT>& driver) {
-    if (!driver.is_initialized())
-        InitCaopMultThrust(driver, hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
+    InitCaopMultThrust(driver, hd, bs, bit_length, H, sign, slide, h_comm, b_comm, t_comm);
     driver.run(wk, wb);
 }
 

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -196,23 +196,6 @@ namespace sbd {
 	auto time_start_davidson = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> hii;
 	makeCAOpHamDiagTerms(basis,bit_length,slide,H,hii);
-#ifdef SBD_THRUST
-	// GPU path (method==0): driver owns GPU resources for the full Davidson+eval
-	// lifetime. InitCaopMultThrust() is safe to call again when H or basis
-	// changes between sbd::diag() calls (orbital optimization cycles).
-	CaopMultThrust<ElemT> device_mult;
-	if( method == 0 ) {
-	  InitCaopMultThrust(device_mult,hii,basis,bit_length,H,sign,
-			     slide,h_comm,b_comm,t_comm);
-	  Davidson(hii,W,device_mult,
-		   h_comm,b_comm,t_comm,
-		   max_it,max_nb,max_iv,eps,seed);
-	} else if ( method == 2 ) {
-	  Lanczos(hii,W,basis,bit_length,slide,H,sign,
-		  h_comm,b_comm,t_comm,
-		  max_it,max_nb,eps);
-	}
-#else
 	if( method == 0 ) {
 	  Davidson(hii,W,basis,bit_length,slide,H,sign,
 		   h_comm,b_comm,t_comm,
@@ -222,7 +205,6 @@ namespace sbd {
 		  h_comm,b_comm,t_comm,
 		  max_it,max_nb,eps);
 	}
-#endif
 	auto time_end_davidson = std::chrono::high_resolution_clock::now();
 	auto elapsed_davidson_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_davidson-time_start_davidson).count();
 	double elapsed_davidson = 0.000001 * elapsed_davidson_count;
@@ -242,11 +224,10 @@ namespace sbd {
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> C(W.size(),0.0);
 #ifdef SBD_THRUST
-	if( method == 0 ) {
-	  device_mult.run(W,C);
-	} else {
+	{
+	  CaopMultThrust<ElemT> eval_driver;
 	  mult(hii,W,C,basis,bit_length,slide,H,sign,
-	       h_comm,b_comm,t_comm);
+	       h_comm,b_comm,t_comm,eval_driver);
 	}
 #else
 	mult(hii,W,C,basis,bit_length,slide,H,sign,

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -117,11 +117,11 @@ namespace sbd {
     void diag(const MPI_Comm & comm,
 	      const SBD & sbd_data,
 	      const GeneralOp<ElemT> & H,
-	      const std::vector<std::vector<size_t>> & basis,
+	      const det_vector<size_t> & basis,
 	      const std::string & loadname,
 	      const std::string & savename,
 	      double & energy,
-	      std::vector<std::vector<size_t>> & co_basis) {
+	      det_vector<size_t> & co_basis) {
       
       int mpi_master = 0;
       int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
@@ -349,7 +349,7 @@ namespace sbd {
 	      const std::string & loadname,
 	      const std::string & savename,
 	      double & energy,
-	      std::vector<std::vector<size_t>> & co_basis) {
+	      det_vector<size_t> & co_basis) {
 
       int mpi_master = 0;
       int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
@@ -409,7 +409,7 @@ namespace sbd {
 	std::cout << " " << make_timestamp()
 		  << " sbd: start load basis" << std::endl;
       }
-      std::vector<std::vector<size_t>> basis;
+      det_vector<size_t> basis;
       if( mpi_rank_h == 0 ) {
 	if( mpi_rank_t == 0 ) {
 	  load_basis_from_files(basisfiles,basis,

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -236,13 +236,12 @@ namespace sbd {
 	 */
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> C(W.size(),0.0);
+	mult(hii,W,C,basis,bit_length,slide,H,sign,
+	     h_comm,b_comm,t_comm
 #ifdef SBD_THRUST
-	mult(hii,W,C,basis,bit_length,slide,H,sign,
-	     h_comm,b_comm,t_comm,caop_driver);
-#else
-	mult(hii,W,C,basis,bit_length,slide,H,sign,
-	     h_comm,b_comm,t_comm);
+	     , caop_driver
 #endif
+	     );
 	auto time_end_mult = std::chrono::high_resolution_clock::now();
 	auto elapsed_mult_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mult-time_start_mult).count();
         double elapsed_mult = 0.000001 * elapsed_mult_count;

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -196,6 +196,23 @@ namespace sbd {
 	auto time_start_davidson = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> hii;
 	makeCAOpHamDiagTerms(basis,bit_length,slide,H,hii);
+#ifdef SBD_THRUST
+	// GPU path (method==0): driver owns GPU resources for the full Davidson+eval
+	// lifetime. InitCaopMultThrust() is safe to call again when H or basis
+	// changes between sbd::diag() calls (orbital optimization cycles).
+	CaopMultThrust<ElemT> device_mult;
+	if( method == 0 ) {
+	  InitCaopMultThrust(device_mult,hii,basis,bit_length,H,sign,
+			     slide,h_comm,b_comm,t_comm);
+	  Davidson(hii,W,device_mult,
+		   h_comm,b_comm,t_comm,
+		   max_it,max_nb,max_iv,eps,seed);
+	} else if ( method == 2 ) {
+	  Lanczos(hii,W,basis,bit_length,slide,H,sign,
+		  h_comm,b_comm,t_comm,
+		  max_it,max_nb,eps);
+	}
+#else
 	if( method == 0 ) {
 	  Davidson(hii,W,basis,bit_length,slide,H,sign,
 		   h_comm,b_comm,t_comm,
@@ -205,6 +222,7 @@ namespace sbd {
 		  h_comm,b_comm,t_comm,
 		  max_it,max_nb,eps);
 	}
+#endif
 	auto time_end_davidson = std::chrono::high_resolution_clock::now();
 	auto elapsed_davidson_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_davidson-time_start_davidson).count();
 	double elapsed_davidson = 0.000001 * elapsed_davidson_count;
@@ -223,8 +241,17 @@ namespace sbd {
 	 */
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> C(W.size(),0.0);
+#ifdef SBD_THRUST
+	if( method == 0 ) {
+	  device_mult.run(W,C);
+	} else {
+	  mult(hii,W,C,basis,bit_length,slide,H,sign,
+	       h_comm,b_comm,t_comm);
+	}
+#else
 	mult(hii,W,C,basis,bit_length,slide,H,sign,
 	     h_comm,b_comm,t_comm);
+#endif
 	auto time_end_mult = std::chrono::high_resolution_clock::now();
 	auto elapsed_mult_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mult-time_start_mult).count();
         double elapsed_mult = 0.000001 * elapsed_mult_count;

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -151,7 +151,7 @@ namespace sbd {
       }
       double eps = sbd_data.eps;
       size_t system_size = sbd_data.system_size;
-      size_t bit_length = sbd_data.bit_length;
+      int bit_length = (int)sbd_data.bit_length;
       bool sign = sbd_data.sign;
 
       /**

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -196,14 +196,27 @@ namespace sbd {
 	auto time_start_davidson = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> hii;
 	makeCAOpHamDiagTerms(basis,bit_length,slide,H,hii);
+#ifdef SBD_THRUST
+	// caop_driver holds GPU resources across Davidson/Lanczos and the energy evaluation.
+	// Call reset() if H or the basis size changes between sbd::diag() calls.
+	CaopMultThrust<ElemT> caop_driver;
+#endif
 	if( method == 0 ) {
 	  Davidson(hii,W,basis,bit_length,slide,H,sign,
 		   h_comm,b_comm,t_comm,
-		   max_it,max_nb,max_iv,eps,seed);
+		   max_it,max_nb,max_iv,eps,seed
+#ifdef SBD_THRUST
+		   , caop_driver
+#endif
+		   );
 	} else if ( method == 2 ) {
 	  Lanczos(hii,W,basis,bit_length,slide,H,sign,
 		  h_comm,b_comm,t_comm,
-		  max_it,max_nb,eps);
+		  max_it,max_nb,eps
+#ifdef SBD_THRUST
+		  , caop_driver
+#endif
+		  );
 	}
 	auto time_end_davidson = std::chrono::high_resolution_clock::now();
 	auto elapsed_davidson_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_davidson-time_start_davidson).count();
@@ -224,11 +237,8 @@ namespace sbd {
 	auto time_start_mult = std::chrono::high_resolution_clock::now();
 	std::vector<ElemT> C(W.size(),0.0);
 #ifdef SBD_THRUST
-	{
-	  CaopMultThrust<ElemT> eval_driver;
-	  mult(hii,W,C,basis,bit_length,slide,H,sign,
-	       h_comm,b_comm,t_comm,eval_driver);
-	}
+	mult(hii,W,C,basis,bit_length,slide,H,sign,
+	     h_comm,b_comm,t_comm,caop_driver);
 #else
 	mult(hii,W,C,basis,bit_length,slide,H,sign,
 	     h_comm,b_comm,t_comm);

--- a/include/sbd/framework/bit_manipulation.h
+++ b/include/sbd/framework/bit_manipulation.h
@@ -1062,23 +1062,14 @@ namespace sbd {
    */
   inline int bit_string_sign_factor(const std::vector<size_t> & w,
 				    int bit_length,
-				    size_t x,
-				    size_t r) {
-    int sign = 1;
-    size_t size_t_one = 1;
-    for(size_t k=0; k < r; k++) {
-      for(size_t l=0; l < bit_length; l++) {
-	if( (w[k] & (size_t_one << l)) != 0 ) {
-	  sign *= -1;
-	}
-      }
+				    int x,
+				    int r) {
+    int parity = 0;
+    for(int k=0; k < r; k++) {
+      parity ^= __builtin_popcountll(w[k]);
     }
-    for(size_t l=0; l < x; l++) {
-      if( ( w[r] & (size_t_one << l) ) != 0 ) {
-	sign *= -1;
-      }
-    }
-    return sign;
+    parity ^= __builtin_popcountll(w[r] & ((size_t(1) << x) - 1));
+    return (parity & 1) ? -1 : 1;
   }
 
 

--- a/include/sbd/framework/mpi_utility_thrust.h
+++ b/include/sbd/framework/mpi_utility_thrust.h
@@ -43,7 +43,6 @@ template <typename ElemT>
 void MpiAllreduce(thrust::device_vector<ElemT> &A, MPI_Op op, MPI_Comm comm)
 {
     SBD_NVTX_RANGE_COLOR("MpiAllreduce", __LINE__);
-    std::cout << "   TEST MpiAllreduce" << std::endl;
     MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
 #if 1
     thrust::device_vector<ElemT> B(A);


### PR DESCRIPTION
CPU binary: `diag-caop3-cpu-2026-07-07` (`42b2bf4`), 72 OMP threads/rank.  
GPU binary: `diag-caop3-thrust-2026-07-07` (`42b2bf4`), 1 GPU/rank.  
Workload: 48-site 20M-det, `--do_redist_basis 1 --iteration 6 --block 10`

| Ranks | GPU davidson | GPU speedup | CPU davidson (72 OMP/rank) | CPU speedup | GPU/CPU |
|-------|-------------|-------------|--------------------------|-------------|---------|
| 1     | 38.35s      | 1.00×       | 69.63s                   | 1.00×       |  1.8×   |
| 2     | 20.23s      | 1.90×       | 74.89s                   | 0.93×       |  3.7×   |
| 4     | 12.22s      | 3.14×       | 74.11s                   | 0.94×       |  6.1×   |
| 8     |  6.75s      | 5.68×       | 67.69s                   | 1.03×       | 10.0×   |