### PR TITLE
gdb: slide the current determinant index map with the ket between correlation tasks (fixes #89)

### DIFF
--- a/include/sbd/chemistry/gdb/correlation_thrust.h
+++ b/include/sbd/chemistry/gdb/correlation_thrust.h
@@ -395,8 +395,12 @@ void MultGDBThrust<ElemT>::correlation(const std::vector<ElemT> & w_in,
 
 			rw = tw;
 			sbd::MpiSlide(rw, tw, slide, this->b_comm());
-			sbd::gdb::MpiSlide(idxmap, idxmap_storage, tidxmap, tidxmap_storage, -exidx[0].slide, this->b_comm());
-
+			// Slide the CURRENT index map together with the wavefunction, as the CPU path
+			// (correlation.h) and the Hamiltonian loop (mult_thrust.h) do. The previous code
+			// re-slid the ORIGINAL idxmap by -exidx[0].slide here before applying `slide`,
+			// which left tidxmap one or more tasks behind tw for every task >= 2 (the third
+			// task on) when b_comm_size >= 3: wrong 1-/2-RDM values when all ranks hold equal alpha counts,
+			// a hang (size mismatch in the correlation kernels) when they do not.
 			thrust::device_vector<uint32_t> ridxmap_storage;
 			DetIndexMapThrust ridxmap;
 			ridxmap.copy(ridxmap_storage, tidxmap, tidxmap_storage);


### PR DESCRIPTION
Fixes #89.

`MultGDBThrust::correlation` slid the ket cumulatively between tasks (`rw = tw; MpiSlide(rw, tw, slide)`) but re-slid
the *original* `idxmap` by `-exidx[0].slide` before applying `slide`, so from the third task on (`b_comm_size >= 3`)
the index map was one or more tasks behind the ket it was paired with. With equal alpha counts per rank the kernels
ran over mis-registered pairs and emitted wrong 1-/2-RDMs (the Davidson energy, computed by the Hamiltonian loop in
`mult_thrust.h`, was unaffected); with unequal counts the run hung after `sbd: start rdm calculation`. The CPU path
(`correlation.h`) and the Hamiltonian loop slide the current map together with the ket; this change makes the Thrust
correlation loop do the same. One file, `include/sbd/chemistry/gdb/correlation_thrust.h`: one line removed, a comment
added.

Verification (GH200, Cray MPICH 9.0.1, CUDA 12.9, `craype-thrust` preset): every one of the 15 one-node
configurations that were wrong or hung before (NORB 6, 8, 12; `b_comm_size` 3–8, equal and unequal splits) now emits
RDMs whose in-app contraction (`zero-body + one-body + two-body energy`) matches `sbd: Energy` to ≤ 4e-13 and which
agree with pyscf FCI element-wise to ≤ 1.5e-9; the 1- and 2-rank results are unchanged. The defect is present in every
upstream state we built back to `9b56474` (the commit that added the file). Details, tables and the reproducer are in
#89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LR3vEWfNvvHnpT3AmnKG9
