### PR TITLE
Use fill_block staging and single H2D, direct copy from flat det_vector

### DIFF
--- a/include/sbd/chemistry/tpb/helper_thrust.h
+++ b/include/sbd/chemistry/tpb/helper_thrust.h
@@ -443,8 +443,10 @@ public:
         std::vector<size_t> permutation;
         // constexpr size_t block_size = 16;
         constexpr size_t block_size = 32;
+#ifdef SBD_DEBUG_HELPER
         printf("[%s,%d] Reordering index arrays (block_size=%zu)\n",
                __FILE__, __LINE__, block_size);
+#endif
         // NOTE:
         // block_size controls the trade-off between improving locality
         // of KetIndex-based accesses and preserving BraIndex locality.
@@ -537,8 +539,10 @@ public:
 
         // Reorder alpha single-excitation arrays
         if (size_single_alpha > 0 && SinglesFromAlphaKetIndex) {
+#ifdef SBD_DEBUG_HELPER
             printf("[%s,%d] Reordering index arrays (size_single_alpha=%zu)\n",
                    __FILE__, __LINE__, size_single_alpha);
+#endif
             setup_permutation(SinglesFromAlphaKetIndex, size_single_alpha);
             reorder_device_array(SinglesFromAlphaKetIndex);
             reorder_device_array(SinglesFromAlphaBraIndex);
@@ -550,8 +554,10 @@ public:
 
         // Reorder beta single-excitation arrays
         if (size_single_beta > 0 && SinglesFromBetaKetIndex) {
+#ifdef SBD_DEBUG_HELPER
             printf("[%s,%d] Reordering index arrays (size_single_beta=%zu)\n",
                    __FILE__, __LINE__, size_single_beta);
+#endif
             setup_permutation(SinglesFromBetaKetIndex, size_single_beta);
             reorder_device_array(SinglesFromBetaKetIndex);
             reorder_device_array(SinglesFromBetaBraIndex);
@@ -563,8 +569,10 @@ public:
 
         // Reorder alpha double-excitation arrays
         if (size_double_alpha > 0 && DoublesFromAlphaKetIndex) {
+#ifdef SBD_DEBUG_HELPER
             printf("[%s,%d] Reordering index arrays (size_double_alpha=%zu)\n",
                    __FILE__, __LINE__, size_double_alpha);
+#endif
             setup_permutation(DoublesFromAlphaKetIndex, size_double_alpha);
             reorder_device_array(DoublesFromAlphaKetIndex);
             reorder_device_array(DoublesFromAlphaBraIndex);
@@ -578,8 +586,10 @@ public:
 
         // Reorder beta double-excitation arrays
         if (size_double_beta > 0 && DoublesFromBetaKetIndex) {
+#ifdef SBD_DEBUG_HELPER
             printf("[%s,%d] Reordering index arrays (size_double_beta=%zu)\n",
                    __FILE__, __LINE__, size_double_beta);
+#endif
             setup_permutation(DoublesFromBetaKetIndex, size_double_beta);
             reorder_device_array(DoublesFromBetaKetIndex);
             reorder_device_array(DoublesFromBetaBraIndex);

--- a/include/sbd/chemistry/tpb/helper_thrust.h
+++ b/include/sbd/chemistry/tpb/helper_thrust.h
@@ -177,53 +177,50 @@ public:
         storage.resize(size);
         base_memory = (size_t*)thrust::raw_pointer_cast(storage.data());
 
+        // Single host staging buffer; one H2D for all excitation blocks.
+        std::vector<size_t> staging(size);
         size_t count = 0;
 
-        // Stage each excitation-list block on the host then do one bulk H2D
-        // transfer, replacing a thrust::copy_n per bra row (and thrust::fill_n
-        // for bra indices). When store_offset is false the layout is
-        // [ket block][bra block] contiguous, so both fit in one transfer.
-        auto upload_rows = [&](auto SM, auto Len, const std::vector<size_t> &offset,
-                               size_t braSize, size_t total, size_t braStart, bool with_bra) {
-            std::vector<size_t> buf(with_bra ? total * 2 : total);
+        auto fill_block = [&](auto SM, auto Len, const std::vector<size_t> &offset,
+                              size_t braSize, size_t total, size_t braStart, bool with_bra) {
+            const size_t base = count;
 #pragma omp parallel for
             for (size_t i = 0; i < braSize; i++) {
                 const size_t off = offset[i];
                 const size_t len = Len[i];
                 for (size_t j = 0; j < len; j++) {
-                    buf[off + j] = SM[i][j];
+                    staging[base + off + j] = SM[i][j];
                 }
                 if (with_bra) {
                     for (size_t j = 0; j < len; j++) {
-                        buf[total + off + j] = i + braStart;
+                        staging[base + total + off + j] = i + braStart;
                     }
                 }
             }
-            thrust::copy_n(buf.begin(), buf.size(), storage.begin() + count);
         };
 
         if (store_offset) {
             // store offsets for non-collapsed loop calculation
             if (taskType != 1) {
                 SinglesFromAlphaOffset = base_memory + count;
-                thrust::copy_n(offset_single_alpha.begin(), braAlphaSize + 1, storage.begin() + count);
+                std::copy_n(offset_single_alpha.data(), braAlphaSize + 1, staging.data() + count);
                 count += braAlphaSize + 1;
 
                 if (taskType == 2) {
                     DoublesFromAlphaOffset = base_memory + count;
-                    thrust::copy_n(offset_double_alpha.begin(), braAlphaSize + 1, storage.begin() + count);
+                    std::copy_n(offset_double_alpha.data(), braAlphaSize + 1, staging.data() + count);
                     count += braAlphaSize + 1;
                 }
             }
 
             if (taskType != 2) {
                 SinglesFromBetaOffset = base_memory + count;
-                thrust::copy_n(offset_single_beta.begin(), braBetaSize + 1, storage.begin() + count);
+                std::copy_n(offset_single_beta.data(), braBetaSize + 1, staging.data() + count);
                 count += braBetaSize + 1;
 
                 if (taskType == 1) {
                     DoublesFromBetaOffset = base_memory + count;
-                    thrust::copy_n(offset_double_beta.begin(), braBetaSize + 1, storage.begin() + count);
+                    std::copy_n(offset_double_beta.data(), braBetaSize + 1, staging.data() + count);
                     count += braBetaSize + 1;
                 }
             }
@@ -240,7 +237,7 @@ public:
                 SinglesFromAlphaKetIndex = base_memory + count;
                 SinglesFromAlphaBraIndex = base_memory + count + size_single_alpha;
             }
-            upload_rows(helper.SinglesFromAlphaSM, helper.SinglesFromAlphaLen,
+            fill_block(helper.SinglesFromAlphaSM, helper.SinglesFromAlphaLen,
                         offset_single_alpha, braAlphaSize, size_single_alpha,
                         helper.braAlphaStart, !store_offset);
 #ifdef SBD_DEBUG
@@ -270,7 +267,7 @@ public:
                     DoublesFromAlphaKetIndex = base_memory + count;
                     DoublesFromAlphaBraIndex = base_memory + count + size_double_alpha;
                 }
-                upload_rows(helper.DoublesFromAlphaSM, helper.DoublesFromAlphaLen,
+                fill_block(helper.DoublesFromAlphaSM, helper.DoublesFromAlphaLen,
                             offset_double_alpha, braAlphaSize, size_double_alpha,
                             helper.braAlphaStart, !store_offset);
                 count += size_double_alpha;
@@ -291,7 +288,7 @@ public:
                 SinglesFromBetaKetIndex = base_memory + count;
                 SinglesFromBetaBraIndex = base_memory + count + size_single_beta;
             }
-            upload_rows(helper.SinglesFromBetaSM, helper.SinglesFromBetaLen,
+            fill_block(helper.SinglesFromBetaSM, helper.SinglesFromBetaLen,
                         offset_single_beta, braBetaSize, size_single_beta,
                         helper.braBetaStart, !store_offset);
 #ifdef SBD_DEBUG
@@ -321,7 +318,7 @@ public:
                     DoublesFromBetaKetIndex = base_memory + count;
                     DoublesFromBetaBraIndex = base_memory + count + size_double_beta;
                 }
-                upload_rows(helper.DoublesFromBetaSM, helper.DoublesFromBetaLen,
+                fill_block(helper.DoublesFromBetaSM, helper.DoublesFromBetaLen,
                             offset_double_beta, braBetaSize, size_double_beta,
                             helper.braBetaStart, !store_offset);
                 count += size_double_beta;
@@ -330,6 +327,9 @@ public:
                 }
             }
         }
+
+        // single H2D for all excitation blocks
+        thrust::copy_n(staging.begin(), size, storage.begin());
 
         // convert CrAn from AoS to SoA
         size_t count_cran = 0;

--- a/include/sbd/chemistry/tpb/helper_thrust.h
+++ b/include/sbd/chemistry/tpb/helper_thrust.h
@@ -6,6 +6,7 @@
 #define SBD_CHEMISTRY_TPB_HELPER_THRUST_H
 
 #include <cassert>
+#include <vector>
 
 #include "sbd/chemistry/tpb/helper.h"
 #include <thrust/device_vector.h>
@@ -177,6 +178,30 @@ public:
         base_memory = (size_t*)thrust::raw_pointer_cast(storage.data());
 
         size_t count = 0;
+
+        // Stage each excitation-list block on the host then do one bulk H2D
+        // transfer, replacing a thrust::copy_n per bra row (and thrust::fill_n
+        // for bra indices). When store_offset is false the layout is
+        // [ket block][bra block] contiguous, so both fit in one transfer.
+        auto upload_rows = [&](auto SM, auto Len, const std::vector<size_t> &offset,
+                               size_t braSize, size_t total, size_t braStart, bool with_bra) {
+            std::vector<size_t> buf(with_bra ? total * 2 : total);
+#pragma omp parallel for
+            for (size_t i = 0; i < braSize; i++) {
+                const size_t off = offset[i];
+                const size_t len = Len[i];
+                for (size_t j = 0; j < len; j++) {
+                    buf[off + j] = SM[i][j];
+                }
+                if (with_bra) {
+                    for (size_t j = 0; j < len; j++) {
+                        buf[total + off + j] = i + braStart;
+                    }
+                }
+            }
+            thrust::copy_n(buf.begin(), buf.size(), storage.begin() + count);
+        };
+
         if (store_offset) {
             // store offsets for non-collapsed loop calculation
             if (taskType != 1) {
@@ -215,28 +240,24 @@ public:
                 SinglesFromAlphaKetIndex = base_memory + count;
                 SinglesFromAlphaBraIndex = base_memory + count + size_single_alpha;
             }
-            for(size_t i=0; i < braAlphaSize; i++) {
-                thrust::copy_n(helper.SinglesFromAlphaSM[i], helper.SinglesFromAlphaLen[i], storage.begin() + count + offset_single_alpha[i]);
+            upload_rows(helper.SinglesFromAlphaSM, helper.SinglesFromAlphaLen,
+                        offset_single_alpha, braAlphaSize, size_single_alpha,
+                        helper.braAlphaStart, !store_offset);
 #ifdef SBD_DEBUG
-                // **** DEBUG ****
+            // **** DEBUG ****
+            for(size_t i=0; i < braAlphaSize; i++) {
                 printf("[%s,%d] SinglesFromAlphaKetIndex: i=%llu, n=%llu, ", __FILE__, __LINE__,
                        i, helper.SinglesFromAlphaLen[i]);
                 for(size_t j=0; j <helper.SinglesFromAlphaLen[i];j++) {
                     printf(" %llu:%llu,", j, helper.SinglesFromAlphaSM[i][j]);
                 }
                 printf("\n");
-#endif
-            }
-            if (!store_offset) {
-                for(size_t i=0; i < braAlphaSize; i++) {
-                    thrust::fill_n(storage.begin() + size_single_alpha + count + offset_single_alpha[i], helper.SinglesFromAlphaLen[i], i + helper.braAlphaStart);
-#ifdef SBD_DEBUG
-                    // **** DEBUG ****
+                if (!store_offset) {
                     printf("[%s,%d] SinglesFromAlphaBraIndex: i=%llu, n=%llu, offset=%llu\n", __FILE__, __LINE__,
                            i, helper.SinglesFromAlphaLen[i], offset_single_alpha[i] );
-#endif
                 }
             }
+#endif
             count += size_single_alpha;
             if (!store_offset) {
                 count += size_single_alpha;
@@ -249,12 +270,9 @@ public:
                     DoublesFromAlphaKetIndex = base_memory + count;
                     DoublesFromAlphaBraIndex = base_memory + count + size_double_alpha;
                 }
-                for(size_t i=0; i < braAlphaSize; i++) {
-                    thrust::copy_n(helper.DoublesFromAlphaSM[i], helper.DoublesFromAlphaLen[i], storage.begin() + count + offset_double_alpha[i]);
-                    if (!store_offset) {
-                        thrust::fill_n(storage.begin() + count + size_double_alpha + offset_double_alpha[i], helper.DoublesFromAlphaLen[i], i + helper.braAlphaStart);
-                    }
-                }
+                upload_rows(helper.DoublesFromAlphaSM, helper.DoublesFromAlphaLen,
+                            offset_double_alpha, braAlphaSize, size_double_alpha,
+                            helper.braAlphaStart, !store_offset);
                 count += size_double_alpha;
                 if (!store_offset) {
                     count += size_double_alpha;
@@ -273,28 +291,24 @@ public:
                 SinglesFromBetaKetIndex = base_memory + count;
                 SinglesFromBetaBraIndex = base_memory + count + size_single_beta;
             }
-            for(size_t i=0; i < braBetaSize; i++) {
-                thrust::copy_n(helper.SinglesFromBetaSM[i], helper.SinglesFromBetaLen[i], storage.begin() + count + offset_single_beta[i]);
+            upload_rows(helper.SinglesFromBetaSM, helper.SinglesFromBetaLen,
+                        offset_single_beta, braBetaSize, size_single_beta,
+                        helper.braBetaStart, !store_offset);
 #ifdef SBD_DEBUG
-                // **** DEBUG ****
+            // **** DEBUG ****
+            for(size_t i=0; i < braBetaSize; i++) {
                 printf("[%s,%d] SinglesFromBetaKetIndex: i=%llu, n=%llu, ", __FILE__, __LINE__,
                        i, helper.SinglesFromBetaLen[i]);
                 for(size_t j=0; j <helper.SinglesFromBetaLen[i];j++) {
                     printf(" %llu:%llu,", j, helper.SinglesFromBetaSM[i][j]);
                 }
                 printf("\n");
-#endif
-            }
-            if (!store_offset) {
-                for(size_t i=0; i < braBetaSize; i++) {
-                    thrust::fill_n(storage.begin() + count + size_single_beta + offset_single_beta[i], helper.SinglesFromBetaLen[i], i + helper.braBetaStart);
-#ifdef SBD_DEBUG
-                    // **** DEBUG ****
+                if (!store_offset) {
                     printf("[%s,%d] SinglesFromBetaBraIndex: i=%llu, n=%llu, offset=%llu\n", __FILE__, __LINE__,
                            i, helper.SinglesFromBetaLen[i], offset_single_beta[i] );
-#endif
                 }
             }
+#endif
             count += size_single_beta;
             if (!store_offset) {
                 count += size_single_beta;
@@ -307,12 +321,9 @@ public:
                     DoublesFromBetaKetIndex = base_memory + count;
                     DoublesFromBetaBraIndex = base_memory + count + size_double_beta;
                 }
-                for(size_t i=0; i < braBetaSize; i++) {
-                    thrust::copy_n(helper.DoublesFromBetaSM[i], helper.DoublesFromBetaLen[i], storage.begin() + count + offset_double_beta[i]);
-                    if (!store_offset) {
-                        thrust::fill_n(storage.begin() + count + size_double_beta + offset_double_beta[i], helper.DoublesFromBetaLen[i], i + helper.braBetaStart);
-                    }
-                }
+                upload_rows(helper.DoublesFromBetaSM, helper.DoublesFromBetaLen,
+                            offset_double_beta, braBetaSize, size_double_beta,
+                            helper.braBetaStart, !store_offset);
                 count += size_double_beta;
                 if (!store_offset) {
                     count += size_double_beta;

--- a/include/sbd/chemistry/tpb/mult_thrust.h
+++ b/include/sbd/chemistry/tpb/mult_thrust.h
@@ -5,8 +5,10 @@
 #ifndef SBD_CHEMISTRY_TPB_MULT_THRUST_H
 #define SBD_CHEMISTRY_TPB_MULT_THRUST_H
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <vector>
 
 #ifdef SBD_USE_NCCL
 #include <nccl.h>
@@ -203,14 +205,23 @@ void MultTPBThrust<ElemT>::Init(
         bdets_size = std::max(bdets_size, helper[task].braBetaEnd - helper[task].braBetaStart);
     }
 
-    // copyin adets, bdets
+    // copyin adets, bdets: staged through a host buffer for one bulk H2D transfer.
     adets.resize(this->D_half_size_ * adets_in.size());
     bdets.resize(this->D_half_size_ * bdets_in.size());
-    for (int i = 0; i < adets_in.size(); i++) {
-        thrust::copy_n(adets_in[i].begin(), this->D_half_size_, adets.begin() + i * this->D_half_size_);
-    }
-    for (int i = 0; i < bdets_in.size(); i++) {
-        thrust::copy_n(bdets_in[i].begin(), this->D_half_size_, bdets.begin() + i * this->D_half_size_);
+    {
+        std::vector<size_t> buf(this->D_half_size_ * adets_in.size());
+#pragma omp parallel for
+        for (size_t i = 0; i < adets_in.size(); i++) {
+            std::copy_n(adets_in[i].begin(), this->D_half_size_, buf.begin() + i * this->D_half_size_);
+        }
+        thrust::copy_n(buf.begin(), buf.size(), adets.begin());
+
+        buf.resize(this->D_half_size_ * bdets_in.size());
+#pragma omp parallel for
+        for (size_t i = 0; i < bdets_in.size(); i++) {
+            std::copy_n(bdets_in[i].begin(), this->D_half_size_, buf.begin() + i * this->D_half_size_);
+        }
+        thrust::copy_n(buf.begin(), buf.size(), bdets.begin());
     }
 
     dets_size = 0;

--- a/include/sbd/chemistry/tpb/mult_thrust.h
+++ b/include/sbd/chemistry/tpb/mult_thrust.h
@@ -205,24 +205,11 @@ void MultTPBThrust<ElemT>::Init(
         bdets_size = std::max(bdets_size, helper[task].braBetaEnd - helper[task].braBetaStart);
     }
 
-    // copyin adets, bdets: staged through a host buffer for one bulk H2D transfer.
+    // copyin adets, bdets: det_vector is flat-packed, one H2D per array.
     adets.resize(this->D_half_size_ * adets_in.size());
+    thrust::copy_n(adets_in.cflat().data(), adets.size(), adets.begin());
     bdets.resize(this->D_half_size_ * bdets_in.size());
-    {
-        std::vector<size_t> buf(this->D_half_size_ * adets_in.size());
-#pragma omp parallel for
-        for (size_t i = 0; i < adets_in.size(); i++) {
-            std::copy_n(adets_in[i].begin(), this->D_half_size_, buf.begin() + i * this->D_half_size_);
-        }
-        thrust::copy_n(buf.begin(), buf.size(), adets.begin());
-
-        buf.resize(this->D_half_size_ * bdets_in.size());
-#pragma omp parallel for
-        for (size_t i = 0; i < bdets_in.size(); i++) {
-            std::copy_n(bdets_in[i].begin(), this->D_half_size_, buf.begin() + i * this->D_half_size_);
-        }
-        thrust::copy_n(buf.begin(), buf.size(), bdets.begin());
-    }
+    thrust::copy_n(bdets_in.cflat().data(), bdets.size(), bdets.begin());
 
     dets_size = 0;
     if (use_precalculated_dets) {

--- a/include/sbd/chemistry/tpb/sbdiag.h
+++ b/include/sbd/chemistry/tpb/sbdiag.h
@@ -346,8 +346,6 @@ namespace sbd {
 	*/
 
 	auto time_start_diag = std::chrono::high_resolution_clock::now();
-	auto time_start_davidson = std::chrono::high_resolution_clock::now();
-	auto time_start_qcham = std::chrono::high_resolution_clock::now();
 #ifdef SBD_THRUST
 	auto time_start_mult_init = std::chrono::high_resolution_clock::now();
         {
@@ -367,12 +365,14 @@ namespace sbd {
 		std::cout << " Elapsed time for mult.Init() " << elapsed_mult_init << " (sec) " << std::endl;
 	}
 
+	auto time_start_qcham = std::chrono::high_resolution_clock::now();
 	thrust::device_vector<double> hii;
         {
             SBD_NVTX_RANGE_COLOR("device_mult.makeQChamDiagTerms", __LINE__);
             device_mult.makeQChamDiagTerms(hii);
         }
 #else
+	auto time_start_qcham = std::chrono::high_resolution_clock::now();
 	std::vector<double> hii;
 	sbd::makeQChamDiagTerms(adet,bdet,bit_length,L,
 				helper,I0,I1,I2,hii,
@@ -385,6 +385,7 @@ namespace sbd {
 		std::cout << " Elapsed time for makeQChamDiagTerms " << elapsed_qcham << " (sec) " << std::endl;
 	}
 
+	auto time_start_davidson = std::chrono::high_resolution_clock::now();
 #ifdef SBD_THRUST
 	if( method == 0 ) {
             SBD_NVTX_RANGE_COLOR("Davidson", __LINE__);


### PR DESCRIPTION
## Summary

- Fix timer nesting: `mult.Init()`, `makeQChamDiagTerms`, and `davidson` timers all started at the same point, causing their printed times to be nested rather than disjoint. Each now starts immediately before its own work.
- Guard verbose `printf("Reordering index arrays...")` calls in the reorder pass behind `SBD_DEBUG_HELPER` to avoid flooding logs in normal builds.
- Replace per-row `thrust::copy_n`/`thrust::fill_n` in `TaskHelpersThrust` constructor with a `fill_block` lambda that stages all excitation-list blocks into one host buffer, then issues a single bulk H2D transfer.
- In `MultTPBThrust::Init`, replace the OMP-parallel staging loop for `adets`/`bdets` with a direct `thrust::copy_n` from `det_vector::cflat().data()`, exploiting the flat-packed layout introduced in PR #71.
