### PR TITLE
Fix GDB RDM (#72)

### DIFF
--- a/apps/chemistry_gdb_selected_basis_diagonalization/main.cc
+++ b/apps/chemistry_gdb_selected_basis_diagonalization/main.cc
@@ -242,12 +242,12 @@ int main(int argc, char * argv[]) {
   }
   if( one_p_rdm.size() != 0 ) {
     if ( mpi_rank == 0 ) {
-      double zerobody = 0.0;
+      Elem zerobody = 0.0;
       Elem onebody = 0.0;
       Elem twobody = 0.0;
-      double I0;
-      sbd::oneInt<double> I1;
-      sbd::twoInt<double> I2;
+      Elem I0;
+      sbd::oneInt<Elem> I1;
+      sbd::twoInt<Elem> I2;
       sbd::SetupIntegrals(fcidump,L,N,I0,I1,I2);
       zerobody = I0;
 

--- a/include/sbd/chemistry/gdb/sbdiag.h
+++ b/include/sbd/chemistry/gdb/sbdiag.h
@@ -369,8 +369,8 @@ namespace sbd {
 	     h_comm,b_comm,t_comm);
 	ElemT E;
 	InnerProduct(w,v,E,b_comm);
-	energy = GetReal(E);
 #endif
+	energy = GetReal(E);
 	if( sbd_data.timing_barriers ) MPI_Barrier(comm);
 	auto time_end_mult = std::chrono::high_resolution_clock::now();
 	auto elapsed_mult_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_mult-time_start_mult).count();

--- a/include/sbd/framework/cuda_utility.h
+++ b/include/sbd/framework/cuda_utility.h
@@ -30,52 +30,32 @@
     } while (0)
 #endif
 
-// atomic_add: type-safe atomic accumulation for device kernels.
-// On device: decomposes complex into two double atomics.
-// On host:   falls back to non-atomic += (host path is never used
-//            for actual computation — only compiled for __host__ __device__
-//            correctness).
+// atomic_add: type-safe atomic accumulation for device kernels only.
 namespace sbd {
 
 template <typename T>
-__host__ __device__ inline void atomic_add(T* p, T v)
+__device__ inline void atomic_add(T* p, T v)
 {
-#ifdef __CUDA_ARCH__
     atomicAdd(p, v);
-#else
-    *p += v;
-#endif
 }
 
 template <>
-__host__ __device__ inline void atomic_add(std::complex<double>* p, std::complex<double> v)
+__device__ inline void atomic_add(std::complex<double>* p, std::complex<double> v)
 {
-#ifdef __CUDA_ARCH__
     atomicAdd(reinterpret_cast<double*>(p),     v.real());
     atomicAdd(reinterpret_cast<double*>(p) + 1, v.imag());
-#else
-    *p += v;
-#endif
 }
 
 // Overload: add a real value to the real part of a complex accumulator.
-__host__ __device__ inline void atomic_add_real(std::complex<double>* p, double v)
+__device__ inline void atomic_add_real(std::complex<double>* p, double v)
 {
-#ifdef __CUDA_ARCH__
     atomicAdd(reinterpret_cast<double*>(p), v);
-#else
-    *p += std::complex<double>(v, 0.0);
-#endif
 }
 
 // Overload for real types (no-op specialisation needed to avoid ambiguity).
-__host__ __device__ inline void atomic_add_real(double* p, double v)
+__device__ inline void atomic_add_real(double* p, double v)
 {
-#ifdef __CUDA_ARCH__
     atomicAdd(p, v);
-#else
-    *p += v;
-#endif
 }
 
 } // namespace sbd


### PR DESCRIPTION
In GDB main.cc I0/I1/I2 and zerobody were hardcoded double, mismatching the Elem-typed one_p_rdm/two_p_rdm and breaking SetupIntegrals template deduction under _COMPLEX.  Changed all four to Elem.

This is hopefully the proper fix for #72.