### PR TITLE
Fix duplicate addition in vector version of ZeroDiffCorrelation

### DIFF
--- a/include/sbd/chemistry/basic/correlation.h
+++ b/include/sbd/chemistry/basic/correlation.h
@@ -32,7 +32,7 @@ namespace sbd {
 	int oj = closed.at(j)/2;
 	int sj = closed.at(j)%2;
 #pragma omp atomic update
-	twobody[sj+2*si][oj+norb*oi+norb*norb*oj+norb*norb*norb*oi]
+	twobody[si+2*sj][oi+norb*oj+norb*norb*oi+norb*norb*norb*oj]
 	  += SquaredNorm(WeightI);
 #pragma omp atomic update
 	twobody[sj+2*si][oj+norb*oi+norb*norb*oj+norb*norb*norb*oi]


### PR DESCRIPTION
The two-body accumulation added SquaredNorm(WeightI) twice to the same (j,i)-ordered element instead of updating both the (i,j)- and (j,i)-ordered elements. Restore the (i,j)-ordered update to match the OMP offload version, which has the correct index pattern.

Verified against a host-side replica of the offload implementation using relative-error comparison.