### PR TITLE
Add fugaku-llvm CMake preset for A64FX

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,6 +23,20 @@
       }
     },
     {
+      "name": "fugaku-llvm",
+      "displayName": "Fugaku A64FX — LLVM/Clang + OpenBLAS (recommended CPU build)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/fugaku-llvm",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/fugaku-llvm.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS":  "-O3 -fopenmp",
+        "SBD_GPU_BACKEND":  "none",
+        "BLAS_LIBRARIES":   "/vol0004/apps/oss/spack-v1.0.1/opt/spack/linux-a64fx/openblas-0.3.30-tayl3edqrmltxa7fylvolkjwg4rvj3gg/lib/libopenblas.so",
+        "LAPACK_LIBRARIES": "/vol0004/apps/oss/spack-v1.0.1/opt/spack/linux-a64fx/openblas-0.3.30-tayl3edqrmltxa7fylvolkjwg4rvj3gg/lib/libopenblas.so"
+      }
+    },
+    {
       "name": "craype-thrust",
       "displayName": "Cray PE + nvc++ Thrust (GH200 / cc90)",
       "generator": "Unix Makefiles",
@@ -76,6 +90,7 @@
   "buildPresets": [
     { "name": "macos-cpu",     "configurePreset": "macos-cpu" },
     { "name": "linux-cpu",     "configurePreset": "linux-cpu" },
+    { "name": "fugaku-llvm",   "configurePreset": "fugaku-llvm" },
     { "name": "craype-thrust", "configurePreset": "craype-thrust" },
     { "name": "nvhpc-thrust",  "configurePreset": "nvhpc-thrust" },
     { "name": "omp5-nvidia",   "configurePreset": "omp5-nvidia" },

--- a/cmake/toolchains/fugaku-llvm.cmake
+++ b/cmake/toolchains/fugaku-llvm.cmake
@@ -1,0 +1,15 @@
+# Fugaku A64FX LLVM/Clang toolchain — mpiclang++ with OpenBLAS
+#
+# Requires: module load LLVM/llvmorg-22.1.0
+# Uses the system Fujitsu MPI wrapper (mpiclang++) which wraps
+# aarch64-linux-gnu-clang++ with Fujitsu MPI.
+# OpenBLAS is the tested BLAS/LAPACK provider for this toolchain.
+
+set(CMAKE_CXX_COMPILER mpiclang++)
+set(CMAKE_C_COMPILER   mpiclang)
+
+# OpenMP via LLVM's libomp
+set(OpenMP_CXX_FLAGS      "-fopenmp")
+set(OpenMP_CXX_LIB_NAMES  "")
+set(OpenMP_CXX_LIBRARIES  "")
+set(OpenMP_CXX_FLAGS_INIT "-fopenmp")


### PR DESCRIPTION
We've been benchmarking SBD on Fugaku as part of the FugakuNEXT effort. While we set up builds we tried a few compiler paths on A64FX and cleanly reproduced the result: LLVM/Clang is significantly faster than the Fujitsu compiler for SBD.

We thought we'd share a preset so that future users on Fugaku get the fast path by default. The preset adds the appropriate `fugaku-llvm` toolchain + configuration presets; producing the final binary is then just:

```sh
module load LLVM/llvmorg-22.1.0
cmake --preset fugaku-llvm
cmake --build --preset fugaku-llvm --target tpb_diag -j
```

What we measured on the same MPI layout (same nodes, same ranks, same input, `-O3 -fopenmp` for LLVM vs `-Kfast -Kopenmp` for Fujitsu):

| nodes | ranks | layout | Fujitsu (s) | LLVM (s) | speedup |
|---|---:|---:|---:|---:|---:|
| 1 | 4 | `1 × 2 × 2` | 404.07 | **304.85** | 1.33x |
| 2 | 8 | `2 × 2 × 2` | 231.33 | **174.70** | 1.33x |
| 4 | 16 | `4 × 2 × 2` | 183.06 | **137.95** | 1.33x |
| 8 | 32 | `4 × 4 × 2` |  96.40 | **72.84** | 1.32x |
| 16 | 64 | `4 × 4 × 4` |  39.51 | **29.62** | 1.33x |

Benchmark system: H₂O / cc-pVDZ with selected alpha determinants at threshold 1e-4 (1,543 α strings, ~2.4M product determinants).
