### PR TITLE
caop: parallel basis load, warm-restart, and shard correctness

### DIFF
--- a/apps/caop_selected_basis_diagonalization/README.md
+++ b/apps/caop_selected_basis_diagonalization/README.md
@@ -200,7 +200,7 @@ Generates 100 random bitstrings of length 16 with exactly 4 ones, sent to stdout
 | `--unique` | flag | (Round-robin mode only) emit only unique bitstrings. |
 | `--sorted-split` | flag | Force sorted-split mode even for single-file or stdout output. |
 | `--round-robin` | flag | Force round-robin mode even when multiple `-o` files are given. Produces overlapping ranges that `diag` will reject at startup. Useful only for testing. |
-| `--workers N` | `int` | Number of parallel worker processes for sorted-split mode (default: `min(cpu_count, 64)`). On DeltaAI GH200 nodes with `--cpus-per-task=72`, `cpu_count` is 72 so the cap applies — effective default is **64 workers**. |
+| `--workers N` | `int` | Number of parallel worker processes for sorted-split mode (default: `min(cpu_count, 64)`). On DeltaAI GH200 nodes, `mp.cpu_count()` returns 288 (4 chips × 72 threads per node, visible regardless of `--cpus-per-task`), so the cap of 64 applies — effective default is **64 workers**. |
 
 ### `--sorted-split` mode
 

--- a/apps/caop_selected_basis_diagonalization/README.md
+++ b/apps/caop_selected_basis_diagonalization/README.md
@@ -150,64 +150,105 @@ python gen_ham.py \
 
 ---
 ## `gen_bits.py`: Bitstring Generator (U(1)-Symmetric)
-This script is a simple and flexible tool for generating bitstrings with fixed Hamming weight, corresponding to a **U(1)-symmetric sector** (fixed particle number).
-It is desgined for preparing test data for selected-basis diagonalization, CI/FCI sampling, and various quantum many-body simulations.
 
-The generator currently supports:
-- Random bitstring generation with fixed number of 1s
-- Optional uniqueness filtering
-- Output to one or multiple files
-- Even (round-robin) distribution of bitstrings across multiple output files
-- Random seed control for reproducibility
-Additional generation methods can be added via the `--method` option.
+This script generates bitstrings with fixed Hamming weight, corresponding to a
+**U(1)-symmetric sector** (fixed particle number), for use as basis states in
+selected-basis diagonalization.
+
+Two output modes are available:
+
+| Mode | Flag | Use case |
+|------|------|----------|
+| **round-robin** (legacy) | *(default)* | Single-file output or testing; files cover overlapping value ranges |
+| **sorted-split** | `--sorted-split` | Multi-rank `diag` runs; produces non-overlapping sorted-range files matching `gdet` output |
+
+> **Important for multi-rank runs**: the `diag` executable checks at startup that
+> basis shard files form globally sorted, non-overlapping ranges (one
+> `MPI_Sendrecv` at the rank boundary).  Round-robin files fail this check and
+> cause an immediate abort with an actionable error message.  Always use
+> `--sorted-split` when generating shards for multi-rank diagonalization.
 
 ### Basic Usage
+
 ```
 python gen_bits.py --bitlength 16 --numones 4 --num 100
 ```
-This generates:
-- Bitstrings of length 16
-- With exactly 4 bits set to 1
-- A total of 100 samples
-- Output sent to stdout
+Generates 100 random bitstrings of length 16 with exactly 4 ones, sent to stdout.
 
-### command-Line Options
-This section describes all available options.
-#### Required Options
-| Option | Argument | Description |
-|--------|----------|-------------|
+### Command-Line Options
+
+#### Required
+
+| Option | Type | Description |
+|--------|------|-------------|
 | `--bitlength L` | `int` | Length of each bitstring (system size). |
-| `--numones N` | `int` | Number of bits set to 1 (particle number in the U(1) sector). |
+| `--numones N` | `int` | Number of bits set to 1 (particle number). |
 
-#### Primary Options
-| Option | Argument | Description |
-|--------|----------|-------------|
+#### Generation control
+
+| Option | Type | Description |
+|--------|------|-------------|
 | `--num M` | `int` | Number of bitstrings to generate (default: 10). |
-| `--method m` | `int` | `0`: Random generation with fixed Hamming weight. |
-| `--unique` | -- | If specified, only unique bitstrings are output. |
-| `--seed R` | `int` | Set random seed to make the output reproducible. |
-| `--outfile files1 [files2 ...]` | `str` | Specify one or more output files. |
+| `--method m` | `int` | `0`: random shuffle of fixed-Hamming-weight base pattern (only method currently supported). |
+| `--seed R` | `int` | Random seed for reproducibility. |
+
+#### Output control
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `-o / --outfile FILE [FILE ...]` | `str` | Output file(s). Without `--sorted-split`, files are filled in round-robin order. |
+| `--unique` | flag | (Round-robin mode only) emit only unique bitstrings. |
+| `--sorted-split` | flag | Write output files as non-overlapping sorted-range slices. Implies uniqueness. See below. |
+| `--workers N` | `int` | Number of parallel worker processes for `--sorted-split` (default: `min(cpu_count, 64)`). On DeltaAI GH200 nodes with `--cpus-per-task=72`, `cpu_count` is 72 so the cap applies — effective default is **64 workers**. |
+
+### `--sorted-split` mode
+
+When `--sorted-split` is given with `-o FILE [FILE ...]`:
+
+1. **N parallel workers** each generate `--num / N` strings, sort and dedup
+   in-process, and write a pre-sorted chunk to a temporary file.
+2. `sort --merge --unique` merges all chunks in linear time (inputs are
+   pre-sorted).
+3. Unique line count is computed; `get_mpi_range`-style boundaries are derived
+   (identical to the formula `diag` uses for target-count computation).
+4. The sorted stream is split into the requested output files so each file holds
+   a contiguous, non-overlapping sorted range — matching the output of `gdet`.
+
+**Performance** (48-site, 100 M strings, 32 workers on a single GH200 node):
+~4.5 min wall time vs ~25–30 min for single-process generation.
 
 ### Usage Examples
-- **Generate 100 bitstrings to stdout**. 
+
+- **Generate 100 bitstrings to stdout**:
   ```
   python gen_bits.py --bitlength 12 --numones 6 --num 100
   ```
-- **Reproducible random generation**. 
+
+- **Reproducible random generation**:
   ```
   python gen_bits.py --bitlength 20 --numones 8 --num 50 --seed 123
   ```
-- **Unique bitstrings only**.  
+
+- **Unique bitstrings only (round-robin, single file)**:
   ```
-  python gen_bits.py --bitlength 20 --numones 10 --num 500 --unique
+  python gen_bits.py --bitlength 20 --numones 10 --num 500 --unique -o basis.txt
   ```
-- **Split output across 2 files**. 
+
+- **Sorted-split into 4 shard files for a 4-rank diag run** (recommended):
   ```
-  python gen_bits.py --bitlength 18 --numones 9 --num 200 \
-          --outfile part1,txt part2.txt
+  python gen_bits.py --bitlength 48 --numones 24 --num 100000000 --seed 42 \
+      --sorted-split --workers 32 \
+      -o basis-00.txt basis-01.txt basis-02.txt basis-03.txt
   ```
+  Each output file covers a non-overlapping sorted range; all four together
+  pass the `diag` global-sort check.
+
 ### Implementation Notes
-- Random samples are generated by shuffling a base bit pattern with fixed Hamming weight.
-- The `--unique` option operates by collecting results in a Python `set`.
-- Output distribution uses a simple round-robin assignment, suitable for HPC batch jobs.
-- The code structure is modular and ready for adding new generation methods.
+
+- Random samples are generated by shuffling a base bit pattern `[1]*numones +
+  [0]*(bitlength-numones)` with a seeded RNG — Hamming weight is preserved
+  exactly.
+- In `--sorted-split` mode, per-worker seeds are derived deterministically from
+  `--seed`, so output is reproducible given fixed `--num` and `--workers`.
+- The `sort --merge` step requires the GNU coreutils `sort` with `--merge`
+  support (standard on Linux).

--- a/apps/caop_selected_basis_diagonalization/README.md
+++ b/apps/caop_selected_basis_diagonalization/README.md
@@ -157,16 +157,16 @@ selected-basis diagonalization.
 
 Two output modes are available:
 
-| Mode | Flag | Use case |
-|------|------|----------|
-| **round-robin** (legacy) | *(default)* | Single-file output or testing; files cover overlapping value ranges |
-| **sorted-split** | `--sorted-split` | Multi-rank `diag` runs; produces non-overlapping sorted-range files matching `gdet` output |
+| Mode | When it applies | Use case |
+|------|-----------------|----------|
+| **sorted-split** | **default** when multiple `-o` files are given | Multi-rank `diag` runs; non-overlapping sorted-range files matching `gdet` output |
+| **round-robin** | default for zero or one `-o` file; `--round-robin` to force | Single-file output or testing; files cover overlapping value ranges |
 
