### PR TITLE
Fix and accelerate GDB heatbath expansion

### DIFF
--- a/apps/chemistry_gdb_selected_basis_diagonalization/README.md
+++ b/apps/chemistry_gdb_selected_basis_diagonalization/README.md
@@ -68,14 +68,26 @@ Below is an explanation of each command-line option.
   The maximum size of the subspace used in the Davidson method.
 - `--tolerance <float>`:  
   Convergence threshold for the Davidson method. It determines the stopping criterion based on the norm of the residual vector.
+- `--carryover_type <int>`:
+  Selects how determinants are retained or expanded after diagonalization (default: 0).
+  - 0: Do not generate carryover determinants.
+  - 1: Retain determinants by wavefunction weight.
+  - 2: Apply on-demand exhaustive heatbath expansion.
+  - 3: Apply integral-driven heatbath expansion.
 - `--carryover_ratio <float>`:  
-  The ratio of bitstrings with large wavefunction weights to be retained during the selection step.
+  For `--carryover_type 1`, specifies the ratio of determinants with the largest wavefunction weights to retain.
+- `--heatbath_cutoff <float>`:
+  For `--carryover_type 2` or `3`, specifies the heatbath selection cutoff (default: `1.0e-4`).
+- `--heatbath_truncation <float>`:
+  For `--carryover_type 2` or `3`, specifies the wavefunction-weight truncation applied before expansion (default: `0.0`).
+- `--heatbath_batch_size <int>`:
+  For `--carryover_type 2` or `3`, specifies the aggregate candidate batch size per MPI rank (default: `1000000`).
 - `--shuffle <int>`:  
   Whether to shuffle the order of input half-determinants. If set to 0, no shuffling is performed; otherwise, the input is shuffled.
 - `--rdm <int>`:  
   Whether to compute the 1-particle and 2-particle reduced density matrices (1pRDM and 2pRDM). If set to 0, they are not computed; otherwise, they are computed.
 - `--carryovername <str>`:
-  Specifies the filename to store the carryover determinants.
+  Specifies the filename prefix used to store the carryover determinants.
 - `--bit_length <int>`:  
   Specifies the bit length handled by each size_t when representing bitstrings using `std::vector<size_t>`. The default value is 20.
 - `--do_redist_alpha_eq <int>`:

--- a/apps/chemistry_gdb_selected_basis_diagonalization/run.sh
+++ b/apps/chemistry_gdb_selected_basis_diagonalization/run.sh
@@ -4,6 +4,5 @@ mpirun -np 16 -x OMP_NUM_THREADS=1 ./diag --fcidump fcidump_Fe4S4.txt \
        --method 0 --block 10 --iteration 4 --tolerance 1.0e-4 \
        --b_comm_size 2 --t_comm_size 1 \
        --init 0 --shuffle 0 \
-       --carryoverfile carryover.txt \
-       --rdm 1 --carryover_ratio 0.1
-
+       --carryovername carryover.txt \
+       --rdm 1 --carryover_type 1 --carryover_ratio 0.1

