### PR TITLE
Fix deadlock in `GetTotalD_Thrust` when `h_comm` has a single rank

### DIFF
--- a/include/sbd/chemistry/basic/davidson_thrust.h
+++ b/include/sbd/chemistry/basic/davidson_thrust.h
@@ -56,12 +56,18 @@ void GetTotalD_Thrust(const thrust::device_vector<ElemT> & hii,
         thrust::device_vector<ElemT>& dii,
         MPI_Comm h_comm) {
     SBD_NVTX_RANGE_COLOR("GetTotalD_Thrust", __LINE__);
+    int h_size; MPI_Comm_size(h_comm, &h_size);
     int size_d = hii.size();
     dii.resize(hii.size());
-    MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
-    {
-        SBD_NVTX_RANGE_COLOR("MPI_Allreduce", 0);
-        MPI_Allreduce((ElemT*)thrust::raw_pointer_cast(hii.data()), (ElemT*)thrust::raw_pointer_cast(dii.data()), size_d, DataT, MPI_SUM, h_comm);
+    if (h_size == 1) {
+        cudaMemcpy(thrust::raw_pointer_cast(dii.data()),
+                   thrust::raw_pointer_cast(hii.data()),
+                   size_d * sizeof(ElemT), cudaMemcpyDeviceToDevice);
+    } else {
+        MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
+        MPI_Allreduce((ElemT*)thrust::raw_pointer_cast(hii.data()),
+                      (ElemT*)thrust::raw_pointer_cast(dii.data()),
+                      size_d, DataT, MPI_SUM, h_comm);
     }
 }
 

--- a/include/sbd/chemistry/basic/davidson_thrust.h
+++ b/include/sbd/chemistry/basic/davidson_thrust.h
@@ -65,9 +65,12 @@ void GetTotalD_Thrust(const thrust::device_vector<ElemT> & hii,
                    size_d * sizeof(ElemT), cudaMemcpyDeviceToDevice);
     } else {
         MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
-        MPI_Allreduce((ElemT*)thrust::raw_pointer_cast(hii.data()),
-                      (ElemT*)thrust::raw_pointer_cast(dii.data()),
-                      size_d, DataT, MPI_SUM, h_comm);
+        {
+            SBD_NVTX_RANGE_COLOR("MPI_Allreduce", 0);
+            MPI_Allreduce((ElemT*)thrust::raw_pointer_cast(hii.data()),
+                          (ElemT*)thrust::raw_pointer_cast(dii.data()),
+                          size_d, DataT, MPI_SUM, h_comm);
+        }
     }
 }
 


### PR DESCRIPTION
### Problem

In multi-node multi-GPU configurations built with `SBD_THRUST` + `SBD_USE_NCCL` + `SBD_USE_CUBLAS` and CUDA-aware MPI, the Davidson solver hangs reproducibly during `GetTotalD_Thrust`. The hang occurs when `h_comm` contains only a single rank.

### Observation

`GetTotalD_Thrust` unconditionally calls `MPI_Allreduce` on device pointers via CUDA-aware MPI, even when `h_comm` has size 1. This is a no-op for h_comm=1, but replacing it with `cudaMemcpy(DeviceToDevice)` eliminates the hang.

The hang reproduces in multi-batch configurations (N nodes × 4 GPUs/node, 1 MPI rank per GPU).

### Suspected mechanism (but I'm not confident)

The CUDA-aware MPI implementation likely enters its internal intra-node transport path (CUDA IPC or host staging buffers) even for a size-1 communicator. When another rank on the same node is already blocked in a different collective (`MPI_Bcast` on `b_comm`), the two operations may contend for shared transport resources, causing a deadlock. Bypassing MPI entirely for this degenerate case avoids the contention.

### Fix

Bypass `MPI_Allreduce` entirely when `h_comm` has size 1. Use `cudaMemcpy(DeviceToDevice)` to copy the input directly to the output buffer:

```cpp
int h_size; MPI_Comm_size(h_comm, &h_size);

if (h_size == 1) {
    cudaMemcpy(thrust::raw_pointer_cast(dii.data()),
               thrust::raw_pointer_cast(hii.data()),
               size_d * sizeof(ElemT), cudaMemcpyDeviceToDevice);
} else {
    MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
    MPI_Allreduce((ElemT*)thrust::raw_pointer_cast(hii.data()),
                  (ElemT*)thrust::raw_pointer_cast(dii.data()),
                  size_d, DataT, MPI_SUM, h_comm);
}
```

Related #77 