### PR TITLE
Destroy NCCL communicators and free a_comm in tpb::diag

### DIFF
--- a/include/sbd/chemistry/tpb/sbdiag.h
+++ b/include/sbd/chemistry/tpb/sbdiag.h
@@ -759,9 +759,19 @@ namespace sbd {
 
       FreeHelpers(helper);
 
+#ifdef SBD_USE_NCCL
+      if (mpi_size_b > 1) {
+          ncclCommDestroy(b_nccl_comm);
+      }
+      if (mpi_size_a > 1) {
+          ncclCommDestroy(a_nccl_comm);
+      }
+#endif
+
       MPI_Comm_free(&h_comm);
       MPI_Comm_free(&b_comm);
       MPI_Comm_free(&t_comm);
+      MPI_Comm_free(&a_comm);
     } // end void diag function
 
     /**


### PR DESCRIPTION
`tpb::diag()` creates `b_nccl_comm` and `a_nccl_comm` on every call but never destroys them, causing NCCL resources to accumulate across repeated calls. It also creates `a_comm` without freeing it.

This change destroys the NCCL communicators using the same guards as their initialization and frees `a_comm`. The uninitialized `h_nccl_comm` and `t_nccl_comm` are left untouched.