--- a/include/sbd/chemistry/gdb/expansion.h
+++ b/include/sbd/chemistry/gdb/expansion.h
@@ -702,10 +702,11 @@ namespace sbd {
       get_mpi_range(mpi_size_x,mpi_rank_x,i_begin,i_end);
 
       sbd::det_vector<size_t> xdet(det.begin() + i_begin, det.begin() + i_end);
+      std::vector<ElemT> xw(w.begin() + i_begin, w.begin() + i_end);
       edet.clear();
 
       if( type == 0 ) {
-	local_heatbath_expansion(xdet,w,bit_length,norb,I0,I1,I2,cutoff,max_batch_size,edet);
+	local_heatbath_expansion(xdet,xw,bit_length,norb,I0,I1,I2,cutoff,max_batch_size,edet);
       } else if( type == 1 ) {
 	sbd::det_vector<size_t, sbd::det_kind::half> adet;
 	sbd::det_vector<size_t, sbd::det_kind::half> bdet;
@@ -713,7 +714,7 @@ namespace sbd {
 	std::vector<size_t> bdet_count;
 	getHalfDets(xdet,bit_length,norb,
 		    adet,bdet,adet_count,bdet_count);
-	local_heatbath_expansion_lookup(xdet,adet,bdet,adet_count,bdet_count,w,
+	local_heatbath_expansion_lookup(xdet,adet,bdet,adet_count,bdet_count,xw,
 					bit_length,norb,I0,I1,I2,cutoff,max_batch_size,edet);
       }
       

--- a/include/sbd/chemistry/gdb/expansion.h
+++ b/include/sbd/chemistry/gdb/expansion.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iterator>
+#include <stdexcept>
 #include <vector>
 #ifdef _OPENMP
 #include <omp.h>
@@ -19,7 +20,7 @@ inline int omp_get_num_threads() { return 1; }
 namespace sbd {
 
   template<typename DetsContainer>
-  void append_candidates_unique(
+  void append_sorted_candidates_unique(
     DetsContainer& dets,
     DetsContainer& candidates) {
 
@@ -27,29 +28,38 @@ namespace sbd {
       return;
     }
 
-    sort_unique_local_bitarray(candidates);
-
     if (dets.empty()) {
       dets = std::move(candidates);
       return;
     }
 
-    sort_unique_local_bitarray(dets);
-
     auto comp = [](const auto& a, const auto& b) {
       return less_from_back(a, b);
     };
     DetsContainer merged;
-    merged.reserve(dets.size() + candidates.size());
+    merged.resize(dets.size() + candidates.size());
     std::merge(
         std::make_move_iterator(dets.begin()),
         std::make_move_iterator(dets.end()),
         std::make_move_iterator(candidates.begin()),
         std::make_move_iterator(candidates.end()),
-        std::back_inserter(merged),
+        merged.begin(),
         comp);
     merged.resize(std::unique(merged.begin(), merged.end()) - merged.begin());
     dets = std::move(merged);
+  }
+
+  template<typename DetsContainer>
+  void append_candidates_unique(
+    DetsContainer& dets,
+    DetsContainer& candidates) {
+
+    if (candidates.empty()) {
+      return;
+    }
+    sort_unique_local_bitarray(candidates);
+    sort_unique_local_bitarray(dets);
+    append_sorted_candidates_unique(dets,candidates);
   }
 
   void append_candidates_unique(
@@ -73,6 +83,245 @@ namespace sbd {
   }
 
   namespace gdb {
+
+    namespace detail {
+
+      template <typename RealT>
+      struct IntegralDoubleExcitation {
+        int created_first;
+        int created_second;
+        RealT abs_integral;
+      };
+
+      template <typename ElemT, typename RealT>
+      class IntegralDoubleExcitationLookup {
+      public:
+        using entry_type = IntegralDoubleExcitation<RealT>;
+        using const_iterator = typename std::vector<entry_type>::const_iterator;
+
+        IntegralDoubleExcitationLookup(size_t norb,
+                                       const twoInt<ElemT> & I2,
+                                       RealT cutoff,
+                                       RealT max_abs_coefficient)
+          : norb_(norb) {
+          if( norb_ == 0 ) {
+            throw std::invalid_argument("number of orbitals must be positive");
+          }
+          if( cutoff < RealT(0) ) {
+            throw std::invalid_argument("heatbath cutoff must be non-negative");
+          }
+
+          const size_t nso = 2 * norb_;
+          const size_t num_pairs = nso * (nso - 1) / 2;
+          pair_offsets_.assign(num_pairs + 1, 0);
+          if( max_abs_coefficient == RealT(0) ) return;
+
+          for(size_t j=1; j < nso; ++j) {
+            for(size_t i=0; i < j; ++i) {
+              size_t count = 0;
+              for(size_t b=1; b < nso; ++b) {
+                for(size_t a=0; a < b; ++a) {
+                  if( a == i || a == j || b == i || b == j ) continue;
+                  const RealT abs_integral = std::abs(
+                    I2.Value(static_cast<int>(a),static_cast<int>(i),
+                             static_cast<int>(b),static_cast<int>(j))
+                    - I2.Value(static_cast<int>(a),static_cast<int>(j),
+                               static_cast<int>(b),static_cast<int>(i)));
+                  if( abs_integral * max_abs_coefficient > cutoff ) ++count;
+                }
+              }
+              const size_t pair = pair_index(i,j);
+              pair_offsets_[pair+1] = count;
+            }
+          }
+          for(size_t pair=0; pair < num_pairs; ++pair) {
+            pair_offsets_[pair+1] += pair_offsets_[pair];
+          }
+
+          entries_.resize(pair_offsets_.back());
+          for(size_t j=1; j < nso; ++j) {
+            for(size_t i=0; i < j; ++i) {
+              const size_t pair = pair_index(i,j);
+              size_t position = pair_offsets_[pair];
+              for(size_t b=1; b < nso; ++b) {
+                for(size_t a=0; a < b; ++a) {
+                  if( a == i || a == j || b == i || b == j ) continue;
+                  const RealT abs_integral = std::abs(
+                    I2.Value(static_cast<int>(a),static_cast<int>(i),
+                             static_cast<int>(b),static_cast<int>(j))
+                    - I2.Value(static_cast<int>(a),static_cast<int>(j),
+                               static_cast<int>(b),static_cast<int>(i)));
+                  if( abs_integral * max_abs_coefficient > cutoff ) {
+                    entries_[position++] = {
+                      static_cast<int>(a),static_cast<int>(b),abs_integral};
+                  }
+                }
+              }
+              std::sort(entries_.begin() + pair_offsets_[pair],
+                        entries_.begin() + pair_offsets_[pair+1],
+                        [](const entry_type & lhs, const entry_type & rhs) {
+                          return lhs.abs_integral > rhs.abs_integral;
+                        });
+            }
+          }
+        }
+
+        const_iterator begin(int first, int second) const {
+          const size_t pair = checked_pair_index(first,second);
+          return entries_.begin() + pair_offsets_[pair];
+        }
+
+        const_iterator end(int first, int second) const {
+          const size_t pair = checked_pair_index(first,second);
+          return entries_.begin() + pair_offsets_[pair+1];
+        }
+
+        size_t entry_count() const noexcept { return entries_.size(); }
+        size_t storage_bytes() const noexcept {
+          return pair_offsets_.size() * sizeof(size_t)
+            + entries_.size() * sizeof(entry_type);
+        }
+
+      private:
+        static size_t pair_index(size_t first, size_t second) noexcept {
+          return second * (second - 1) / 2 + first;
+        }
+
+        size_t checked_pair_index(int first, int second) const {
+          const int nso = static_cast<int>(2*norb_);
+          if( first < 0 || second < 0 || first == second
+              || first >= nso || second >= nso ) {
+            throw std::out_of_range("invalid annihilation pair");
+          }
+          if( first > second ) std::swap(first,second);
+          return pair_index(static_cast<size_t>(first),
+                            static_cast<size_t>(second));
+        }
+
+        size_t norb_;
+        std::vector<size_t> pair_offsets_;
+        std::vector<entry_type> entries_;
+      };
+
+      template <typename ElemT, typename RealT>
+      void local_heatbath_expansion_integral(
+          const sbd::det_vector<size_t> & det,
+          const std::vector<ElemT> & w,
+          size_t bit_length,
+          size_t norb,
+          const oneInt<ElemT> & I1,
+          const twoInt<ElemT> & I2,
+          RealT cutoff,
+          size_t max_batch_size,
+          sbd::det_vector<size_t> & edet) {
+        if( det.size() != w.size() ) {
+          throw std::invalid_argument(
+            "determinant and coefficient counts must match");
+        }
+        if( cutoff < RealT(0) ) {
+          throw std::invalid_argument("heatbath cutoff must be non-negative");
+        }
+        edet = det;
+        sort_unique_local_bitarray(edet);
+        if( det.empty() ) return;
+
+        RealT max_abs_coefficient = RealT(0);
+        for(const auto & coefficient : w) {
+          max_abs_coefficient = std::max(max_abs_coefficient,
+                                         std::abs(coefficient));
+        }
+        IntegralDoubleExcitationLookup<ElemT,RealT> lookup(
+          norb,I2,cutoff,max_abs_coefficient);
+
+        constexpr size_t automatic_batch_size = 1000000;
+        const size_t aggregate_batch_size = (max_batch_size == 0)
+          ? automatic_batch_size : max_batch_size;
+        const size_t nso = 2*norb;
+
+#pragma omp parallel
+        {
+          const size_t num_threads =
+            static_cast<size_t>(omp_get_num_threads());
+          const size_t local_batch_size =
+            std::max<size_t>(1,aggregate_batch_size/num_threads);
+          sbd::det_vector<size_t> candidates;
+          candidates.resize(local_batch_size);
+          size_t candidate_count = 0;
+          std::vector<size_t> candidate = det[0];
+          std::vector<int> occupied(nso);
+          std::vector<int> unoccupied(nso);
+
+          auto flush_candidates = [&]() {
+            if( candidate_count == 0 ) return;
+            candidates.resize(candidate_count);
+            sort_unique_local_bitarray(candidates);
+#pragma omp critical(sbd_gdb_heatbath_append_candidates)
+            { append_sorted_candidates_unique(edet,candidates); }
+            candidates.resize(local_batch_size);
+            candidate_count = 0;
+          };
+          auto store_candidate = [&]() {
+            candidates[candidate_count++] = candidate;
+            if( candidate_count == local_batch_size ) flush_candidates();
+          };
+
+#pragma omp for schedule(static)
+          for(size_t idet=0; idet < det.size(); ++idet) {
+            const RealT abs_coefficient = std::abs(w[idet]);
+            if( abs_coefficient == RealT(0) ) continue;
+            size_t occupied_count = 0;
+            size_t unoccupied_count = 0;
+            for(size_t orbital=0; orbital < nso; ++orbital) {
+              if( getocc(det[idet],bit_length,static_cast<int>(orbital)) ) {
+                occupied[occupied_count++] = static_cast<int>(orbital);
+              } else {
+                unoccupied[unoccupied_count++] = static_cast<int>(orbital);
+              }
+            }
+
+            for(size_t oi=0; oi < occupied_count; ++oi) {
+              int annihilated = occupied[oi];
+              for(size_t ua=0; ua < unoccupied_count; ++ua) {
+                int created = unoccupied[ua];
+                if( (annihilated % 2) != (created % 2) ) continue;
+                const ElemT hij = OneExcite(det[idet],bit_length,
+                                            annihilated,created,I1,I2);
+                if( std::abs(hij) * abs_coefficient > cutoff ) {
+                  candidate = det[idet];
+                  setocc(candidate,bit_length,annihilated,false);
+                  setocc(candidate,bit_length,created,true);
+                  store_candidate();
+                }
+              }
+            }
+
+            for(size_t oi=0; oi < occupied_count; ++oi) {
+              for(size_t oj=oi+1; oj < occupied_count; ++oj) {
+                const int first = occupied[oi];
+                const int second = occupied[oj];
+                const auto entries_begin = lookup.begin(first,second);
+                const auto entries_end = lookup.end(first,second);
+                for(auto entry=entries_begin; entry != entries_end; ++entry) {
+                  if( entry->abs_integral * abs_coefficient <= cutoff ) break;
+                  if( getocc(det[idet],bit_length,entry->created_first)
+                      || getocc(det[idet],bit_length,entry->created_second) ) {
+                    continue;
+                  }
+                  candidate = det[idet];
+                  setocc(candidate,bit_length,first,false);
+                  setocc(candidate,bit_length,second,false);
+                  setocc(candidate,bit_length,entry->created_first,true);
+                  setocc(candidate,bit_length,entry->created_second,true);
+                  store_candidate();
+                }
+              }
+            }
+          }
+          flush_candidates();
+        }
+      }
+
+    } // end namespace detail
 
     void singles_from_hdet(const std::vector<size_t> & hdet,
 			  size_t bit_length,
@@ -231,6 +480,9 @@ namespace sbd {
 					 size_t max_batch_size,
 					 sbd::det_vector<size_t> & edet) {
 
+      edet.clear();
+      if( det.empty() ) return;
+
       DetIndexMap idxmap;
       makeDetIndexMap(det,adet,bdet,adet_count,bdet_count,
 		      bit_length,norb,idxmap);
@@ -250,12 +502,6 @@ namespace sbd {
 			 bdet_single,borb_single,
 			 bdet_double,borb_double);
 
-      size_t num_threads = 1;
-#pragma omp parallel
-      {
-	num_threads = omp_get_num_threads();
-      }
-
       size_t num_one_a = static_cast<size_t>(bitcount(adet[0],bit_length,norb));
       size_t num_one_b = static_cast<size_t>(bitcount(bdet[0],bit_length,norb));
       size_t num_ex_single_a = (norb - num_one_a) * num_one_a;
@@ -274,10 +520,8 @@ namespace sbd {
       const size_t effective_max_batch_size =
           (max_batch_size == 0) ? det.size() * max_candidates_per_det
                                 : max_batch_size;
-      const size_t local_batch_size =
-          std::max<size_t>(1, effective_max_batch_size / num_threads);
-
       edet = det;
+      sort_unique_local_bitarray(edet);
 
       // Flatten the ragged (ia, ib) space using prefix sums of AdetToDetLen.
       // Each OpenMP thread owns a contiguous range in this flattened space.
@@ -296,6 +540,8 @@ namespace sbd {
 	thread_id = omp_get_thread_num();
 	num_threads_in_parallel = omp_get_num_threads();
 #endif
+	const size_t local_batch_size =
+	  std::max<size_t>(1, effective_max_batch_size / num_threads_in_parallel);
 
 	const size_t pair_begin = num_adet_det_pairs * thread_id / num_threads_in_parallel;
 	const size_t pair_end   = num_adet_det_pairs * (thread_id + 1) / num_threads_in_parallel;
@@ -307,9 +553,10 @@ namespace sbd {
 	  if (candidates.empty()) {
 	    return;
 	  }
+	  sort_unique_local_bitarray(candidates);
 #pragma omp critical(sbd_gdb_heatbath_append_candidates)
 	  {
-	    append_candidates_unique(edet, candidates);
+	    append_sorted_candidates_unique(edet, candidates);
 	  }
 	  candidates.clear();
 	  candidates.reserve(local_batch_size);
@@ -439,7 +686,8 @@ namespace sbd {
 				  size_t max_batch_size,
 				  sbd::det_vector<size_t> & edet) {
 
-      if( det.size() == static_cast<size_t>(0) ) return;
+      edet.clear();
+      if( det.empty() ) return;
 
       sbd::det_vector<size_t, sbd::det_kind::half> adet;
       sbd::det_vector<size_t, sbd::det_kind::half> bdet;
@@ -449,12 +697,6 @@ namespace sbd {
       DetIndexMap idxmap;
       makeDetIndexMap(det,adet,bdet,adet_count,bdet_count,bit_length,norb,idxmap);
 
-      size_t num_threads = 1;
-#pragma omp parallel
-      {
-	num_threads = omp_get_num_threads();
-      }
-      
       size_t num_one_a = static_cast<size_t>(bitcount(adet[0],bit_length,norb));
       size_t num_one_b = static_cast<size_t>(bitcount(bdet[0],bit_length,norb));
       size_t num_ex_single_a = (norb - num_one_a) * num_one_a;
@@ -473,9 +715,8 @@ namespace sbd {
       const size_t effective_max_batch_size =
           (max_batch_size == 0) ? det.size() * max_candidates_per_det
                                 : max_batch_size;
-      const size_t local_batch_size =
-          std::max<size_t>(1, effective_max_batch_size / num_threads);
       edet = det;
+      sort_unique_local_bitarray(edet);
       std::vector<size_t> adet_to_det_offset(idxmap.AdetToDetLen.size() + 1, 0);
       for(size_t ia = 0; ia < idxmap.AdetToDetLen.size(); ++ia) {
 	adet_to_det_offset[ia + 1] = adet_to_det_offset[ia] + idxmap.AdetToDetLen[ia];
@@ -491,6 +732,8 @@ namespace sbd {
 	thread_id = omp_get_thread_num();
 	num_threads_in_parallel = omp_get_num_threads();
 #endif
+	const size_t local_batch_size =
+	  std::max<size_t>(1, effective_max_batch_size / num_threads_in_parallel);
 
 	const size_t pair_begin = num_adet_det_pairs * thread_id / num_threads_in_parallel;
 	const size_t pair_end   = num_adet_det_pairs * (thread_id + 1) / num_threads_in_parallel;
@@ -502,9 +745,10 @@ namespace sbd {
 	  if (candidates.empty()) {
 	    return;
 	  }
+	  sort_unique_local_bitarray(candidates);
 #pragma omp critical(sbd_gdb_heatbath_append_candidates)
 	  {
-	    append_candidates_unique(edet, candidates);
+	    append_sorted_candidates_unique(edet, candidates);
 	  }
 	  candidates.clear();
 	  candidates.reserve(local_batch_size);
@@ -687,6 +931,14 @@ namespace sbd {
 			   MPI_Comm b_comm,
 			   MPI_Comm comm) {
 
+      if( det.size() != w.size() ) {
+	throw std::invalid_argument(
+	  "determinant and coefficient counts must match");
+      }
+      if( type != 0 && type != 1 ) {
+	throw std::invalid_argument("heatbath method must be 0 or 1");
+      }
+
       int mpi_rank; MPI_Comm_rank(comm,&mpi_rank);
       int mpi_size; MPI_Comm_size(comm,&mpi_size);
       int mpi_rank_b; MPI_Comm_rank(b_comm,&mpi_rank_b);
@@ -708,14 +960,8 @@ namespace sbd {
       if( type == 0 ) {
 	local_heatbath_expansion(xdet,xw,bit_length,norb,I0,I1,I2,cutoff,max_batch_size,edet);
       } else if( type == 1 ) {
-	sbd::det_vector<size_t, sbd::det_kind::half> adet;
-	sbd::det_vector<size_t, sbd::det_kind::half> bdet;
-	std::vector<size_t> adet_count;
-	std::vector<size_t> bdet_count;
-	getHalfDets(xdet,bit_length,norb,
-		    adet,bdet,adet_count,bdet_count);
-	local_heatbath_expansion_lookup(xdet,adet,bdet,adet_count,bdet_count,xw,
-					bit_length,norb,I0,I1,I2,cutoff,max_batch_size,edet);
+	detail::local_heatbath_expansion_integral(
+	  xdet,xw,bit_length,norb,I1,I2,cutoff,max_batch_size,edet);
       }
       
       sort_global_bitarray(edet,comm);

--- a/include/sbd/chemistry/gdb/expansion.h
+++ b/include/sbd/chemistry/gdb/expansion.h
@@ -38,48 +38,15 @@ namespace sbd {
     };
     DetsContainer merged;
     merged.resize(dets.size() + candidates.size());
-    std::merge(
+    const auto merged_end = std::set_union(
         std::make_move_iterator(dets.begin()),
         std::make_move_iterator(dets.end()),
         std::make_move_iterator(candidates.begin()),
         std::make_move_iterator(candidates.end()),
         merged.begin(),
         comp);
-    merged.resize(std::unique(merged.begin(), merged.end()) - merged.begin());
+    merged.resize(merged_end - merged.begin());
     dets = std::move(merged);
-  }
-
-  template<typename DetsContainer>
-  void append_candidates_unique(
-    DetsContainer& dets,
-    DetsContainer& candidates) {
-
-    if (candidates.empty()) {
-      return;
-    }
-    sort_unique_local_bitarray(candidates);
-    sort_unique_local_bitarray(dets);
-    append_sorted_candidates_unique(dets,candidates);
-  }
-
-  void append_candidates_unique(
-    std::vector<std::vector<size_t>>& dets,
-    std::vector<std::vector<std::vector<size_t>>>& candidates_per_thread) {
-
-    std::vector<std::vector<size_t>> candidates_all;
-    size_t total_size = 0;
-    for (const auto& cand : candidates_per_thread) {
-      total_size += cand.size();
-    }
-    candidates_all.reserve(total_size);
-    for (auto& cand : candidates_per_thread) {
-      candidates_all.insert(
-          candidates_all.end(),
-          std::make_move_iterator(cand.begin()),
-          std::make_move_iterator(cand.end()));
-      cand.clear();
-    }
-    append_candidates_unique(dets, candidates_all);
   }
 
   namespace gdb {

--- a/include/sbd/chemistry/gdb/sbdiag.h
+++ b/include/sbd/chemistry/gdb/sbdiag.h
@@ -27,7 +27,7 @@ namespace sbd {
       double threshold = 0.01;
       double heatbath_cutoff = 1.0e-4;
       double heatbath_truncation = 0.0;
-      size_t heatbath_batch_size = 200000000;
+      size_t heatbath_batch_size = 1000000;
       size_t bit_length = 20;
       size_t seed = 1729;
       bool timing_barriers = false;
@@ -138,10 +138,16 @@ namespace sbd {
       } else  if( sbd_data.carryover_type == 1 ) {
 	std::cout << "# carryover type: weight truncation" << std::endl;
 	std::cout << "# carryover ratio: " << sbd_data.ratio << std::endl;
-      } else if ( sbd_data.carryover_type == 2 || sbd_data.carryover_type == 3 ) {
-	std::cout << "# carryover type: heatbath expansion" << std::endl;
+      } else if ( sbd_data.carryover_type == 2 ) {
+	std::cout << "# carryover type: on-demand exhaustive heatbath expansion" << std::endl;
 	std::cout << "# heatbath truncation: " << sbd_data.heatbath_truncation << std::endl;
 	std::cout << "# heatbath cutoff: " << sbd_data.heatbath_cutoff << std::endl;
+	std::cout << "# heatbath batch size per rank: " << sbd_data.heatbath_batch_size << std::endl;
+      } else if ( sbd_data.carryover_type == 3 ) {
+	std::cout << "# carryover type: integral-driven heatbath expansion" << std::endl;
+	std::cout << "# heatbath truncation: " << sbd_data.heatbath_truncation << std::endl;
+	std::cout << "# heatbath cutoff: " << sbd_data.heatbath_cutoff << std::endl;
+	std::cout << "# heatbath batch size per rank: " << sbd_data.heatbath_batch_size << std::endl;
       }
     }
 
@@ -587,9 +593,9 @@ namespace sbd {
 		    << " sbd: start heatbath expansion" << std::endl;
 	}
 	auto time_start_hb = std::chrono::high_resolution_clock::now();
-	int hb_type = (co_type == 2) ? 0 : 1;
+	int heatbath_method = (co_type == 2) ? 0 : 1;
 	HeatbathExpansion(cdet,cw,bit_length,static_cast<size_t>(L),I0,I1,I2,
-			  hb_type,hb_cutoff,hb_batch_size,rdet,b_comm,comm);
+			  heatbath_method,hb_cutoff,hb_batch_size,rdet,b_comm,comm);
 	auto time_end_hb = std::chrono::high_resolution_clock::now();
 	auto elapsed_hb_count = std::chrono::duration_cast<std::chrono::microseconds>(time_end_hb-time_start_hb).count();
 	double elapsed_hb = 1.0e-6 * elapsed_hb_count;

--- a/tests/functionality/Makefile
+++ b/tests/functionality/Makefile
@@ -82,6 +82,11 @@ test: $(TEST_EXECS)
 		echo ""; \
 		echo "Running $$test..."; \
 		case $$test in \
+			test_heatbath_expansion) \
+				echo "  (MPI regression - h and t replicated layouts)"; \
+				$(MPI_LAUNCHER) -n 4 ./$$test ../../data/h2o/fcidump.txt h && \
+				$(MPI_LAUNCHER) -n 4 ./$$test ../../data/h2o/fcidump.txt t; \
+				;; \
 			test_determinants|test_inner_product) \
 				echo "  (MPI test - using $(MPI_LAUNCHER))"; \
 				$(MPI_LAUNCHER) -n 1 ./$$test; \

--- a/tests/functionality/test_heatbath_expansion.cc
+++ b/tests/functionality/test_heatbath_expansion.cc
@@ -7,6 +7,7 @@
 
 #include <mpi.h>
 
+#include <complex>
 #include <cstddef>
 #include <iostream>
 #include <string>
@@ -47,7 +48,6 @@ void aligned_reference(
     const ElemT& scalar_integral,
     const sbd::oneInt<ElemT>& one_integrals,
     const sbd::twoInt<ElemT>& two_integrals,
-    int type,
     double cutoff,
     sbd::det_vector<std::size_t>& expanded,
     MPI_Comm b_comm,
@@ -73,23 +73,9 @@ void aligned_reference(
       coefficients.begin() + begin, coefficients.begin() + end);
 
   expanded.clear();
-  if(type == 0) {
-    sbd::gdb::local_heatbath_expansion(
-        local_determinants, local_coefficients, bit_length, norb,
-        scalar_integral, one_integrals, two_integrals, cutoff, 0, expanded);
-  } else {
-    sbd::det_vector<std::size_t, sbd::det_kind::half> alpha_determinants;
-    sbd::det_vector<std::size_t, sbd::det_kind::half> beta_determinants;
-    std::vector<std::size_t> alpha_counts;
-    std::vector<std::size_t> beta_counts;
-    sbd::gdb::getHalfDets(local_determinants, bit_length, norb,
-                          alpha_determinants, beta_determinants,
-                          alpha_counts, beta_counts);
-    sbd::gdb::local_heatbath_expansion_lookup(
-        local_determinants, alpha_determinants, beta_determinants,
-        alpha_counts, beta_counts, local_coefficients, bit_length, norb,
-        scalar_integral, one_integrals, two_integrals, cutoff, 0, expanded);
-  }
+  sbd::gdb::local_heatbath_expansion(
+      local_determinants, local_coefficients, bit_length, norb,
+      scalar_integral, one_integrals, two_integrals, cutoff, 0, expanded);
 
   sbd::sort_global_bitarray(expanded, comm);
   sbd::redistribution_bitarray(expanded, comm);
@@ -142,7 +128,7 @@ int main(int argc, char** argv) {
   sbd::SetupIntegrals(fcidump, norb, nelec, scalar_integral,
                       one_integrals, two_integrals);
 
-  constexpr std::size_t bit_length = 20;
+  constexpr std::size_t bit_length = 64;
   const std::size_t spin_orbitals = 2 * static_cast<std::size_t>(norb);
   sbd::det_vector<std::size_t>::init_elem_size(
       (spin_orbitals + bit_length - 1) / bit_length);
@@ -167,29 +153,87 @@ int main(int argc, char** argv) {
     coefficients = {0.31, 0.17};
   }
 
-  constexpr double cutoff = 0.01;
   bool all_modes_match = true;
-  for(int type = 0; type <= 1; ++type) {
+  const std::vector<double> cutoffs{0.1, 0.01, 0.001};
+  const std::vector<std::size_t> batch_sizes{1, 1000000};
+  for(int truncated = 0; truncated <= 1; ++truncated) {
+    sbd::det_vector<std::size_t> input_determinants = determinants;
+    std::vector<double> input_coefficients = coefficients;
+    if(truncated != 0) {
+      input_determinants.resize(1);
+      input_coefficients.resize(1);
+    }
+    for(const double cutoff : cutoffs) {
+      sbd::det_vector<std::size_t> expected;
+      aligned_reference(
+          input_determinants, input_coefficients, bit_length,
+          static_cast<std::size_t>(norb), scalar_integral, one_integrals,
+          two_integrals, cutoff, expected, b_comm, comm);
+
+      for(const std::size_t batch_size : batch_sizes) {
+        for(int type = 0; type <= 1; ++type) {
+          sbd::det_vector<std::size_t> actual;
+          sbd::gdb::HeatbathExpansion(
+              input_determinants, input_coefficients, bit_length,
+              static_cast<std::size_t>(norb), scalar_integral, one_integrals,
+              two_integrals, type, cutoff, batch_size,
+              actual, b_comm, comm);
+
+          const int local_match = same_determinants(actual, expected) ? 1 : 0;
+          int global_match = 0;
+          MPI_Allreduce(&local_match, &global_match, 1, MPI_INT, MPI_MIN, comm);
+          all_modes_match = all_modes_match && global_match;
+          if(rank == 0) {
+            std::cout << "layout=" << replicated_dimension
+                      << " truncated=" << truncated
+                      << " cutoff=" << cutoff
+                      << " batch=" << batch_size
+                      << " type=" << type << " match: "
+                      << (global_match ? "yes" : "NO") << '\n';
+          }
+        }
+      }
+    }
+  }
+
+  std::complex<double> complex_scalar_integral;
+  sbd::oneInt<std::complex<double>> complex_one_integrals;
+  sbd::twoInt<std::complex<double>> complex_two_integrals;
+  int complex_norb = 0;
+  int complex_nelec = 0;
+  sbd::SetupIntegrals(
+      fcidump, complex_norb, complex_nelec, complex_scalar_integral,
+      complex_one_integrals, complex_two_integrals);
+  std::vector<std::complex<double>> complex_coefficients;
+  for(std::size_t i = 0; i < coefficients.size(); ++i) {
+    const double imaginary_part = (i % 2 == 0) ? 0.13 : -0.07;
+    complex_coefficients.emplace_back(coefficients[i], imaginary_part);
+  }
+  for(const double cutoff : cutoffs) {
     sbd::det_vector<std::size_t> expected;
     aligned_reference(
-        determinants, coefficients, bit_length,
-        static_cast<std::size_t>(norb), scalar_integral, one_integrals,
-        two_integrals, type, cutoff, expected, b_comm, comm);
-
-    sbd::det_vector<std::size_t> actual;
-    sbd::gdb::HeatbathExpansion(
-        determinants, coefficients, bit_length,
-        static_cast<std::size_t>(norb), scalar_integral, one_integrals,
-        two_integrals, type, cutoff, 0, actual, b_comm, comm);
-
-    const int local_match = same_determinants(actual, expected) ? 1 : 0;
-    int global_match = 0;
-    MPI_Allreduce(&local_match, &global_match, 1, MPI_INT, MPI_MIN, comm);
-    all_modes_match = all_modes_match && global_match;
-    if(rank == 0) {
-      std::cout << "layout=" << replicated_dimension << " type=" << type
-                << " determinant/coefficient slices match: "
-                << (global_match ? "yes" : "NO") << '\n';
+        determinants, complex_coefficients, bit_length,
+        static_cast<std::size_t>(complex_norb), complex_scalar_integral,
+        complex_one_integrals, complex_two_integrals, cutoff,
+        expected, b_comm, comm);
+    for(const std::size_t batch_size : batch_sizes) {
+      sbd::det_vector<std::size_t> actual;
+      sbd::gdb::HeatbathExpansion(
+          determinants, complex_coefficients, bit_length,
+          static_cast<std::size_t>(complex_norb), complex_scalar_integral,
+          complex_one_integrals, complex_two_integrals, 1, cutoff, batch_size,
+          actual, b_comm, comm);
+      const int local_match = same_determinants(actual, expected) ? 1 : 0;
+      int global_match = 0;
+      MPI_Allreduce(&local_match, &global_match, 1, MPI_INT, MPI_MIN, comm);
+      all_modes_match = all_modes_match && global_match;
+      if(rank == 0) {
+        std::cout << "layout=" << replicated_dimension
+                  << " complex=1 cutoff=" << cutoff
+                  << " batch=" << batch_size
+                  << " type=1 match: "
+                  << (global_match ? "yes" : "NO") << '\n';
+      }
     }
   }
 

--- a/tests/functionality/test_heatbath_expansion.cc
+++ b/tests/functionality/test_heatbath_expansion.cc
@@ -1,0 +1,201 @@
+/**
+ * @file test_heatbath_expansion.cc
+ * @brief MPI regression for determinant/coefficient slicing in HeatbathExpansion.
+ */
+
+#include "sbd/sbd.h"
+
+#include <mpi.h>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::size_t> make_determinant(
+    const std::vector<int>& occupied,
+    std::size_t bit_length,
+    std::size_t spin_orbitals) {
+  std::vector<std::size_t> determinant(
+      (spin_orbitals + bit_length - 1) / bit_length, 0);
+  for(const int orbital : occupied) {
+    sbd::setocc(determinant, bit_length, orbital, true);
+  }
+  return determinant;
+}
+
+bool same_determinants(const sbd::det_vector<std::size_t>& lhs,
+                       const sbd::det_vector<std::size_t>& rhs) {
+  if(lhs.size() != rhs.size()) return false;
+  for(std::size_t i = 0; i < lhs.size(); ++i) {
+    if(std::vector<std::size_t>(lhs[i]) !=
+       std::vector<std::size_t>(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename ElemT>
+void aligned_reference(
+    const sbd::det_vector<std::size_t>& determinants,
+    const std::vector<ElemT>& coefficients,
+    std::size_t bit_length,
+    std::size_t norb,
+    const ElemT& scalar_integral,
+    const sbd::oneInt<ElemT>& one_integrals,
+    const sbd::twoInt<ElemT>& two_integrals,
+    int type,
+    double cutoff,
+    sbd::det_vector<std::size_t>& expanded,
+    MPI_Comm b_comm,
+    MPI_Comm comm) {
+  int world_rank = 0;
+  int b_rank = 0;
+  MPI_Comm_rank(comm, &world_rank);
+  MPI_Comm_rank(b_comm, &b_rank);
+
+  MPI_Comm x_comm = MPI_COMM_NULL;
+  MPI_Comm_split(comm, b_rank, world_rank, &x_comm);
+  int x_rank = 0;
+  int x_size = 1;
+  MPI_Comm_rank(x_comm, &x_rank);
+  MPI_Comm_size(x_comm, &x_size);
+
+  std::size_t begin = 0;
+  std::size_t end = determinants.size();
+  sbd::get_mpi_range(x_size, x_rank, begin, end);
+  sbd::det_vector<std::size_t> local_determinants(
+      determinants.begin() + begin, determinants.begin() + end);
+  std::vector<ElemT> local_coefficients(
+      coefficients.begin() + begin, coefficients.begin() + end);
+
+  expanded.clear();
+  if(type == 0) {
+    sbd::gdb::local_heatbath_expansion(
+        local_determinants, local_coefficients, bit_length, norb,
+        scalar_integral, one_integrals, two_integrals, cutoff, 0, expanded);
+  } else {
+    sbd::det_vector<std::size_t, sbd::det_kind::half> alpha_determinants;
+    sbd::det_vector<std::size_t, sbd::det_kind::half> beta_determinants;
+    std::vector<std::size_t> alpha_counts;
+    std::vector<std::size_t> beta_counts;
+    sbd::gdb::getHalfDets(local_determinants, bit_length, norb,
+                          alpha_determinants, beta_determinants,
+                          alpha_counts, beta_counts);
+    sbd::gdb::local_heatbath_expansion_lookup(
+        local_determinants, alpha_determinants, beta_determinants,
+        alpha_counts, beta_counts, local_coefficients, bit_length, norb,
+        scalar_integral, one_integrals, two_integrals, cutoff, 0, expanded);
+  }
+
+  sbd::sort_global_bitarray(expanded, comm);
+  sbd::redistribution_bitarray(expanded, comm);
+  MPI_Comm_free(&x_comm);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rank = 0;
+  int size = 1;
+  MPI_Comm_rank(comm, &rank);
+  MPI_Comm_size(comm, &size);
+
+  if(argc != 3 || size != 4) {
+    if(rank == 0) {
+      std::cerr << "usage: test_heatbath_expansion FCIDUMP h|t"
+                << " (exactly four MPI ranks required)\n";
+    }
+    MPI_Finalize();
+    return 1;
+  }
+
+  const std::string replicated_dimension(argv[2]);
+  if(replicated_dimension != "h" && replicated_dimension != "t") {
+    if(rank == 0) std::cerr << "replicated dimension must be h or t\n";
+    MPI_Finalize();
+    return 1;
+  }
+
+  const int h_size = replicated_dimension == "h" ? 2 : 1;
+  const int b_size = 2;
+  const int t_size = replicated_dimension == "t" ? 2 : 1;
+  MPI_Comm h_comm = MPI_COMM_NULL;
+  MPI_Comm b_comm = MPI_COMM_NULL;
+  MPI_Comm t_comm = MPI_COMM_NULL;
+  sbd::gdb::DetBasisCommunicator(
+      comm, h_size, b_size, t_size, h_comm, b_comm, t_comm);
+
+  sbd::FCIDump fcidump;
+  if(rank == 0) fcidump = sbd::LoadFCIDump(argv[1]);
+  sbd::MpiBcast(fcidump, 0, comm);
+  int norb = 0;
+  int nelec = 0;
+  double scalar_integral = 0.0;
+  sbd::oneInt<double> one_integrals;
+  sbd::twoInt<double> two_integrals;
+  sbd::SetupIntegrals(fcidump, norb, nelec, scalar_integral,
+                      one_integrals, two_integrals);
+
+  constexpr std::size_t bit_length = 20;
+  const std::size_t spin_orbitals = 2 * static_cast<std::size_t>(norb);
+  sbd::det_vector<std::size_t>::init_elem_size(
+      (spin_orbitals + bit_length - 1) / bit_length);
+  sbd::det_vector<std::size_t, sbd::det_kind::half>::init_elem_size(
+      (static_cast<std::size_t>(norb) + bit_length - 1) / bit_length);
+
+  int b_rank = 0;
+  MPI_Comm_rank(b_comm, &b_rank);
+  sbd::det_vector<std::size_t> determinants;
+  std::vector<double> coefficients;
+  if(b_rank == 0) {
+    determinants.push_back(make_determinant(
+        {0,1,2,3,4,5,6,7,8,9}, bit_length, spin_orbitals));
+    determinants.push_back(make_determinant(
+        {0,1,2,3,4,5,6,7,8,11}, bit_length, spin_orbitals));
+    coefficients = {0.91, -0.21};
+  } else {
+    determinants.push_back(make_determinant(
+        {0,1,2,3,4,5,6,7,10,11}, bit_length, spin_orbitals));
+    determinants.push_back(make_determinant(
+        {0,1,2,3,4,5,6,9,10,11}, bit_length, spin_orbitals));
+    coefficients = {0.31, 0.17};
+  }
+
+  constexpr double cutoff = 0.01;
+  bool all_modes_match = true;
+  for(int type = 0; type <= 1; ++type) {
+    sbd::det_vector<std::size_t> expected;
+    aligned_reference(
+        determinants, coefficients, bit_length,
+        static_cast<std::size_t>(norb), scalar_integral, one_integrals,
+        two_integrals, type, cutoff, expected, b_comm, comm);
+
+    sbd::det_vector<std::size_t> actual;
+    sbd::gdb::HeatbathExpansion(
+        determinants, coefficients, bit_length,
+        static_cast<std::size_t>(norb), scalar_integral, one_integrals,
+        two_integrals, type, cutoff, 0, actual, b_comm, comm);
+
+    const int local_match = same_determinants(actual, expected) ? 1 : 0;
+    int global_match = 0;
+    MPI_Allreduce(&local_match, &global_match, 1, MPI_INT, MPI_MIN, comm);
+    all_modes_match = all_modes_match && global_match;
+    if(rank == 0) {
+      std::cout << "layout=" << replicated_dimension << " type=" << type
+                << " determinant/coefficient slices match: "
+                << (global_match ? "yes" : "NO") << '\n';
+    }
+  }
+
+  MPI_Comm_free(&h_comm);
+  MPI_Comm_free(&b_comm);
+  MPI_Comm_free(&t_comm);
+  MPI_Finalize();
+  return all_modes_match ? 0 : 2;
+}


### PR DESCRIPTION
## Summary

- Fix determinant/coefficient misalignment in `HeatbathExpansion` when the input is partitioned across replicated communicators.
- Add an optional integral-driven heatbath expansion path.
- Keep the on-demand exhaustive implementation as the reference and fallback path.
- Reduce the default rank-total candidate batch size from 200,000,000 to 1,000,000.

## Background

`HeatbathExpansion` partitions determinants over an auxiliary communicator, but previously passed the unsliced coefficient vector to the local expansion routines. When `h_comm_size * t_comm_size > 1`, determinants could therefore be paired with coefficients at incorrect offsets.

While fixing this issue, an integral-driven double-excitation search was evaluated as an alternative to exhaustive excitation enumeration. The new path builds a cutoff-filtered lookup sorted by the absolute antisymmetrized two-electron integral and stops scanning once the heatbath threshold can no longer be met.

## Changes

- Apply the same `[i_begin, i_end)` slice to determinants and coefficients.
- Add `gdb::detail::IntegralDoubleExcitationLookup` using flat offset and entry arrays.
- Add an integral-driven local expansion kernel with fixed-size, indexed candidate buffers.
- Sort and deduplicate thread-local candidates before entering the shared merge section.
- Remove the OpenMP shared write used to discover the thread count.
- Route:
  - `carryover_type=2` to the on-demand exhaustive implementation.
  - `carryover_type=3` to the integral-driven implementation.
- Retain the old half-determinant lookup implementation in the source, but remove it from the normal application path.
- Add input validation and empty-slice handling.
- Add an MPI regression test covering replicated communicator layouts.

## Validation

Functionality tests used:

- 4 MPI ranks.
- `h=2, b=2, t=1` and `h=1, b=2, t=2`.
- OpenMP 1 and 4 threads.
- Cutoffs `0.1`, `0.01`, and `0.001`.
- Candidate batch sizes 1 and 1,000,000.
- Full and truncated determinant inputs.
- `double` and `std::complex<double>` coefficients.
- Normal and `_UHF` integral storage.

All 120 comparisons matched the corrected on-demand exhaustive reference.

The GDB application was also built on macOS using Apple Clang, Homebrew Open MPI/libomp, and Apple Accelerate.

For the included Fe4S4 input with 59,536 initial determinants:

- 4 MPI ranks x 4 OpenMP threads.
- `h=2, b=2, t=1`.
- Heatbath cutoff `0.01`.
- Both paths produced identical per-rank carryover files containing 59,556 determinants.
- On-demand exhaustive expansion: 14.081 s.
- Integral-driven expansion: 0.434 s.

This is approximately a 32.5x speedup for the heatbath expansion in this local test.

## Scope

The integral-driven path remains optional. Accelerator and multi-node scaling are not addressed in this PR. Complex coefficients and UHF integral storage were tested at the function level; full complex-mode GDB application execution was not tested.