-> **Important for multi-rank runs**: the `diag` executable checks at startup that
-> basis shard files form globally sorted, non-overlapping ranges (one
+> **Why sorted-split is the multi-file default**: the `diag` executable checks at
+> startup that basis shard files form globally sorted, non-overlapping ranges (one
 > `MPI_Sendrecv` at the rank boundary).  Round-robin files fail this check and
-> cause an immediate abort with an actionable error message.  Always use
-> `--sorted-split` when generating shards for multi-rank diagonalization.
+> cause an immediate abort.  Generating multiple output files with round-robin
+> (`--round-robin`) produces shards that diag will refuse to load.
 
 ### Basic Usage
 
@@ -198,8 +198,9 @@ Generates 100 random bitstrings of length 16 with exactly 4 ones, sent to stdout
 |--------|------|-------------|
 | `-o / --outfile FILE [FILE ...]` | `str` | Output file(s). Without `--sorted-split`, files are filled in round-robin order. |
 | `--unique` | flag | (Round-robin mode only) emit only unique bitstrings. |
-| `--sorted-split` | flag | Write output files as non-overlapping sorted-range slices. Implies uniqueness. See below. |
-| `--workers N` | `int` | Number of parallel worker processes for `--sorted-split` (default: `min(cpu_count, 64)`). On DeltaAI GH200 nodes with `--cpus-per-task=72`, `cpu_count` is 72 so the cap applies — effective default is **64 workers**. |
+| `--sorted-split` | flag | Force sorted-split mode even for single-file or stdout output. |
+| `--round-robin` | flag | Force round-robin mode even when multiple `-o` files are given. Produces overlapping ranges that `diag` will reject at startup. Useful only for testing. |
+| `--workers N` | `int` | Number of parallel worker processes for sorted-split mode (default: `min(cpu_count, 64)`). On DeltaAI GH200 nodes with `--cpus-per-task=72`, `cpu_count` is 72 so the cap applies — effective default is **64 workers**. |
 
 ### `--sorted-split` mode
 
@@ -234,14 +235,15 @@ When `--sorted-split` is given with `-o FILE [FILE ...]`:
   python gen_bits.py --bitlength 20 --numones 10 --num 500 --unique -o basis.txt
   ```
 
-- **Sorted-split into 4 shard files for a 4-rank diag run** (recommended):
+- **Split into 4 shard files for a 4-rank diag run** (sorted-split is automatic):
   ```
   python gen_bits.py --bitlength 48 --numones 24 --num 100000000 --seed 42 \
-      --sorted-split --workers 32 \
+      --workers 32 \
       -o basis-00.txt basis-01.txt basis-02.txt basis-03.txt
   ```
-  Each output file covers a non-overlapping sorted range; all four together
-  pass the `diag` global-sort check.
+  Multiple `-o` files → sorted-split by default.  Each file covers a
+  non-overlapping sorted range; all four together pass the `diag` global-sort
+  check.
 
 ### Implementation Notes
 

--- a/apps/caop_selected_basis_diagonalization/gen_bits.py
+++ b/apps/caop_selected_basis_diagonalization/gen_bits.py
@@ -3,22 +3,22 @@
 
 Two output modes:
 
-round-robin (default, legacy):
-    Bitstrings are generated one at a time and written to output files in
-    round-robin order (bitstring i → file i % n_files).  Files cover
-    overlapping value ranges — suitable only for single-file output or when
-    cross-shard duplicates are acceptable.
-
-sorted-split (--sorted-split):
+sorted-split (default when multiple -o files are given):
     Generate all strings in parallel (one process per --workers N workers),
     sort and dedup each chunk in parallel, merge-sort all chunks into a single
     sorted stream, then range-split into output files so each file holds a
     contiguous non-overlapping sorted range — matching gdet's output format.
-    Required when running with the diag global-sort validation check.
+    The diag executable enforces this layout at startup via a global-sort
+    check; round-robin files will cause an immediate abort.
 
-Usage:
+round-robin (--round-robin, or default when zero/one -o files are given):
+    Bitstrings are generated one at a time and written to output files in
+    round-robin order (bitstring i → file i % n_files).  Files cover
+    overlapping value ranges — only useful for single-file output or testing.
+
+Usage (4-shard diag run — sorted-split is automatic with multiple -o files):
     python3 gen_bits.py --bitlength 48 --numones 24 --num 100000000 --seed 42 \\
-        --sorted-split --workers 32 \\
+        --workers 32 \\
         -o basis48-25M-00.txt basis48-25M-01.txt basis48-25M-02.txt basis48-25M-03.txt
 """
 
@@ -250,16 +250,20 @@ def parse_args():
                         help="(Round-robin mode only) output only unique bitstrings.")
     parser.add_argument("--sorted-split", action="store_true",
                         help=(
-                            "Write output files as non-overlapping sorted-range slices "
-                            "(matches gdet output format).  Uses parallel workers.  "
-                            "Overrides --unique (implies uniqueness via dedup)."
+                            "Force sorted-split mode even for single-file or stdout output."
+                        ))
+    parser.add_argument("--round-robin", action="store_true",
+                        help=(
+                            "Force round-robin mode even when multiple -o files are given.  "
+                            "Produces overlapping ranges; diag will reject these files at "
+                            "startup.  Useful only for testing or single-file output."
                         ))
     parser.add_argument("--workers", type=int, default=None,
-                        help="Number of parallel workers for --sorted-split "
+                        help="Number of parallel workers for sorted-split mode "
                              "(default: min(cpu_count, 64)).")
     parser.add_argument("-o", "--outfile", nargs="+",
-                        help="Output file(s).  Multiple files: round-robin (default) "
-                             "or sorted-range (--sorted-split).")
+                        help="Output file(s).  Multiple files: sorted-split by default "
+                             "(use --round-robin to override).")
     return parser.parse_args()
 
 
@@ -277,9 +281,21 @@ def main():
         print("Error: --num must be positive.", file=sys.stderr)
         sys.exit(1)
 
+    if args.sorted_split and args.round_robin:
+        print("Error: --sorted-split and --round-robin are mutually exclusive.",
+              file=sys.stderr)
+        sys.exit(1)
+
     rng = random.Random(args.seed)
 
-    if args.sorted_split:
+    # Default: sorted-split when multiple output files are given (required by
+    # diag's global-sort check); round-robin otherwise.
+    use_sorted_split = (
+        args.sorted_split
+        or (not args.round_robin and len(args.outfile or []) > 1)
+    )
+
+    if use_sorted_split:
         write_sorted_split_parallel(
             args.bitlength, args.numones, args.num,
             args.seed, args.outfile or [],

--- a/apps/caop_selected_basis_diagonalization/gen_bits.py
+++ b/apps/caop_selected_basis_diagonalization/gen_bits.py
@@ -1,84 +1,267 @@
 #!/usr/bin/env python3
-import argparse
-import random
-import sys
+"""Generate fixed-Hamming-weight bitstrings under U(1) symmetry.
 
-def method_0_random(bit_length: int, num_ones: int, num_bitstrings: int, rng: random.Random):
+Two output modes:
+
+round-robin (default, legacy):
+    Bitstrings are generated one at a time and written to output files in
+    round-robin order (bitstring i → file i % n_files).  Files cover
+    overlapping value ranges — suitable only for single-file output or when
+    cross-shard duplicates are acceptable.
+
+sorted-split (--sorted-split):
+    Generate all strings in parallel (one process per --workers N workers),
+    sort and dedup each chunk in parallel, merge-sort all chunks into a single
+    sorted stream, then range-split into output files so each file holds a
+    contiguous non-overlapping sorted range — matching gdet's output format.
+    Required when running with the diag global-sort validation check.
+
+Usage:
+    python3 gen_bits.py --bitlength 48 --numones 24 --num 100000000 --seed 42 \\
+        --sorted-split --workers 32 \\
+        -o basis48-25M-00.txt basis48-25M-01.txt basis48-25M-02.txt basis48-25M-03.txt
+"""
+
+import argparse
+import multiprocessing as mp
+import os
+import random
+import subprocess
+import sys
+import tempfile
+
+
+# ---------------------------------------------------------------------------
+# Worker (module-level so multiprocessing can pickle it)
+# ---------------------------------------------------------------------------
+
+def _worker_generate_sorted(args):
+    """Generate ``count`` random bitstrings, sort+dedup in-process, write to
+    ``out_path``.  Returns ``out_path`` on success.
+
+    Each worker uses its own seeded RNG so output is deterministic and
+    workers are fully independent (no shared state, no locking).
+    The in-worker sort means the main process only needs ``sort --merge``
+    (linear-time merge of pre-sorted runs) rather than a full re-sort.
     """
-    Method 0:
-    Random generation of bitstrings with fixed Hamming weight (U(1) symmetry).
-    """
+    worker_id, bit_length, num_ones, count, seed, out_path = args
+    rng = random.Random(seed)
+    base_bits = [1] * num_ones + [0] * (bit_length - num_ones)
+
+    # Generate directly into a list, then sort+dedup in Python (faster than
+    # writing to a temp file and shelling out for small per-worker counts).
+    strings = []
+    for _ in range(count):
+        rng.shuffle(base_bits)
+        strings.append("".join(str(b) for b in base_bits))
+
+    strings.sort()
+
+    # Dedup (strings is sorted so duplicates are adjacent)
+    with open(out_path, "w") as f:
+        prev = None
+        for s in strings:
+            if s != prev:
+                f.write(s + "\n")
+                prev = s
+
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Generation helpers
+# ---------------------------------------------------------------------------
+
+def method_0_random(bit_length: int, num_ones: int, num_bitstrings: int,
+                    rng: random.Random):
+    """Method 0: random Hamming-weight-preserving shuffle, one string at a time."""
     base_bits = [1] * num_ones + [0] * (bit_length - num_ones)
     for _ in range(num_bitstrings):
         rng.shuffle(base_bits)
         yield "".join(str(b) for b in base_bits)
 
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Generate bitstrings under U(1) symmetry with optional uniqueness."
-    )
 
-    parser.add_argument(
-        "--bitlength", type=int, required=True,
-        help="Total bitstring length (system size)."
-    )
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
 
-    parser.add_argument(
-        "--numones", type=int, required=True,
-        help="Number of 1-bits (particle number)."
-    )
+def _mpi_range(n_files: int, rank: int, total: int):
+    """(i_begin, i_end) for shard ``rank`` — identical to SBD's get_mpi_range."""
+    base  = total // n_files
+    extra = total % n_files
+    i_begin = rank * base + min(rank, extra)
+    i_end   = i_begin + base + (1 if rank < extra else 0)
+    return i_begin, i_end
 
-    parser.add_argument(
-        "--num", type=int, default=10,
-        help="How many bitstrings to generate (default: 10)."
-    )
 
-    parser.add_argument(
-        "--method", type=int, default=0,
-        help="Generation method. Currently only 0 (random)."
-    )
-
-    parser.add_argument(
-        "--seed", type=int, default=None,
-        help="Random seed (optional)."
-    )
-
-    parser.add_argument(
-        "--unique", action="store_true",
-        help="If specified, output only unique bitstrings."
-    )
-
-    parser.add_argument(
-        "-o", "--outfile", nargs="+",
-        help=(
-            "Output file name(s). "
-            "If multiple files are given, lines are distributed roughly evenly. "
-            "If omitted, write to stdout."
-        )
-    )
-
-    return parser.parse_args()
-
-def write_outputs(bitstrings, outfiles):
-    """
-    Write bitstrings either to stdout (if outfiles is None)
-    or distribute them across multiple files in round-robin fashion.
-    """
+def write_roundrobin(bitstrings, outfiles):
+    """Write bitstrings to ``outfiles`` in round-robin order (legacy mode)."""
     if not outfiles:
-        # No output file specified: write to stdout
         for bs in bitstrings:
             print(bs)
         return
 
     n_files = len(outfiles)
-    files = [open(name, "w") for name in outfiles]
+    handles = [open(name, "w") for name in outfiles]
     try:
         for idx, bs in enumerate(bitstrings):
-            f = files[idx % n_files]
-            f.write(bs + "\n")
+            handles[idx % n_files].write(bs + "\n")
     finally:
-        for f in files:
+        for f in handles:
             f.close()
+
+
+def write_sorted_split_parallel(bit_length: int, num_ones: int, total_n: int,
+                                seed, outfiles: list, n_workers: int = None):
+    """Generate, sort, and range-split into non-overlapping shard files.
+
+    Pipeline:
+      1. N workers each generate (total_n / N) strings, sort+dedup in-process,
+         write sorted chunks to temp files — all in parallel.
+      2. ``sort --merge --unique`` merges the pre-sorted chunks (linear time).
+      3. Count unique lines; compute get_mpi_range boundaries.
+      4. Stream through sorted file, write each line to its shard by index.
+
+    Wall time is dominated by the parallel generation step (~total_n / N / shuffle_rate).
+    """
+    if not outfiles:
+        # No output files: fall back to printing sorted unique strings.
+        master_rng = random.Random(seed)
+        strings = list(method_0_random(bit_length, num_ones, total_n, master_rng))
+        strings.sort()
+        prev = None
+        for s in strings:
+            if s != prev:
+                print(s)
+                prev = s
+        return
+
+    if n_workers is None:
+        n_workers = min(mp.cpu_count(), 64)
+
+    n_files   = len(outfiles)
+    dirpath   = os.path.dirname(os.path.abspath(outfiles[0]))
+
+    # Derive deterministic per-worker seeds from the main seed.
+    master_rng   = random.Random(seed)
+    worker_seeds = [master_rng.randint(0, 2**32 - 1) for _ in range(n_workers)]
+
+    # Distribute total_n across workers (each gets base or base+1 items).
+    base_count = total_n // n_workers
+    extra      = total_n % n_workers
+    counts     = [base_count + (1 if i < extra else 0) for i in range(n_workers)]
+
+    # Temp paths for per-worker sorted chunks.
+    tmp_chunks = [
+        tempfile.mktemp(dir=dirpath, suffix=f".w{i:03d}.chunk_tmp")
+        for i in range(n_workers)
+    ]
+
+    print(f"  [gen_bits] {n_workers} workers × ~{base_count:,} strings each "
+          f"(total {total_n:,}) ...", file=sys.stderr, flush=True)
+
+    # ---- Step 1: parallel generate + sort ----------------------------------
+    worker_args = [
+        (i, bit_length, num_ones, counts[i], worker_seeds[i], tmp_chunks[i])
+        for i in range(n_workers)
+    ]
+    try:
+        with mp.Pool(n_workers) as pool:
+            pool.map(_worker_generate_sorted, worker_args)
+
+        # ---- Step 2: merge pre-sorted chunks --------------------------------
+        tmp_merged = tempfile.mktemp(dir=dirpath, suffix=".merged.gen_tmp")
+        try:
+            print(f"  [gen_bits] sort --merge --unique ({n_workers} chunks) ...",
+                  file=sys.stderr, flush=True)
+            subprocess.run(
+                ["sort", "--merge", "--unique", "-o", tmp_merged] + tmp_chunks,
+                check=True,
+            )
+            for p in tmp_chunks:
+                if os.path.exists(p):
+                    os.unlink(p)
+
+            # ---- Step 3: count unique lines --------------------------------
+            result = subprocess.run(
+                ["wc", "-l", tmp_merged],
+                check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+            unique_total = int(result.stdout.split()[0])
+            print(f"  [gen_bits] {unique_total:,} unique strings after dedup",
+                  file=sys.stderr, flush=True)
+
+            # Precompute range boundaries
+            boundaries = [_mpi_range(n_files, r, unique_total)[0]
+                          for r in range(n_files)] + [unique_total]
+
+            # ---- Step 4: stream-split to output files ----------------------
+            handles = [open(fn, "w") for fn in outfiles]
+            try:
+                cur = 0
+                with open(tmp_merged) as sf:
+                    for i, line in enumerate(sf):
+                        while cur + 1 < n_files and i >= boundaries[cur + 1]:
+                            cur += 1
+                        handles[cur].write(line)
+            finally:
+                for fh in handles:
+                    fh.close()
+
+            for r, fn in enumerate(outfiles):
+                count = boundaries[r + 1] - boundaries[r]
+                print(f"  [gen_bits] {fn}: {count:,} records",
+                      file=sys.stderr, flush=True)
+
+        finally:
+            if os.path.exists(tmp_merged):
+                os.unlink(tmp_merged)
+
+    finally:
+        # Best-effort cleanup of any leftover chunk files.
+        for p in tmp_chunks:
+            if os.path.exists(p):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing and main
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--bitlength", type=int, required=True,
+                        help="Total bitstring length (system size).")
+    parser.add_argument("--numones", type=int, required=True,
+                        help="Number of 1-bits (particle number).")
+    parser.add_argument("--num", type=int, default=10,
+                        help="How many bitstrings to generate (default: 10).")
+    parser.add_argument("--method", type=int, default=0,
+                        help="Generation method.  Currently only 0 (random).")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="Random seed (optional).")
+    parser.add_argument("--unique", action="store_true",
+                        help="(Round-robin mode only) output only unique bitstrings.")
+    parser.add_argument("--sorted-split", action="store_true",
+                        help=(
+                            "Write output files as non-overlapping sorted-range slices "
+                            "(matches gdet output format).  Uses parallel workers.  "
+                            "Overrides --unique (implies uniqueness via dedup)."
+                        ))
+    parser.add_argument("--workers", type=int, default=None,
+                        help="Number of parallel workers for --sorted-split "
+                             "(default: min(cpu_count, 64)).")
+    parser.add_argument("-o", "--outfile", nargs="+",
+                        help="Output file(s).  Multiple files: round-robin (default) "
+                             "or sorted-range (--sorted-split).")
+    return parser.parse_args()
+
 
 def main():
     args = parse_args()
@@ -86,35 +269,30 @@ def main():
     if args.bitlength <= 0:
         print("Error: --bitlength must be positive.", file=sys.stderr)
         sys.exit(1)
-
     if not (0 <= args.numones <= args.bitlength):
-        print("Error: --numones must satisfy 0 <= numones <= bitlength.", file=sys.stderr)
+        print("Error: --numones must satisfy 0 <= numones <= bitlength.",
+              file=sys.stderr)
         sys.exit(1)
-
     if args.num <= 0:
         print("Error: --num must be positive.", file=sys.stderr)
         sys.exit(1)
 
     rng = random.Random(args.seed)
 
-    # Select method
-    if args.method == 0:
+    if args.sorted_split:
+        write_sorted_split_parallel(
+            args.bitlength, args.numones, args.num,
+            args.seed, args.outfile or [],
+            n_workers=args.workers,
+        )
+    elif args.unique:
+        strings = sorted(set(method_0_random(args.bitlength, args.numones,
+                                             args.num, rng)))
+        write_roundrobin(iter(strings), args.outfile)
+    else:
         generator = method_0_random(args.bitlength, args.numones, args.num, rng)
-    else:
-        print(f"Error: Unknown method {args.method}.", file=sys.stderr)
-        sys.exit(1)
+        write_roundrobin(generator, args.outfile)
 
-    if args.unique:
-        # Collect unique bitstrings
-        seen = set()
-        for bs in generator:
-            seen.add(bs)
-        # Sort for reproducibility (optional; remove sorted() if不要なら)
-        outputs = sorted(seen)
-    else:
-        outputs = generator
-
-    write_outputs(outputs, args.outfile)
 
 if __name__ == "__main__":
     main()

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -8,6 +8,8 @@
 #include <sys/stat.h>
 #include <iomanip>
 
+#include <omp.h>
+
 #include "sbd/framework/type_def.h"
 #include "sbd/framework/mpi_utility.h"
 #include "sbd/framework/bit_manipulation.h"
@@ -327,16 +329,25 @@ namespace sbd {
       my_first = rem * (base + 1) + (mpi_rank - rem) * base;
     }
     const int my_last = my_first + my_count;
-    
-    for (int i = my_first; i < my_last; ++i) {
-      const std::string & fname = all_filenames[i];
-      
-      Container local;
-      load_basis_from_file(fname, local, bit_length, total_bit_length);
-      
+    (void)my_last;  // kept for readability; loop now uses my_count directly
+
+    // Load each assigned file in parallel: one OMP thread per file.
+    // Threads write to private per_file[i] containers — no shared mutable state.
+    std::vector<Container> per_file(my_count);
+    {
+      const int nthreads = std::min(my_count, omp_get_max_threads());
+      #pragma omp parallel for schedule(static) num_threads(nthreads)
+      for (int i = 0; i < my_count; ++i) {
+        load_basis_from_file(all_filenames[my_first + i], per_file[i],
+                             bit_length, total_bit_length);
+      }
+    }
+
+    // Merge per-file results into config in file order (sequential).
+    for (int i = 0; i < my_count; ++i) {
       config.insert(config.end(),
-		    std::make_move_iterator(local.begin()),
-		    std::make_move_iterator(local.end()));
+		    std::make_move_iterator(per_file[i].begin()),
+		    std::make_move_iterator(per_file[i].end()));
     }
     sort_bitarray(config);
   }

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -534,6 +534,64 @@ namespace sbd {
         t_done - t0);
       fflush(stderr);
 
+      // ---- Global sorted-and-no-cross-shard-dup check -------------------------
+      // Send this rank's last element to rank+1; rank+1 verifies its first
+      // element is strictly greater.  Cost: one MPI_Sendrecv of row_len*8 bytes.
+      // Catches overlapping shard ranges (e.g. round-robin gen_bits.py output)
+      // that are individually sorted but collectively non-monotone across ranks.
+      if (mpi_size > 1) {
+        const size_t row_len = (config.empty() ? 0 : config.elem_size());
+        size_t max_row_len = 0;
+        MPI_Allreduce(&row_len, &max_row_len, 1, SBD_MPI_SIZE_T, MPI_MAX, comm);
+
+        if (max_row_len > 0) {
+          // Send last element (or all-zeros sentinel if this rank is empty).
+          std::vector<size_t> send_buf(max_row_len, 0);
+          if (!config.empty()) {
+            const auto& last = config[config.size() - 1];
+            std::memcpy(send_buf.data(), last.data(), max_row_len * sizeof(size_t));
+          }
+          std::vector<size_t> recv_buf(max_row_len, 0);
+
+          const int send_to   = (mpi_rank + 1) % mpi_size;
+          const int recv_from = (mpi_rank - 1 + mpi_size) % mpi_size;
+          MPI_Sendrecv(send_buf.data(), static_cast<int>(max_row_len), SBD_MPI_SIZE_T,
+                       send_to,   98,
+                       recv_buf.data(), static_cast<int>(max_row_len), SBD_MPI_SIZE_T,
+                       recv_from, 98, comm, MPI_STATUS_IGNORE);
+
+          // Rank 0's recv_buf is rank (mpi_size-1)'s last element — wrap-around,
+          // not a continuity constraint.  Only check ranks 1..mpi_size-1.
+          bool local_ok = true;
+          if (mpi_rank > 0 && !config.empty()) {
+            const auto& my_first = config[0];
+            bool is_dup = (std::memcmp(my_first.data(), recv_buf.data(),
+                                       max_row_len * sizeof(size_t)) == 0);
+            bool out_of_order = less_from_back(my_first, recv_buf);
+            local_ok = !is_dup && !out_of_order;
+          }
+
+          int local_ok_i = static_cast<int>(local_ok);
+          int all_ok = 0;
+          MPI_Allreduce(&local_ok_i, &all_ok, 1, MPI_INT, MPI_LAND, comm);
+
+          if (!all_ok) {
+            if (mpi_rank == 0) {
+              fprintf(stderr,
+                "sbd: ERROR: basis shards are not globally sorted or contain\n"
+                "  cross-shard duplicate records.  Each shard must cover a\n"
+                "  non-overlapping sorted range (as produced by gdet).\n"
+                "  Fix: regenerate shards with:\n"
+                "    python3 sbd/apps/caop_selected_basis_diagonalization/gen_bits.py"
+                " --sorted-split ...\n"
+                "  or run gdet on the alpha-det file.\n");
+              fflush(stderr);
+            }
+            MPI_Abort(comm, 1);
+          }
+        }
+      }
+
     } else {
       // Fallback for other Container types (e.g. std::vector<std::vector<size_t>>):
       // original sequential load + sort_bitarray.

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -7,6 +7,7 @@
 
 #include <sys/stat.h>
 #include <iomanip>
+#include <atomic>
 
 #include <omp.h>
 
@@ -225,21 +226,31 @@ namespace sbd {
       if( !ifs )
 	throw std::runtime_error("Failed to read basis bit-string file.");
 
+      // Pre-allocate all inner vectors before the parallel region so that
+      // each thread's resize()+fill() operates on already-constructed objects.
+      // This avoids false sharing on the outer vector's metadata while still
+      // allowing each thread to do its own small heap allocations with minimal
+      // allocator contention (modern allocators use per-thread arenas).
       config.resize(num_records);
+
+      std::atomic<bool> parse_error{false};
+      #pragma omp parallel for schedule(static)
       for(size_t i = 0; i < num_records; i++) {
-	const char* rec = buf.data() + i * record_size;
-	config[i].resize(num_words);
-	std::fill(config[i].begin(), config[i].end(), size_t(0));
-	for(size_t j = 0; j < total_bit_length; j++) {
-	  if( rec[j] == '1' ) {
-	    size_t bit_idx = total_bit_length - 1 - j;
-	    config[i][bit_idx / bit_length] |= (size_t(1) << (bit_idx % bit_length));
-	  } else if( rec[j] != '0' ) {
-	    throw std::runtime_error(
-	      "Unexpected character in basis file: expected '0' or '1'");
-	  }
-	}
+        config[i].resize(num_words);
+        std::fill(config[i].begin(), config[i].end(), size_t(0));
+        const char* rec = buf.data() + i * record_size;
+        for(size_t j = 0; j < total_bit_length; j++) {
+          if( rec[j] == '1' ) {
+            size_t bit_idx = total_bit_length - 1 - j;
+            config[i][bit_idx / bit_length] |= (size_t(1) << (bit_idx % bit_length));
+          } else if( rec[j] != '0' ) {
+            parse_error.store(true, std::memory_order_relaxed);
+          }
+        }
       }
+      if( parse_error.load() )
+        throw std::runtime_error(
+          "Unexpected character in basis file: expected '0' or '1'");
     } else if ( get_extension(filename) == std::string("bin") ) {
       std::ifstream ifs(filename, std::ios::binary);
       if( !ifs.is_open() ) {
@@ -329,25 +340,17 @@ namespace sbd {
       my_first = rem * (base + 1) + (mpi_rank - rem) * base;
     }
     const int my_last = my_first + my_count;
-    (void)my_last;  // kept for readability; loop now uses my_count directly
+    (void)my_last;  // kept for readability
 
-    // Load each assigned file in parallel: one OMP thread per file.
-    // Threads write to private per_file[i] containers — no shared mutable state.
-    std::vector<Container> per_file(my_count);
-    {
-      const int nthreads = std::min(my_count, omp_get_max_threads());
-      #pragma omp parallel for schedule(static) num_threads(nthreads)
-      for (int i = 0; i < my_count; ++i) {
-        load_basis_from_file(all_filenames[my_first + i], per_file[i],
-                             bit_length, total_bit_length);
-      }
-    }
-
-    // Merge per-file results into config in file order (sequential).
-    for (int i = 0; i < my_count; ++i) {
+    // Load files sequentially so concurrent reads don't contend on shared
+    // filesystem bandwidth; parallelism is in the per-record parse (see
+    // load_basis_from_file).
+    for (int i = my_first; i < my_first + my_count; ++i) {
+      Container local;
+      load_basis_from_file(all_filenames[i], local, bit_length, total_bit_length);
       config.insert(config.end(),
-		    std::make_move_iterator(per_file[i].begin()),
-		    std::make_move_iterator(per_file[i].end()));
+		    std::make_move_iterator(local.begin()),
+		    std::make_move_iterator(local.end()));
     }
     sort_bitarray(config);
   }

--- a/include/sbd/caop/basic/basis.h
+++ b/include/sbd/caop/basic/basis.h
@@ -8,6 +8,8 @@
 #include <sys/stat.h>
 #include <iomanip>
 #include <atomic>
+#include <cstdio>
+#include <type_traits>
 
 #include <omp.h>
 
@@ -23,13 +25,49 @@ namespace sbd {
 		      size_t total_bit_length,
 		      MPI_Comm comm) {
     int mpi_size; MPI_Comm_size(comm,&mpi_size);
+    int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
+
+    // Fast-path: if every rank already holds its target count of records AND
+    // its slice is locally sorted, the shuffle and re-sort inside
+    // mpi_redistribution are both no-ops.  Skip them.
+    //
+    // This fires at r=1 (trivially: mpi_size==1), and also at r>1 when
+    // load_basis_from_files has already k-way-merged the files into sorted
+    // per-rank slices of equal size (the common case with equal-size shards).
+    //
+    // Cost of the check: one MPI_Allreduce (size_t) + one MPI_Allreduce (int)
+    // + an O(n/r) sequential sorted scan — negligible vs the sort it avoids.
+    {
+      size_t local_n = static_cast<size_t>(config.size());
+      size_t total_n = 0;
+      MPI_Allreduce(&local_n, &total_n, 1, SBD_MPI_SIZE_T, MPI_SUM, comm);
+
+      // Compute the target [want_begin, want_end) range for this rank using the
+      // same formula that mpi_redistribution uses internally (get_mpi_range).
+      size_t want_begin = 0, want_end = total_n;
+      get_mpi_range(mpi_size, mpi_rank, want_begin, want_end);
+      size_t want_n = want_end - want_begin;
+
+      // Local checks: correct count AND locally sorted.
+      bool local_ok = (local_n == want_n);
+      if (local_ok && local_n > 1) {
+        for (size_t i = 1; i < local_n && local_ok; ++i)
+          if (less_from_back(config[i], config[i-1])) local_ok = false;
+      }
+
+      int local_ok_i = static_cast<int>(local_ok);
+      int all_ok = 0;
+      MPI_Allreduce(&local_ok_i, &all_ok, 1, MPI_INT, MPI_LAND, comm);
+      if (all_ok) return;
+    }
+
     Container config_begin(mpi_size);
     Container config_end(mpi_size);
     std::vector<size_t> index_begin(mpi_size);
     std::vector<size_t> index_end(mpi_size);
     mpi_redistribution(config,config_begin,config_end,index_begin,index_end,
 		       total_bit_length,bit_length,comm);
-    
+
   }
   
 
@@ -209,9 +247,14 @@ namespace sbd {
     if( get_extension(filename) == std::string("txt") ) {
       // Fast path: text is regular fixed-width records (total_bit_length chars of
       // '0'/'1' + '\n').  Read the whole file in one shot and parse in-place.
+      int rank = 0; MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+      // --- open ---
+      double t0 = omp_get_wtime();
       std::ifstream ifs(filename, std::ios::binary);
       if( !ifs.is_open() )
 	throw std::runtime_error("Failed to open basis bit-string file.");
+      double t_open = omp_get_wtime();
 
       ifs.seekg(0, std::ios::end);
       const size_t file_size = ifs.tellg();
@@ -221,18 +264,21 @@ namespace sbd {
       const size_t num_records = (file_size + 1) / record_size;
       const size_t num_words   = (total_bit_length + bit_length - 1) / bit_length;
 
+      // --- alloc read buffer (zero-init touches all pages) ---
       std::vector<char> buf(file_size);
+      double t_alloc = omp_get_wtime();
+
+      // --- read ---
       ifs.read(buf.data(), file_size);
       if( !ifs )
 	throw std::runtime_error("Failed to read basis bit-string file.");
+      double t_read = omp_get_wtime();
 
-      // Pre-allocate all inner vectors before the parallel region so that
-      // each thread's resize()+fill() operates on already-constructed objects.
-      // This avoids false sharing on the outer vector's metadata while still
-      // allowing each thread to do its own small heap allocations with minimal
-      // allocator contention (modern allocators use per-thread arenas).
+      // --- alloc output container (single flat allocation of num_records * num_words * 8B) ---
       config.resize(num_records);
+      double t_resize = omp_get_wtime();
 
+      // --- parse: each thread processes its own row range in the flat buffer ---
       std::atomic<bool> parse_error{false};
       #pragma omp parallel for schedule(static)
       for(size_t i = 0; i < num_records; i++) {
@@ -251,6 +297,23 @@ namespace sbd {
       if( parse_error.load() )
         throw std::runtime_error(
           "Unexpected character in basis file: expected '0' or '1'");
+      double t_parse = omp_get_wtime();
+
+      // Report per-rank, per-file breakdown to stderr.
+      const double read_dt = t_read - t_alloc;
+      const double read_bw = (read_dt > 1e-6) ? file_size / read_dt / 1e6 : 0.0;
+      fprintf(stderr,
+        "basis-timing rank=%d file=%s size=%.0fMB "
+        "open=%.3fs buf_alloc=%.3fs read=%.3fs(%.0fMB/s) "
+        "cfg_alloc=%.3fs parse=%.3fs total=%.3fs\n",
+        rank, filename.c_str(), file_size / 1.0e6,
+        t_open   - t0,
+        t_alloc  - t_open,
+        read_dt, read_bw,
+        t_resize - t_read,
+        t_parse  - t_resize,
+        t_parse  - t0);
+      fflush(stderr);
     } else if ( get_extension(filename) == std::string("bin") ) {
       std::ifstream ifs(filename, std::ios::binary);
       if( !ifs.is_open() ) {
@@ -313,6 +376,83 @@ namespace sbd {
     return filename;
   }
 
+  // ---- Helper: is_sorted_fromback -----------------------------------------
+  // O(n) check: is container a sorted in less_from_back order?
+  // Works for det_vector<size_t> (rows have size() and operator[]).
+  template<typename Container>
+  bool is_sorted_fromback(const Container& a) {
+    const size_t n = a.size();
+    if (n <= 1) return true;
+    for (size_t i = 1; i < n; ++i) {
+      if (less_from_back(a[i], a[i-1]))  // a[i] < a[i-1] → out of order
+        return false;
+    }
+    return true;
+  }
+
+  // ---- Helper: kway_merge_detvec -------------------------------------------
+  // K-way merge of k already-sorted det_vector<size_t> sources into dest.
+  // Uses a min-heap over (row-pointer, source-index, row-index).
+  // Deduplicates identical rows (consistent with sort_bitarray semantics).
+  // Precondition: every sources[i] is sorted in less_from_back order.
+  template<det_kind Kind>
+  void kway_merge_detvec(std::vector<det_vector<size_t, Kind>>& sources,
+                         det_vector<size_t, Kind>& dest) {
+    const int k = static_cast<int>(sources.size());
+    if (k == 0) { dest.clear(); return; }
+    if (k == 1) { dest = std::move(sources[0]); return; }
+
+    size_t total = 0;
+    for (auto& s : sources) total += s.size();
+    dest.resize(total);  // over-allocate; trimmed to unique_n at end
+
+    const size_t row_len = sources[0].elem_size();
+
+    struct Entry { size_t* ptr; int src; size_t idx; };
+    // STL heap is a max-heap; comparator inverted so smallest row is at top.
+    const auto heap_cmp = [row_len](const Entry& a, const Entry& b) noexcept {
+      for (int w = static_cast<int>(row_len) - 1; w >= 0; --w) {
+        if (b.ptr[w] < a.ptr[w]) return true;   // b < a → a should not be at top
+        if (b.ptr[w] > a.ptr[w]) return false;
+      }
+      return false;
+    };
+
+    std::vector<Entry> heap;
+    heap.reserve(k);
+    for (int i = 0; i < k; ++i)
+      if (!sources[i].empty())
+        heap.push_back({sources[i][0].data(), i, 0});
+    std::make_heap(heap.begin(), heap.end(), heap_cmp);
+
+    size_t out = 0;
+    while (!heap.empty()) {
+      std::pop_heap(heap.begin(), heap.end(), heap_cmp);
+      Entry e = heap.back(); heap.pop_back();
+
+      // Dedup: skip if equal to last written row.
+      if (out == 0 || std::memcmp(dest[out-1].data(), e.ptr,
+                                   row_len * sizeof(size_t)) != 0) {
+        std::memcpy(dest[out].data(), e.ptr, row_len * sizeof(size_t));
+        ++out;
+      }
+
+      if (e.idx + 1 < sources[e.src].size()) {
+        e.idx++;
+        e.ptr = sources[e.src][e.idx].data();
+        heap.push_back(e);
+        std::push_heap(heap.begin(), heap.end(), heap_cmp);
+      }
+    }
+    dest.resize(out);  // trim to unique count
+  }
+
+  // ---- load_basis_from_files -----------------------------------------------
+  // Loads the rank's assigned shard files sequentially, checks each is sorted
+  // (aborts with an error if not — sort files in advance with
+  // scripts/sort-basis-shards.py), then k-way merges the sorted runs.
+  // The sort_bitarray() call that previously dominated (~28 s at r=1 for 100M
+  // records) is eliminated: the merge is O(n log k) with k = files-per-rank.
   template<typename Container>
   void load_basis_from_files(const std::vector<std::string> & all_filenames,
 			     Container & config,
@@ -321,17 +461,14 @@ namespace sbd {
 			     MPI_Comm comm) {
     int mpi_rank; MPI_Comm_rank(comm, &mpi_rank);
     int mpi_size; MPI_Comm_size(comm, &mpi_size);
-    
+
     const int num_files = static_cast<int>(all_filenames.size());
     config.clear();
-    
     if (num_files == 0) return;
-    
+
     const int base = num_files / mpi_size;
     const int rem  = num_files % mpi_size;
-
-    int my_first = 0;
-    int my_count = 0;
+    int my_first = 0, my_count = 0;
     if (mpi_rank < rem) {
       my_count = base + 1;
       my_first = mpi_rank * my_count;
@@ -339,20 +476,76 @@ namespace sbd {
       my_count = base;
       my_first = rem * (base + 1) + (mpi_rank - rem) * base;
     }
-    const int my_last = my_first + my_count;
-    (void)my_last;  // kept for readability
 
-    // Load files sequentially so concurrent reads don't contend on shared
-    // filesystem bandwidth; parallelism is in the per-record parse (see
-    // load_basis_from_file).
-    for (int i = my_first; i < my_first + my_count; ++i) {
-      Container local;
-      load_basis_from_file(all_filenames[i], local, bit_length, total_bit_length);
-      config.insert(config.end(),
-		    std::make_move_iterator(local.begin()),
-		    std::make_move_iterator(local.end()));
+    if constexpr (std::is_same_v<Container, det_vector<size_t>>) {
+      // Fast path for det_vector<size_t>: check-sorted + k-way merge.
+      double t0 = omp_get_wtime();
+
+      // Load files sequentially (concurrent reads contend on shared FS).
+      std::vector<Container> per_file(my_count);
+      for (int i = 0; i < my_count; ++i)
+        load_basis_from_file(all_filenames[my_first + i], per_file[i],
+                             bit_length, total_bit_length);
+      double t_load = omp_get_wtime();
+
+      // Require each file to be sorted; abort otherwise.
+      // Sort files once in advance with: python3 scripts/sort-basis-shards.py FILE...
+      for (int i = 0; i < my_count; ++i) {
+        if (!is_sorted_fromback(per_file[i])) {
+          fprintf(stderr,
+            "load_basis_from_files rank=%d: ERROR file not sorted: %s\n"
+            "  Sort shard files in advance with:\n"
+            "    python3 scripts/sort-basis-shards.py FILE...\n",
+            mpi_rank, all_filenames[my_first + i].c_str());
+          fflush(stderr);
+          MPI_Abort(comm, 1);
+        }
+      }
+      double t_check = omp_get_wtime();
+
+      // K-way merge of sorted runs, or plain concatenation if globally ordered.
+      bool globally_ordered = (my_count <= 1);
+      if (!globally_ordered) {
+        globally_ordered = true;
+        for (int i = 0; i + 1 < my_count && globally_ordered; ++i) {
+          if (!per_file[i].empty() && !per_file[i+1].empty()) {
+            // last of per_file[i] must be <= first of per_file[i+1]
+            if (less_from_back(per_file[i+1][0],
+                               per_file[i][per_file[i].size()-1]))
+              globally_ordered = false;
+          }
+        }
+      }
+
+      if (globally_ordered) {
+        for (int i = 0; i < my_count; ++i)
+          config.insert(config.end(), per_file[i].begin(), per_file[i].end());
+      } else {
+        kway_merge_detvec(per_file, config);
+      }
+      double t_done = omp_get_wtime();
+
+      fprintf(stderr,
+        "load-files rank=%d files=%d: load=%.3fs check=%.3fs "
+        "merge=%.3fs(globally_ordered=%d) total=%.3fs\n",
+        mpi_rank, my_count,
+        t_load - t0, t_check - t_load,
+        t_done - t_check, (int)globally_ordered,
+        t_done - t0);
+      fflush(stderr);
+
+    } else {
+      // Fallback for other Container types (e.g. std::vector<std::vector<size_t>>):
+      // original sequential load + sort_bitarray.
+      for (int i = my_first; i < my_first + my_count; ++i) {
+        Container local;
+        load_basis_from_file(all_filenames[i], local, bit_length, total_bit_length);
+        config.insert(config.end(),
+                      std::make_move_iterator(local.begin()),
+                      std::make_move_iterator(local.end()));
+      }
+      sort_bitarray(config);
     }
-    sort_bitarray(config);
   }
   
   // load single file

--- a/include/sbd/caop/basic/mkham.h
+++ b/include/sbd/caop/basic/mkham.h
@@ -98,11 +98,21 @@ namespace sbd {
 
 #pragma omp parallel
       {
-	// round-robin assignment of work to threads
-	size_t thread_id = omp_get_thread_num();
-	size_t ib_start = thread_id;
-	size_t ib_end   = brasize;
-	size_t reserve_size = brasize * num_terms / num_thread;
+	// Round-robin assignment of work to threads.
+	// When num_thread > 1, thread 0 is reserved for MPI overlap in mult()
+	// and receives no COO rows.  Threads 1..N-1 cover all brasize rows using
+	// a stride of num_compute = num_thread - 1.
+	// When num_thread == 1, thread 0 covers all rows (unchanged behaviour).
+	size_t thread_id  = omp_get_thread_num();
+	size_t ib_end     = brasize;
+	size_t num_compute = (num_thread > 1) ? (num_thread - 1) : size_t(1);
+	// ib_start: thread 0 gets ib_end (empty loop) when multi-threaded;
+	//           thread k>0 starts at k-1 so threads cover {0, 1, ..., N-2, N-1, ...}
+	size_t ib_start   = (num_thread > 1)
+	                      ? (thread_id > 0 ? thread_id - 1 : ib_end)
+	                      : size_t(0);
+	size_t reserve_size = (thread_id == 0 && num_thread > 1)
+	                      ? size_t(0) : brasize * num_terms / num_compute;
 	ih[task][thread_id].reserve(reserve_size);
 	jh[task][thread_id].reserve(reserve_size);
 	hij[task][thread_id].reserve(reserve_size);
@@ -113,7 +123,7 @@ namespace sbd {
 	int sign_count;
 	bool check;
 	
-	for(size_t ib=ib_start; ib < ib_end; ib+=num_thread) {
+	for(size_t ib=ib_start; ib < ib_end; ib+=num_compute) {
 
 	  vb = bs[ib];
 	  for(size_t n=0; n < H.o_.size(); n++) {

--- a/include/sbd/caop/basic/mkham.h
+++ b/include/sbd/caop/basic/mkham.h
@@ -19,12 +19,11 @@ namespace sbd {
     hii.resize(bs.size(),ElemT(0.0));
 #pragma omp parallel
     {
-      std::vector<size_t> v;
       size_t size_t_one = static_cast<size_t>(1);
       bool check;
 #pragma omp for
       for(size_t ib=0; ib < bs.size(); ib++) {
-	v = bs[ib];
+	const auto& v = bs[ib];
 	for(size_t n=0; n < H.d_.size(); n++) {
 	  check = false;
 	  for(int k=0; k < H.d_[n].n_dag_; k++) {
@@ -117,18 +116,17 @@ namespace sbd {
 	jh[task][thread_id].reserve(reserve_size);
 	hij[task][thread_id].reserve(reserve_size);
 
-	std::vector<size_t> vb;
 	std::vector<size_t> vk;
 	size_t size_t_one = static_cast<size_t>(1);
 	int sign_count;
 	bool check;
-	
+
 	for(size_t ib=ib_start; ib < ib_end; ib+=num_compute) {
 
-	  vb = bs[ib];
+	  const auto& vb = bs[ib];
 	  for(size_t n=0; n < H.o_.size(); n++) {
 	    sign_count = 1;
-	    vk = vb;
+	    assign_det(vk, vb);
 	    check = false;
 	    for(int k=0; k < H.o_[n].n_dag_; k++) {
 	      size_t q = static_cast<size_t>(H.o_[n].fops_[k].q_);

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -204,10 +204,12 @@ namespace sbd {
 	size_t thread_id   = omp_get_thread_num();
 
 	// Thread 0 starts the ring-shift into the next ping-pong buffer.
-	// MpiSlide blocks until data transfer completes, so thread 0 then
-	// falls through to the compute loop below.
+	// MpiSlide blocks until data transfer completes.
 	// Threads 1..N-1 proceed directly to compute — their work overlaps
 	// with thread 0's MPI blocking call.
+	// makeCAOpHam assigns no COO rows to thread 0 when num_thread > 1,
+	// so thread 0's compute loop below is a no-op in that case.
+	// When num_thread == 1, thread 0 does MPI then handles all rows.
 	if( thread_id == 0 && !last_task ) {
 	  int bslide = slide[task]-slide[task+1];
 	  MpiSlide(*twk_cur, *twk_next, bslide, b_comm);

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -158,7 +158,7 @@ namespace sbd {
 	    MPI_Comm h_comm,
 	    MPI_Comm b_comm,
 	    MPI_Comm t_comm) {
-    
+
     int mpi_rank_h; MPI_Comm_rank(h_comm,&mpi_rank_h);
     int mpi_size_h; MPI_Comm_size(h_comm,&mpi_size_h);
     int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
@@ -166,46 +166,60 @@ namespace sbd {
     int mpi_rank_t; MPI_Comm_rank(t_comm,&mpi_rank_t);
     int mpi_size_t; MPI_Comm_size(t_comm,&mpi_size_t);
 
-    std::vector<ElemT> twk;
-    std::vector<ElemT> rwk;
+    // Ping-pong buffers for the ring-shifted weight vector.
+    // Thread 0 writes *twk_next via MpiSlide while compute threads
+    // read *twk_cur — both are separate buffers so there is no data race.
+    std::vector<ElemT> buf_A, buf_B;
+    std::vector<ElemT>* twk_cur  = &buf_A;
+    std::vector<ElemT>* twk_next = &buf_B;
 
     if( slide.size() != 0 ) {
-      if( slide[0] != 0 ) {
-	MpiSlide(w,twk,-slide[0],b_comm);
-      } else {
-	twk = w;
-      }
+      if( slide[0] != 0 )
+	MpiSlide(w, *twk_cur, -slide[0], b_comm);
+      else
+	*twk_cur = w;
     }
 
     ElemT volp(1.0/(mpi_size_h*mpi_size_t));
 #pragma omp parallel for
-    for(size_t i=0; i < hw.size(); i++) {
-      hw[i] *= volp;
-    }
+    for(size_t i=0; i < hw.size(); i++) hw[i] *= volp;
 
     if( mpi_rank_t == 0 ) {
 #pragma omp parallel for
-      for(size_t i=0; i < twk.size(); i++) {
-	hw[i] += hii[i] * twk[i];
-      }
+      for(size_t i=0; i < twk_cur->size(); i++)
+	hw[i] += hii[i] * (*twk_cur)[i];
     }
 
+    // Ring-slide loop with overlap.
+    // Each task uses a per-task #pragma omp parallel (matching original structure).
+    // Inside the parallel region: thread 0 calls MpiSlide into *twk_next while
+    // all threads (including thread 0 after MPI completes) compute from *twk_cur.
+    // The implicit barrier at the end of the parallel region ensures the slide
+    // finishes before the pointer swap.  hij[task] is indexed by thread_id so
+    // it matches makeCAOpHam's original num_thread slot layout exactly.
     for(size_t task=0; task < slide.size(); task++) {
+      bool last_task = (task == slide.size() - 1);
 #pragma omp parallel
       {
-	size_t thread_id = omp_get_thread_num();
-	size_t num_threads = omp_get_num_threads();
-	for(size_t k=0; k < hij[task][thread_id].size(); k++) {
-	  hw[ih[task][thread_id][k]] += hij[task][thread_id][k]
-	    * twk[jh[task][thread_id][k]];
+	size_t thread_id   = omp_get_thread_num();
+
+	// Thread 0 starts the ring-shift into the next ping-pong buffer.
+	// MpiSlide blocks until data transfer completes, so thread 0 then
+	// falls through to the compute loop below.
+	// Threads 1..N-1 proceed directly to compute — their work overlaps
+	// with thread 0's MPI blocking call.
+	if( thread_id == 0 && !last_task ) {
+	  int bslide = slide[task]-slide[task+1];
+	  MpiSlide(*twk_cur, *twk_next, bslide, b_comm);
 	}
+
+	for(size_t k=0; k < hij[task][thread_id].size(); k++)
+	  hw[ih[task][thread_id][k]] += hij[task][thread_id][k]
+	    * (*twk_cur)[jh[task][thread_id][k]];
+	// Implicit barrier at end of omp parallel
       }
-      if( task != slide.size()-1 ) {
-	int bslide = slide[task]-slide[task+1];
-	rwk.resize(twk.size());
-	std::memcpy(rwk.data(),twk.data(),twk.size()*sizeof(ElemT));
-	MpiSlide(rwk,twk,bslide,b_comm);
-      }
+      // Swap pointers so the next task reads the freshly received data.
+      if( !last_task ) std::swap(twk_cur, twk_next);
     }
     MpiAllreduce(hw,MPI_SUM,t_comm);
     MpiAllreduce(hw,MPI_SUM,h_comm);

--- a/include/sbd/caop/basic/mult.h
+++ b/include/sbd/caop/basic/mult.h
@@ -68,7 +68,6 @@ namespace sbd {
       {
 	size_t ib_start = 0;
 	size_t ib_end   = bs.size();
-	std::vector<size_t> vb;
 	std::vector<size_t> vk;
 	int sign_count;
 	size_t size_t_one = static_cast<size_t>(1);
@@ -76,7 +75,7 @@ namespace sbd {
 #pragma omp for schedule(dynamic)
 	for(size_t ib = ib_start; ib < ib_end; ib++) {
 
-	  vb = bs[ib];
+	  const auto& vb = bs[ib];
 	  for(size_t n=0; n < H.o_.size(); n++) {
 	    // fast reject: required bits absent or forbidden bits present
 	    {
@@ -90,7 +89,7 @@ namespace sbd {
 	    }
 	    // survivor: construct ket and accumulate sign
 	    sign_count = 1;
-	    vk = vb;
+	    assign_det(vk, vb);
 	    for(int k=0; k < H.o_[n].n_dag_; k++) {
 	      int q = H.o_[n].fops_[k].q_;
 	      int r = q / bit_length;

--- a/include/sbd/caop/basic/restart.h
+++ b/include/sbd/caop/basic/restart.h
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <sstream>
 #include <fstream>
+#include <omp.h>
 
 namespace sbd {
 
@@ -88,17 +89,23 @@ namespace sbd {
 	auto cmp = [](const auto & x, const auto & y) {
 	  return sbd::less_from_back(x,y);
 	};
-	std::vector<size_t> index_not_found;
-	index_not_found.reserve(load_basis_size);
-	for(size_t i=0; i < load_basis_size; i++) {
-	  auto itn = std::lower_bound(basis.begin(),basis.end(),load_basis[i],cmp);
-	  if( itn == basis.end() || *itn != load_basis[i] ) {
-	    index_not_found.push_back(i);
-	  } else {
-	    auto n = static_cast<size_t>(itn - basis.begin());
-	    w[n] = load_w[i];
+	// Parallel binary search: race-free because basis is sorted and unique, so
+	// each load_basis[i] maps to at most one slot.  Use std::vector<char>
+	// rather than std::vector<bool> to avoid the bit-packed specialisation's
+	// concurrent-write pitfall (two bools in the same byte, distinct indices).
+	std::vector<char> found_flag(load_basis_size, 0);
+	#pragma omp parallel for schedule(static)
+	for (size_t i = 0; i < load_basis_size; ++i) {
+	  auto it = std::lower_bound(basis.begin(), basis.end(), load_basis[i], cmp);
+	  if (it != basis.end() && *it == load_basis[i]) {
+	    w[static_cast<size_t>(it - basis.begin())] = load_w[i];
+	    found_flag[i] = 1;
 	  }
 	}
+	std::vector<size_t> index_not_found;
+	index_not_found.reserve(load_basis_size);
+	for (size_t i = 0; i < load_basis_size; ++i)
+	  if (!found_flag[i]) index_not_found.push_back(i);
 	det_vector<size_t> send_basis(index_not_found.size());
 	std::vector<ElemT> send_w(index_not_found.size());
 	for(size_t k=0; k < index_not_found.size(); k++) {
@@ -109,17 +116,20 @@ namespace sbd {
 	for(int slide=1; slide < mpi_size_b; slide++) {
 	  MpiSlide(send_basis,load_basis,1,b_comm);
 	  MpiSlide(send_w,load_w,1,b_comm);
-	  index_not_found.resize(0);
-	  index_not_found.reserve(load_basis.size());
-	  for(size_t i=0; i < load_basis.size(); i++) {
-	    auto itn = std::lower_bound(basis.begin(),basis.end(),load_basis[i],cmp);
-	    if( itn == basis.end() || *itn != load_basis[i] ) {
-	      index_not_found.push_back(i);
-	    } else {
-	      auto n = static_cast<size_t>(itn - basis.begin());
-	      w[n] = load_w[i];
+	  const size_t slide_sz = load_basis.size();
+	  std::vector<char> slide_found(slide_sz, 0);
+	  #pragma omp parallel for schedule(static)
+	  for (size_t i = 0; i < slide_sz; ++i) {
+	    auto it = std::lower_bound(basis.begin(), basis.end(), load_basis[i], cmp);
+	    if (it != basis.end() && *it == load_basis[i]) {
+	      w[static_cast<size_t>(it - basis.begin())] = load_w[i];
+	      slide_found[i] = 1;
 	    }
 	  }
+	  index_not_found.clear();
+	  index_not_found.reserve(slide_sz);
+	  for (size_t i = 0; i < slide_sz; ++i)
+	    if (!slide_found[i]) index_not_found.push_back(i);
 	  send_basis.resize(index_not_found.size());
 	  send_w.resize(index_not_found.size());
 	  for(size_t k=0; k < index_not_found.size(); k++) {

--- a/include/sbd/caop/basic/sbdiag.h
+++ b/include/sbd/caop/basic/sbdiag.h
@@ -432,7 +432,8 @@ namespace sbd {
 	  load_basis_from_files(basisfiles,basis,
 				bit_length,system_size,
 				b_comm);
-	  sort_bitarray(basis);
+	  // sort_bitarray(basis) removed: load_basis_from_files guarantees sorted
+	  // output, and mpi_redistribution sorts its own received data internally.
 	  if( sbd_data.do_sort_basis ) {
 	    redistribution(basis,bit_length,system_size,b_comm);
 	    reordering(basis,bit_length,system_size,b_comm);

--- a/include/sbd/chemistry/basic/correlation.h
+++ b/include/sbd/chemistry/basic/correlation.h
@@ -13,8 +13,8 @@ namespace sbd {
   /**
      Function for adding diagonal contribution
    */
-  template <typename ElemT>
-  void ZeroDiffCorrelation(const std::vector<size_t> & DetI,
+  template <typename ElemT, typename DetT>
+  void ZeroDiffCorrelation(const DetT & DetI,
 			   ElemT WeightI,
 			   size_t bit_length,
 			   size_t norb,
@@ -99,8 +99,8 @@ namespace sbd {
   /**
      Function for adding one-occupation different contribution
    */
-  template <typename ElemT>
-  void OneDiffCorrelation(const std::vector<size_t> & DetI,
+  template <typename ElemT, typename DetT>
+  void OneDiffCorrelation(const DetT & DetI,
 			  const ElemT WeightI,
 			  const ElemT WeightJ,
 			  const size_t bit_length,
@@ -197,8 +197,8 @@ namespace sbd {
   /**
      Function for adding two-occupation different contribution
    */
-  template <typename ElemT>
-  void TwoDiffCorrelation(const std::vector<size_t> & DetI,
+  template <typename ElemT, typename DetT>
+  void TwoDiffCorrelation(const DetT & DetI,
 			  const ElemT WeightI,
 			  const ElemT WeightJ,
 			  const size_t bit_length,

--- a/include/sbd/chemistry/basic/determinants.h
+++ b/include/sbd/chemistry/basic/determinants.h
@@ -9,8 +9,8 @@ namespace sbd {
 
 #ifdef SBD_TRADMODE
 
-  template<typename ARange, typename BRange>
-  std::vector<size_t> DetFromAlphaBeta(const ARange& A, const BRange& B,
+  template<typename ADetT, typename BDetT>
+  std::vector<size_t> DetFromAlphaBeta(const ADetT& A, const BDetT& B,
                                        const size_t bit_length,
                                        const size_t L) {
     int dsize = (2*L + bit_length - 1) / bit_length;
@@ -52,11 +52,11 @@ namespace sbd {
     return D;
   }
 
-  template<typename ARange, typename BRange>
-  void DetFromAlphaBeta(const ARange& A, const BRange& B,
+  template<typename ADetT, typename BDetT, typename DetT>
+  void DetFromAlphaBeta(const ADetT& A, const BDetT& B,
                         const size_t bit_length,
                         const size_t L,
-                        std::vector<size_t>& D) {
+                        DetT& D) {
     int fsize = L / bit_length;
     int half = bit_length / 2;
     int extra = L - fsize*bit_length;
@@ -94,8 +94,8 @@ namespace sbd {
   }
 
 #else
-  template<typename ARange, typename BRange>
-  std::vector<size_t> DetFromAlphaBeta(const ARange& A, const BRange& B,
+  template<typename ADetT, typename BDetT>
+  std::vector<size_t> DetFromAlphaBeta(const ADetT& A, const BDetT& B,
 				       const size_t bit_length,
 				       const size_t L) {
     size_t D_size = (2*L+bit_length-1)/bit_length;
@@ -118,11 +118,11 @@ namespace sbd {
     return D;
   }
 
-  template<typename ARange, typename BRange>
-  void DetFromAlphaBeta(const ARange& A, const BRange& B,
+  template<typename ADetT, typename BDetT, typename DetT>
+  void DetFromAlphaBeta(const ADetT& A, const BDetT& B,
 			const size_t bit_length,
 			const size_t L,
-			std::vector<size_t>& D) {
+			DetT& D) {
     std::fill(D.begin(),D.end(),static_cast<size_t>(0));
     for(size_t i=0; i < L; ++i) {
       size_t block = i / bit_length;

--- a/include/sbd/chemistry/basic/determinants.h
+++ b/include/sbd/chemistry/basic/determinants.h
@@ -9,8 +9,8 @@ namespace sbd {
 
 #ifdef SBD_TRADMODE
 
-  std::vector<size_t> DetFromAlphaBeta(const std::vector<size_t> & A,
-                                       const std::vector<size_t> & B,
+  template<typename ARange, typename BRange>
+  std::vector<size_t> DetFromAlphaBeta(const ARange& A, const BRange& B,
                                        const size_t bit_length,
                                        const size_t L) {
     int dsize = (2*L + bit_length - 1) / bit_length;
@@ -52,11 +52,11 @@ namespace sbd {
     return D;
   }
 
-  void DetFromAlphaBeta(const std::vector<size_t> & A,
-                        const std::vector<size_t> & B,
+  template<typename ARange, typename BRange>
+  void DetFromAlphaBeta(const ARange& A, const BRange& B,
                         const size_t bit_length,
                         const size_t L,
-                        std::vector<size_t> & D) {
+                        std::vector<size_t>& D) {
     int fsize = L / bit_length;
     int half = bit_length / 2;
     int extra = L - fsize*bit_length;
@@ -94,8 +94,8 @@ namespace sbd {
   }
 
 #else
-  std::vector<size_t> DetFromAlphaBeta(const std::vector<size_t>& A,
-				       const std::vector<size_t>& B,
+  template<typename ARange, typename BRange>
+  std::vector<size_t> DetFromAlphaBeta(const ARange& A, const BRange& B,
 				       const size_t bit_length,
 				       const size_t L) {
     size_t D_size = (2*L+bit_length-1)/bit_length;
@@ -118,11 +118,11 @@ namespace sbd {
     return D;
   }
 
-  void DetFromAlphaBeta(const std::vector<size_t> & A,
-			const std::vector<size_t> & B,
+  template<typename ARange, typename BRange>
+  void DetFromAlphaBeta(const ARange& A, const BRange& B,
 			const size_t bit_length,
 			const size_t L,
-			std::vector<size_t> & D) {
+			std::vector<size_t>& D) {
     std::fill(D.begin(),D.end(),static_cast<size_t>(0));
     for(size_t i=0; i < L; ++i) {
       size_t block = i / bit_length;
@@ -174,7 +174,8 @@ namespace sbd {
     return (det[index] >> bit_pos) & 1;
   }
 
-  inline int bitcount(const std::vector<size_t> & det,
+  template<typename DetT>
+  inline int bitcount(const DetT& det,
 		      const size_t bit_length,
 		      const size_t L) {
     int count = 0;
@@ -206,11 +207,12 @@ namespace sbd {
     return cindex;
   }
 
-  int getOpenClosed(const std::vector<size_t> & det,
+  template<typename DetT>
+  int getOpenClosed(const DetT& det,
 		    const size_t bit_length,
 		    const size_t L,
-		    std::vector<int> & open,
-		    std::vector<int> & closed) {
+		    std::vector<int>& open,
+		    std::vector<int>& closed) {
     int cindex = 0;
     int oindex = 0;
     int csize = bitcount(det,bit_length,L);
@@ -328,10 +330,11 @@ namespace sbd {
     return beta;
   }
 
-  void getAdet(const std::vector<size_t> & det,
+  template<typename DetT>
+  void getAdet(const DetT& det,
 	       size_t bit_length,
 	       size_t norb,
-	       std::vector<size_t> & adet) {
+	       std::vector<size_t>& adet) {
     size_t adet_size = (norb + bit_length - 1 ) / bit_length;
     if( adet_size != adet.size() ) {
       adet.resize(adet_size);
@@ -345,10 +348,11 @@ namespace sbd {
     }
   }
 
-  void getBdet(const std::vector<size_t>& det,
+  template<typename DetT>
+  void getBdet(const DetT& det,
 	       size_t bit_length,
 	       size_t norb,
-	       std::vector<size_t> & bdet) {
+	       std::vector<size_t>& bdet) {
     size_t bdet_size = (norb + bit_length - 1 ) / bit_length;
     if( bdet_size != bdet.size() ) {
       bdet.resize(bdet_size);

--- a/include/sbd/chemistry/basic/determinants.h
+++ b/include/sbd/chemistry/basic/determinants.h
@@ -191,7 +191,8 @@ namespace sbd {
     return count;
   }
 
-  int getClosed(const std::vector<size_t> & det,
+  template<typename DetT>
+  int getClosed(const DetT & det,
 		const size_t bit_length,
 		const size_t L,
 		std::vector<int> & closed) {
@@ -230,7 +231,8 @@ namespace sbd {
     return cindex;
   }
 
-  void parity(const std::vector<size_t> & dets,
+  template<typename DetT>
+  void parity(const DetT & dets,
 	      const size_t bit_length,
 	      const int & start, const int & end, double& sgn) {
     if (start > end) {
@@ -438,8 +440,8 @@ namespace sbd {
     }
   }
 
-  template <typename ElemT>
-  ElemT ZeroExcite(const std::vector<size_t> & det,
+  template <typename ElemT, typename DetT>
+  ElemT ZeroExcite(const DetT & det,
 		   const size_t bit_length,
 		   const size_t L,
 		   const ElemT & I0,
@@ -463,8 +465,8 @@ namespace sbd {
         return energy + I0;
   }
 
-  template <typename ElemT>
-  ElemT OneExcite(const std::vector<size_t> & det,
+  template <typename ElemT, typename DetT>
+  ElemT OneExcite(const DetT & det,
 		  const size_t bit_length,
 		  int & i,
 		  int & a,
@@ -487,8 +489,8 @@ namespace sbd {
         return energy;
   }
 
-  template <typename ElemT>
-  ElemT TwoExcite(const std::vector<size_t> & det,
+  template <typename ElemT, typename DetT>
+  ElemT TwoExcite(const DetT & det,
 		  const size_t bit_length,
 		  int & i,
 		  int & j,

--- a/include/sbd/chemistry/gdb/expansion.h
+++ b/include/sbd/chemistry/gdb/expansion.h
@@ -74,7 +74,8 @@ namespace sbd {
 
   namespace gdb {
 
-    void singles_from_hdet(const std::vector<size_t> & hdet,
+    template<typename HDetT>
+    void singles_from_hdet(const HDetT& hdet,
 			  size_t bit_length,
 			  size_t norb,
 			  size_t num_one,
@@ -86,7 +87,7 @@ namespace sbd {
       size_t num_ex = num_one * (norb - num_one);
       edet.resize(num_ex);
       cran.resize(2*num_ex);
-      std::vector<size_t> base = hdet;
+      std::vector<size_t> base(hdet.begin(), hdet.end());
       size_t ex_count = 0;
       for(size_t i=0; i < num_one; i++) {
 	setocc(base,bit_length,closed[i],false);
@@ -101,7 +102,8 @@ namespace sbd {
       }
     }
 
-    void doubles_from_hdet(const std::vector<size_t> & hdet,
+    template<typename HDetT>
+    void doubles_from_hdet(const HDetT& hdet,
 			  size_t bit_length,
 			  size_t norb,
 			  size_t num_one,
@@ -113,7 +115,7 @@ namespace sbd {
       size_t num_ex = num_one * (num_one-1) * (norb - num_one) * (norb - num_one - 1) / 4;
       edet.resize(num_ex);
       cran.resize(4*num_ex);
-      std::vector<size_t> base = hdet;
+      std::vector<size_t> base(hdet.begin(), hdet.end());
       size_t ex_count = 0;
       for(size_t i=0; i < num_one; i++) {
 	setocc(base,bit_length,closed[i],false);

--- a/include/sbd/chemistry/gdb/expansion.h
+++ b/include/sbd/chemistry/gdb/expansion.h
@@ -324,7 +324,7 @@ namespace sbd {
 	  }
 	};
 
-	std::vector<size_t> cdet = det[0];
+	std::vector<size_t> cdet(det[0].begin(), det[0].end());
 
 	if(pair_begin < pair_end) {
 	  size_t ia = static_cast<size_t>(
@@ -519,7 +519,7 @@ namespace sbd {
 	  }
 	};
 
-	std::vector<size_t> cdet = det[0];
+	std::vector<size_t> cdet(det[0].begin(), det[0].end());
 
 	if(pair_begin < pair_end) {
 	  size_t ia = static_cast<size_t>(
@@ -572,7 +572,7 @@ namespace sbd {
 				    I1,I2);
 	      RealT hijc = std::abs( hij * w[idet] );
 	      if( hijc > cutoff ) {
-		cdet = det[idet];
+		assign_det(cdet, det[idet]);
 		setocc(cdet,bit_length,aorb_single[2*ja+1],true);
 		setocc(cdet,bit_length,aorb_single[2*ja+0],false);
 		push_candidate(cdet);
@@ -589,7 +589,7 @@ namespace sbd {
 				    I1,I2);
 	      RealT hijc = std::abs( hij * w[idet] );
 	      if( hijc > cutoff ) {
-		cdet = det[idet];
+		assign_det(cdet, det[idet]);
 		setocc(cdet,bit_length,aorb_double[4*ja+3],true);
 		setocc(cdet,bit_length,aorb_double[4*ja+1],false);
 		setocc(cdet,bit_length,aorb_double[4*ja+2],true);
@@ -609,7 +609,7 @@ namespace sbd {
 				      I1,I2);
 		RealT hijc = std::abs( hij * w[idet] );
 		if( hijc > cutoff ) {
-		  cdet = det[idet];
+		  assign_det(cdet, det[idet]);
 		  setocc(cdet,bit_length,aorb_single[2*ja+1],true);
 		  setocc(cdet,bit_length,aorb_single[2*ja+0],false);
 		  setocc(cdet,bit_length,borb_single[2*jb+1],true);
@@ -627,7 +627,7 @@ namespace sbd {
 				    I1,I2);
 	      RealT hijc = std::abs( hij * w[idet] );
 	      if( hijc > cutoff ) {
-		cdet = det[idet];
+		assign_det(cdet, det[idet]);
 		setocc(cdet,bit_length,borb_single[2*jb+1],true);
 		setocc(cdet,bit_length,borb_single[2*jb+0],false);
 		push_candidate(cdet);
@@ -644,7 +644,7 @@ namespace sbd {
 				    I1,I2);
 	      RealT hijc = std::abs( hij * w[idet] );
 	      if( hijc > cutoff ) {
-		cdet = det[idet];
+		assign_det(cdet, det[idet]);
 		setocc(cdet,bit_length,borb_double[4*jb+3],true);
 		setocc(cdet,bit_length,borb_double[4*jb+1],false);
 		setocc(cdet,bit_length,borb_double[4*jb+2],true);

--- a/include/sbd/chemistry/tpb/extend.h
+++ b/include/sbd/chemistry/tpb/extend.h
@@ -90,7 +90,7 @@ namespace sbd {
     size_t ia_count = 0;
     for(size_t ia=adet_begin; ia < adet_end; ia++) {
       if( adet_count[ia] > 0 ) {
-	new_adet_local[ia_count++] = adet[ia];
+	assign_det(new_adet_local[ia_count++], adet[ia]);
       }
     }
 
@@ -109,7 +109,7 @@ namespace sbd {
     size_t ib_count = 0;
     for(size_t ib=bdet_begin; ib < bdet_end; ib++) {
       if( bdet_count[ib] > 0 ) {
-	new_bdet_local[ib_count++] = bdet[ib];
+	assign_det(new_bdet_local[ib_count++], bdet[ib]);
       }
     }
     hdet_ex.resize(max_single_from_b);
@@ -226,7 +226,7 @@ namespace sbd {
 
     size_t ia_count = 0;
     for(size_t ia=adet_begin; ia < adet_end; ia++) {
-      new_adet_local[ia_count++] = adet[ia];
+      assign_det(new_adet_local[ia_count++], adet[ia]);
     }
     std::vector<std::vector<size_t>> hdet_ex(max_single_from_a);
     std::vector<int> open_adet(norb-num_one_a);
@@ -242,7 +242,7 @@ namespace sbd {
 
     size_t ib_count = 0;
     for(size_t ib=bdet_begin; ib < bdet_end; ib++) {
-      new_bdet_local[ib_count++] = bdet[ib];
+      assign_det(new_bdet_local[ib_count++], bdet[ib]);
     }
     hdet_ex.resize(max_single_from_b);
     std::vector<int> open_bdet(norb-num_one_a);

--- a/include/sbd/chemistry/tpb/helper.h
+++ b/include/sbd/chemistry/tpb/helper.h
@@ -94,7 +94,7 @@ namespace sbd {
         int nclosed = getOpenClosed(ADets[ib],bit_length,norb,open,closed);
         for(size_t j=0; j < nclosed; j++) {
   	  for(size_t k=0; k < norb-nclosed; k++) {
-  	    aDet = ADets[ib];
+	    assign_det(aDet, ADets[ib]);
 	    setocc(aDet,bit_length,closed[j],false);
 	    setocc(aDet,bit_length,open[k],true);
 	    auto itk = std::find(ADets.begin()+ketAlphaStart,
@@ -120,7 +120,7 @@ namespace sbd {
         int nclosed = getOpenClosed(BDets[ib],bit_length,norb,open,closed);
         for(size_t j=0; j < nclosed; j++) {
 	  for(size_t k=0; k < norb-nclosed; k++) {
-	    bDet = BDets[ib];
+	    assign_det(bDet, BDets[ib]);
 	    setocc(bDet,bit_length,closed[j],false);
 	    setocc(bDet,bit_length,open[k],true);
 	    auto itk = std::find(BDets.begin()+ketBetaStart,

--- a/include/sbd/framework/bit_manipulation.h
+++ b/include/sbd/framework/bit_manipulation.h
@@ -530,7 +530,19 @@ namespace sbd {
       MPI_Barrier(comm);
     } // end for(int recv_rank=0; recv_rank < mpi_size; recv_rank++)
 
-    sort_bitarray(new_config);
+    // Skip sort_bitarray if new_config is already sorted.  When the source
+    // data was globally ordered before redistribution (e.g. sorted-split
+    // shard files with a rank-count mismatch), mpi_redistribution ships
+    // contiguous slices in rank order, so new_config arrives sorted and the
+    // O((n/r) log(n/r)) sort is pure waste.  The O(n/r) check below costs
+    // nothing relative to the sort it avoids.
+    {
+      bool needs_sort = false;
+      const size_t nc = new_config.size();
+      for (size_t i = 1; i < nc && !needs_sort; ++i)
+        if (less_from_back(new_config[i], new_config[i-1])) needs_sort = true;
+      if (needs_sort) sort_bitarray(new_config);
+    }
     config = std::move(new_config);
 
     std::fill(send_config_size.begin(),send_config_size.end(),static_cast<size_t>(0));

--- a/include/sbd/framework/bit_manipulation.h
+++ b/include/sbd/framework/bit_manipulation.h
@@ -189,7 +189,8 @@ namespace sbd {
      @param[in] bit_length: length of the bitstring managed by each size_t
      @param[in] L: number of total bits in the bitstring
    */
-  std::string makestring(const std::vector<size_t> & config,
+  template<typename DetT>
+  std::string makestring(const DetT& config,
 			 size_t bit_length,
 			 size_t L) {
     std::string s;

--- a/include/sbd/framework/bit_manipulation.h
+++ b/include/sbd/framework/bit_manipulation.h
@@ -1286,11 +1286,12 @@ namespace sbd {
     sort_bitarray(dets);
   }
 
+  template<typename DetT>
   inline int destination_by_splitters(
-    const std::vector<size_t> &det,
+    const DetT &det,
     const std::vector<std::vector<size_t>> &splitters) {
     auto it = std::upper_bound(splitters.begin(), splitters.end(), det,
-			       [](const std::vector<size_t>& a, const std::vector<size_t>& b) {
+			       [](const auto& a, const auto& b) {
 				 return less_from_back(a, b); });
     return static_cast<int>(it - splitters.begin());
   }

--- a/include/sbd/framework/det_vector.h
+++ b/include/sbd/framework/det_vector.h
@@ -64,6 +64,15 @@ public:
                 throw std::length_error("det_vector::row: resize to wrong size");
         }
 
+        // Assigns from an iterator range [first, last); size must match the row width.
+        template<typename InputIt>
+        void assign(InputIt first, InputIt last) {
+            size_t n = static_cast<size_t>(std::distance(first, last));
+            if (n != size())
+                throw std::length_error("det_vector::row::assign: size mismatch");
+            std::copy(first, last, _data);
+        }
+
         ElemT& operator[](size_t k) noexcept       { return _data[k]; }
         const ElemT& operator[](size_t k) const noexcept { return _data[k]; }
 
@@ -75,13 +84,14 @@ public:
         const ElemT* begin() const noexcept { return _data; }
         const ElemT* end()   const noexcept { return _data + size(); }
 
-        operator std::vector<ElemT>() const {
+        explicit operator std::vector<ElemT>() const {
             return std::vector<ElemT>(_data, _data + size());
         }
 
-        // In-place copy from vector; sets _elem_size if not yet set, else must match.
+        // In-place copy from vector; size must match the row width.
         row& operator=(const std::vector<ElemT>& v) {
-            det_vector::_set_elem_size(v.size());
+            if (v.size() != size())
+                throw std::length_error("det_vector::row::operator=: size mismatch");
             std::memcpy(_data, v.data(), size() * sizeof(ElemT));
             return *this;
         }
@@ -578,6 +588,16 @@ private:
         std::memcpy(_data.data() + i * stride(), src, _elem_size * sizeof(ElemT));
     }
 };
+
+// ---- assignment utility ----
+
+// No-allocation range assign: copies src contents into dst, reusing dst's
+// existing allocation.  dst must support assign(InputIt, InputIt)
+// (std::vector and det_vector::row both do).  src needs only begin()/end().
+template<typename Dst, typename Src>
+void assign_det(Dst& dst, const Src& src) {
+    dst.assign(src.begin(), src.end());
+}
 
 // ---- sort / unique free functions ----
 //

--- a/include/sbd/framework/dm_vector.h
+++ b/include/sbd/framework/dm_vector.h
@@ -281,8 +281,11 @@ namespace sbd {
     h.resize(k);
     for(IntT i=0; i < k; i++) {
       InnerProduct(V[i],W,h[i],comm);
+      ElemT hi = h[i];
+      const std::vector<ElemT> & Vi = V[i];
+#pragma omp parallel for schedule(static)
       for(size_t s=0; s < W.size(); s++) {
-	W[s] -= h[i] * V[i][s];
+	W[s] -= hi * Vi[s];
       }
     }
   }

--- a/include/sbd/framework/mpi_utility.h
+++ b/include/sbd/framework/mpi_utility.h
@@ -502,32 +502,35 @@ namespace sbd {
     }
   }
 
+// v5: use MPI_IN_PLACE to eliminate the 200 MB heap allocation that the prior
+// std::vector<ElemT> B(A) pattern incurred on every call.  With IN_PLACE, A
+// serves as both send and receive buffer; on a size-1 communicator MPICH
+// returns immediately with no data movement.
+
 #ifdef SBD_TRADMODE
   template <typename ElemT>
   void MpiAllreduce(std::vector<ElemT> & A, MPI_Op op, MPI_Comm comm) {
     MPI_Datatype DataT = GetMpiType<ElemT>::MpiT;
-    std::vector<ElemT> B(A);
 #if MPI_VERSION >= 4
-    MPI_Allreduce_c(B.data(),A.data(),A.size(),DataT,op,comm);
+    MPI_Allreduce_c(MPI_IN_PLACE,A.data(),A.size(),DataT,op,comm);
 #else
     if (A.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
         throw std::runtime_error("MPI_Allreduce: count exceeds INT_MAX (MPI<4). Use MPI-4 *_c API.");
     }
-    MPI_Allreduce(B.data(),A.data(),static_cast<int>(A.size()),DataT,op,comm);
+    MPI_Allreduce(MPI_IN_PLACE,A.data(),static_cast<int>(A.size()),DataT,op,comm);
 #endif
   }
 
   template <>
   void MpiAllreduce(std::vector<size_t> & A, MPI_Op op, MPI_Comm comm) {
     MPI_Datatype DataT = SBD_MPI_SIZE_T;
-    std::vector<size_t> B(A);
 #if MPI_VERSION >= 4
-    MPI_Allreduce_c(B.data(),A.data(),A.size(),DataT,op,comm);
+    MPI_Allreduce_c(MPI_IN_PLACE,A.data(),A.size(),DataT,op,comm);
 #else
     if (A.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
         throw std::runtime_error("MPI_Allreduce: count exceeds INT_MAX (MPI<4). Use MPI-4 *_c API.");
     }
-    MPI_Allreduce(B.data(),A.data(),static_cast<int>(A.size()),DataT,op,comm);
+    MPI_Allreduce(MPI_IN_PLACE,A.data(),static_cast<int>(A.size()),DataT,op,comm);
 #endif
   }
 #else
@@ -539,14 +542,13 @@ namespace sbd {
     } else {
       DataT = GetMpiType<ElemT>::MpiT;
     }
-    std::vector<ElemT> B(A);
 #if MPI_VERSION >= 4
-    MPI_Allreduce_c(B.data(),A.data(),A.size(),DataT,op,comm);
+    MPI_Allreduce_c(MPI_IN_PLACE,A.data(),A.size(),DataT,op,comm);
 #else
     if (A.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
         throw std::runtime_error("MPI_Allreduce: count exceeds INT_MAX (MPI<4). Use MPI-4 *_c API.");
     }
-    MPI_Allreduce(B.data(),A.data(),static_cast<int>(A.size()),DataT,op,comm);
+    MPI_Allreduce(MPI_IN_PLACE,A.data(),static_cast<int>(A.size()),DataT,op,comm);
 #endif
   }
 #endif

--- a/tests/functionality/test_determinants.cc
+++ b/tests/functionality/test_determinants.cc
@@ -33,6 +33,32 @@ void test_DetFromAlphaBeta_simple() {
   TEST_ASSERT((D1[0] & 0b1100) == 0b0100);
   TEST_ASSERT((D1[0] & 0b110000) == 0b100000);
   TEST_ASSERT((D1[0] & 0b11000000) == 0);
+
+  // Call with det_vector<size_t, det_kind::half>::row as inputs A and B.
+  // det_vector(size_t n, const std::vector<ElemT>& v) constructs n rows each
+  // initialised to v; [0] returns a row& (non-owning view into the flat buffer).
+  det_vector<size_t, det_kind::half> dv_A(1, A);
+  det_vector<size_t, det_kind::half> dv_B(1, B);
+  auto D3 = DetFromAlphaBeta(dv_A[0], dv_B[0], bit_length, L);
+  TEST_ASSERT(D3.size() == D1.size());
+  for (size_t i = 0; i < D1.size(); i++) {
+    TEST_ASSERT(D3[i] == D1[i]);
+  }
+
+  // Void form with det_vector<size_t, det_kind::full>::row as output D.
+  const size_t dsize = D1.size();
+  det_vector<size_t, det_kind::full> dv_D(1, std::vector<size_t>(dsize, 0));
+  DetFromAlphaBeta(A, B, bit_length, L, dv_D[0]);
+  for (size_t i = 0; i < dsize; i++) {
+    TEST_ASSERT(dv_D[0][i] == D1[i]);
+  }
+
+  // Void form: det_vector inputs + det_vector full output.
+  det_vector<size_t, det_kind::full> dv_D2(1, std::vector<size_t>(dsize, 0));
+  DetFromAlphaBeta(dv_A[0], dv_B[0], bit_length, L, dv_D2[0]);
+  for (size_t i = 0; i < dsize; i++) {
+    TEST_ASSERT(dv_D2[0][i] == D1[i]);
+  }
 }
 
 void test_DetFromAlphaBeta_multiword() {
@@ -60,21 +86,48 @@ void test_DetFromAlphaBeta_multiword() {
     TEST_ASSERT(alpha_set == (orb % 5 == 0));
     TEST_ASSERT(beta_set == (orb % 7 == 0));
   }
+
+  // det_vector inputs: for L=100, half-dets are 2 words; full-dets are 4 words.
+  // Use distinct det_kind values (101/102) so their independent _elem_size statics
+  // don't conflict with the det_kind::half/full instances in test_DetFromAlphaBeta_simple.
+  det_vector<size_t, static_cast<det_kind>(101)> dv_A(1, A);
+  det_vector<size_t, static_cast<det_kind>(101)> dv_B(1, B);
+  auto D2 = DetFromAlphaBeta(dv_A[0], dv_B[0], bit_length, L);
+  TEST_ASSERT(D2.size() == D1.size());
+  for (size_t i = 0; i < D1.size(); i++) {
+    TEST_ASSERT(D2[i] == D1[i]);
+  }
+
+  // Void form with det_vector<size_t, static_cast<det_kind>(102)>::row as output D.
+  const size_t dsize = D1.size();
+  det_vector<size_t, static_cast<det_kind>(102)> dv_D(1, std::vector<size_t>(dsize, 0));
+  DetFromAlphaBeta(A, B, bit_length, L, dv_D[0]);
+  for (size_t i = 0; i < dsize; i++) {
+    TEST_ASSERT(dv_D[0][i] == D1[i]);
+  }
+
+  // Void form: det_vector(101) inputs + det_vector(102) output.
+  det_vector<size_t, static_cast<det_kind>(102)> dv_D2(1, std::vector<size_t>(dsize, 0));
+  DetFromAlphaBeta(dv_A[0], dv_B[0], bit_length, L, dv_D2[0]);
+  for (size_t i = 0; i < dsize; i++) {
+    TEST_ASSERT(dv_D2[0][i] == D1[i]);
+  }
 }
 
 void test_DetFromAlphaBeta_edge_cases() {
   const size_t bit_length = 64;
   size_t L = 4;
 
+  using V = std::vector<size_t>;
   // Empty
-  TEST_ASSERT(DetFromAlphaBeta({0}, {0}, bit_length, L)[0] == 0);
+  TEST_ASSERT(DetFromAlphaBeta(V{0}, V{0}, bit_length, L)[0] == 0);
   // Full
-  TEST_ASSERT(DetFromAlphaBeta({0b1111}, {0b1111}, bit_length, L)[0] ==
+  TEST_ASSERT(DetFromAlphaBeta(V{0b1111}, V{0b1111}, bit_length, L)[0] ==
               0b11111111);
   // Alpha only
-  TEST_ASSERT(DetFromAlphaBeta({0b1010}, {0}, bit_length, L)[0] == 0b01000100);
+  TEST_ASSERT(DetFromAlphaBeta(V{0b1010}, V{0}, bit_length, L)[0] == 0b01000100);
   // Beta only
-  TEST_ASSERT(DetFromAlphaBeta({0}, {0b1010}, bit_length, L)[0] == 0b10001000);
+  TEST_ASSERT(DetFromAlphaBeta(V{0}, V{0b1010}, bit_length, L)[0] == 0b10001000);
 }
 
 void test_DetFromAlphaBeta_regression_Fe4S4() {


### PR DESCRIPTION
**Changes**

Basis-loading pipeline (basis.h, bit_manipulation.h) — parallel per-file loading and record parsing; k-way merge replaces sort_bitarray on the merged array; redistribution fast-path skips mpi_redistribution when counts and order are already correct; mpi_redistribution skips its internal sort when the assembled buffer is already sorted; global sorted-range check via MPI_Sendrecv aborts with a diagnostic on bad shard input.

Davidson iteration (mult.h, mkham.h, dm_vector.h, mpi_utility.h) — ring-slide overlapped with GPU compute; thread 0 dedicated to MPI when num_thread > 1; MGS update loop parallelized with OpenMP; MPI_IN_PLACE in MpiAllreduce.

Warm restart (restart.h) — LoadWavefunction binary-search loops parallelized with OpenMP; std::vector<char> avoids the bit-packed bool specialization's concurrent-write hazard.

gen_bits.py — sorted-split default for multi-file output (round-robin produced overlapping ranges that the new global-sort check rejects at startup); parallel generation via multiprocessing.Pool.

**Component-level speedups** — 48-site, 100 M dets, 1 GH200 node

```
┌───────────────────────┬──────────────────────────┬───────────┬─────────┐
│       Component       │         pub/main         │ caop_cpu2 │ Speedup │
├───────────────────────┼──────────────────────────┼───────────┼─────────┤
│ Basis load, r=1       │ 24.2 s                   │ 1.5 s     │ 18×     │
├───────────────────────┼──────────────────────────┼───────────┼─────────┤
│ Basis load, r=4       │ 7.3 s                    │ 0.4 s     │ 18×     │
├───────────────────────┼──────────────────────────┼───────────┼─────────┤
│ LoadWavefunction, r=1 │ ~115 s (est. sequential) │ 1.6 s     │ ~72×    │
└───────────────────────┴──────────────────────────┴───────────┴─────────┘
```

**End-to-end cold start**

--method 0 (Thrust GPU on-the-fly Davidson): the GPU kernel dominates; basis savings are a small fraction of total.

```
┌────────────────────────┬──────────┬───────────┬─────────┐
│                        │ pub/main │ caop_cpu2 │ Speedup │
├────────────────────────┼──────────┼───────────┼─────────┤
│ r=1 (basis + davidson) │ ~205 s   │ ~182 s    │ ~1.1×   │
├────────────────────────┼──────────┼───────────┼─────────┤
│ r=4                    │ ~58 s    │ ~51 s     │ ~1.1×   │
└────────────────────────┴──────────┴───────────┴─────────┘
```

--method 1 (CPU precomputed): makeCAOpHam dominates at 245 s/163 s (r=1/r=4) and is essentially unchanged by this PR; basis savings are proportionally small.

```
┌────────────────────────────────┬──────────┬───────────┬─────────┐
│                                │ pub/main │ caop_cpu2 │ Speedup │
├────────────────────────────────┼──────────┼───────────┼─────────┤
│ r=1 (basis + mkham + davidson) │ ~287 s   │ ~269 s    │ ~1.1×   │
├────────────────────────────────┼──────────┼───────────┼─────────┤
│ r=4                            │ ~182 s   │ ~185 s    │ ~1.0×   │
└────────────────────────────────┴──────────┴───────────┴─────────┘
```

**End-to-end SQD warm-start cycles** (2nd+ iteration)

--method 0: no mkham, so the basis and LoadWavefunction savings dominate.

```
┌──────────────────────────────────────┬──────────┬───────────┬─────────┐
│                                      │ pub/main │ caop_cpu2 │ Speedup │
├──────────────────────────────────────┼──────────┼───────────┼─────────┤
│ r=1 (basis + LoadWF + warm davidson) │ ~153 s   │ ~17 s     │ ~9×     │
└──────────────────────────────────────┴──────────┴───────────┴─────────┘
```

--method 1: mkham runs every iteration on the new basis (~245 s, unchanged); warm-start benefit is real but mkham-limited.

```
┌──────────────────────────────────────────────┬──────────┬───────────┬─────────┐
│                                              │ pub/main │ caop_cpu2 │ Speedup │
├──────────────────────────────────────────────┼──────────┼───────────┼─────────┤
│ r=1 (basis + mkham + LoadWF + warm davidson) │ ~404 s   │ ~250 s    │ ~1.6×   │
└──────────────────────────────────────────────┴──────────┴───────────┴─────────┘
```

Method 0 warm-start Davidson estimated at ~14 s (cold 180 s scaled by the 13× reduction in iterations measured on method 1). Energy is bit-identical across all configurations.